### PR TITLE
fix(app): avoid throwing on handled message load error

### DIFF
--- a/fluxer_app/src/actions/MessageActionCreators.tsx
+++ b/fluxer_app/src/actions/MessageActionCreators.tsx
@@ -264,7 +264,7 @@ export const fetchMessages = async (
 		} catch (error) {
 			logger.error(`Failed to fetch messages for channel ${channelId}:`, error);
 			MessageStore.handleLoadMessagesFailure({channelId});
-			throw error;
+			return [];
 		}
 	})();
 


### PR DESCRIPTION
this caused redundant sentry noise