### PR TITLE
fix(metrics): clickhouse query alias collision issue

### DIFF
--- a/fluxer_api/src/worker/WorkerMetricsCollector.ts
+++ b/fluxer_api/src/worker/WorkerMetricsCollector.ts
@@ -318,7 +318,7 @@ export class WorkerMetricsCollector {
 				last_execution: Date | null;
 			}>(`
 				SELECT identifier, known_since, last_execution
-				FROM graphile_worker.known_crontabs
+				FROM graphile_worker._private_known_crontabs
 			`);
 
 			const now = new Date();


### PR DESCRIPTION
fixes an issue where all metrics in the admin panel showed up empty because of the alias `timestamp_bucket` shadowing the column name, causing `GROUP BY` to reference the DateTime64 column instead of the Int64 alias, resulting in type mismatches and empty results