### PR TITLE
fix(api): strip expired premium flags using read repair

### DIFF
--- a/fluxer_api/src/user/UserHelpers.ts
+++ b/fluxer_api/src/user/UserHelpers.ts
@@ -55,3 +55,29 @@ export function checkIsPremium(user: PremiumCheckable): boolean {
 
 	return nowMs <= untilMs + GRACE_MS;
 }
+
+export const PREMIUM_CLEAR_FIELDS = [
+	'premium_type',
+	'premium_since',
+	'premium_until',
+	'premium_will_cancel',
+	'premium_billing_cycle',
+] as const;
+
+export type PremiumClearField = (typeof PREMIUM_CLEAR_FIELDS)[number];
+
+export function shouldStripExpiredPremium(user: PremiumCheckable): boolean {
+	if ((user.premiumType ?? 0) <= 0) {
+		return false;
+	}
+
+	return !checkIsPremium(user);
+}
+
+export function mapExpiredPremiumFields<T>(mapper: (field: PremiumClearField) => T): Record<PremiumClearField, T> {
+	const result = {} as Record<PremiumClearField, T>;
+	for (const field of PREMIUM_CLEAR_FIELDS) {
+		result[field] = mapper(field);
+	}
+	return result;
+}


### PR DESCRIPTION
previously, premium badges would remain on user profiles when their gift subscription had expired. this did not grant them access to premium functionality still, as that is determined by checking their `premium_until`, but `premium_type` did persist and show up in responses, creating the illusion that they still have premium.