### PR TITLE
fix(app): silence fixed errors from outdated electron clients

### DIFF
--- a/fluxer_app/src/utils/DeepLinkUtils.ts
+++ b/fluxer_app/src/utils/DeepLinkUtils.ts
@@ -146,13 +146,17 @@ export const startDeepLinkHandling = async (): Promise<void> => {
 			}
 		});
 
-		electronApi.onRpcNavigate((path) => {
-			try {
-				handleRpcNavigation(path);
-			} catch (error) {
-				console.error('[DeepLink] Failed to handle RPC navigation', path, error);
-			}
-		});
+		if (typeof electronApi.onRpcNavigate === 'function') {
+			electronApi.onRpcNavigate((path) => {
+				try {
+					handleRpcNavigation(path);
+				} catch (error) {
+					console.error('[DeepLink] Failed to handle RPC navigation', path, error);
+				}
+			});
+		} else {
+			console.warn('[DeepLink] onRpcNavigate not available on this host version');
+		}
 
 		return;
 	}


### PR DESCRIPTION
some outdated pre-release versions of the electron app didn't have this defined, adding a check for backward compatibility and to prevent sentry noise