### PR TITLE
fix(app): fix perf issues and bugs with textarea autosizing

### DIFF
--- a/fluxer_app/src/components/channel/EditingMessageInput.tsx
+++ b/fluxer_app/src/components/channel/EditingMessageInput.tsx
@@ -221,6 +221,7 @@ export const EditingMessageInput = observer(
 											style={{position: 'absolute', visibility: 'hidden', pointerEvents: 'none'}}
 										/>
 										<TextareaInputField
+											channelId={channel.id}
 											disabled={false}
 											isMobile={mobileLayout.enabled}
 											value={value}

--- a/fluxer_app/src/components/channel/Messages.module.css
+++ b/fluxer_app/src/components/channel/Messages.module.css
@@ -30,6 +30,10 @@
 	--message-group-spacing: 16px;
 }
 
+.nativeAnchor {
+	overflow-anchor: auto !important;
+}
+
 .scrollerContainer {
 	position: absolute;
 	inset: 0;

--- a/fluxer_app/src/components/channel/Messages.tsx
+++ b/fluxer_app/src/components/channel/Messages.tsx
@@ -718,6 +718,7 @@ export const Messages = observer(function Messages({channel}: {channel: ChannelR
 			{topBar}
 			<div className={styles.scrollerContainer}>
 				<Scroller
+					className={state.isAtBottom ? styles.nativeAnchor : undefined}
 					fade={false}
 					scrollbar="regular"
 					hideThumbWhenWindowBlurred

--- a/fluxer_app/src/components/channel/textarea/TextareaInput.module.css
+++ b/fluxer_app/src/components/channel/textarea/TextareaInput.module.css
@@ -72,7 +72,7 @@
 .textarea {
 	width: 100%;
 	resize: none;
-	overflow: visible;
+	overflow: hidden;
 	white-space: pre-wrap;
 	word-break: break-word;
 	background-color: transparent;
@@ -86,6 +86,12 @@
 	outline: none;
 	font-family: inherit;
 	font-size: inherit;
+}
+
+@supports (field-sizing: content) {
+	.textarea {
+		field-sizing: content;
+	}
 }
 
 .textarea:disabled {


### PR DESCRIPTION
fixes a wide range of issues with autosizing of the channel textarea and adding newlines causing incorrect measurements and scroll adjustments, as well as preferring built-in `field-sizing: content` when supported (all browsers except for Firefox)