### PR TITLE
fix(api): premium sanitisation recursion issue

### DIFF
--- a/fluxer_api/src/rpc/RpcService.ts
+++ b/fluxer_api/src/rpc/RpcService.ts
@@ -43,7 +43,6 @@ import {
 } from '~/Constants';
 import {mapChannelToResponse, mapMessageToResponse} from '~/channel/ChannelModel';
 import type {IChannelRepository} from '~/channel/IChannelRepository';
-import type {UserRow} from '~/database/types/UserTypes';
 import {RateLimitError, UnauthorizedError, UnknownGuildError} from '~/Errors';
 import {mapFavoriteMemeToResponse} from '~/favorite_meme/FavoriteMemeModel';
 import type {IFavoriteMemeRepository} from '~/favorite_meme/IFavoriteMemeRepository';
@@ -88,7 +87,7 @@ import type {RpcRequest, RpcResponse, RpcResponseGuildData, RpcResponseSessionDa
 import type {IUserRepository} from '~/user/IUserRepository';
 import {CustomStatusValidator} from '~/user/services/CustomStatusValidator';
 import {getCachedUserPartialResponse} from '~/user/UserCacheHelpers';
-import {mapExpiredPremiumFields, shouldStripExpiredPremium} from '~/user/UserHelpers';
+import {createPremiumClearPatch, shouldStripExpiredPremium} from '~/user/UserHelpers';
 import {
 	mapRelationshipToResponse,
 	mapUserGuildSettingsToResponse,
@@ -574,10 +573,7 @@ export class RpcService {
 
 		if (needsPremiumStrip) {
 			try {
-				const strippedUser = await this.userRepository.patchUpsert(
-					user.id,
-					mapExpiredPremiumFields(() => null) as Partial<UserRow>,
-				);
+				const strippedUser = await this.userRepository.patchUpsert(user.id, createPremiumClearPatch());
 				if (strippedUser) {
 					user = strippedUser;
 					userData.user = strippedUser;

--- a/fluxer_api/src/user/UserHelpers.ts
+++ b/fluxer_api/src/user/UserHelpers.ts
@@ -19,6 +19,7 @@
 
 import {Config} from '~/Config';
 import {UserFlags} from '~/Constants';
+import type {UserRow} from '~/database/types/UserTypes';
 
 interface PremiumCheckable {
 	premiumType: number | null;
@@ -80,4 +81,8 @@ export function mapExpiredPremiumFields<T>(mapper: (field: PremiumClearField) =>
 		result[field] = mapper(field);
 	}
 	return result;
+}
+
+export function createPremiumClearPatch(): Partial<UserRow> {
+	return mapExpiredPremiumFields(() => null) as Partial<UserRow>;
 }

--- a/fluxer_api/src/user/repositories/account/crud/UserDataRepository.ts
+++ b/fluxer_api/src/user/repositories/account/crud/UserDataRepository.ts
@@ -20,10 +20,8 @@
 import {createUserID, type UserID} from '~/BrandedTypes';
 import {buildPatchFromData, Db, executeVersionedUpdate, fetchMany, fetchOne} from '~/database/Cassandra';
 import {EMPTY_USER_ROW, USER_COLUMNS, type UserRow} from '~/database/CassandraTypes';
-import {Logger} from '~/Logger';
 import {User} from '~/Models';
 import {Users} from '~/Tables';
-import {shouldStripExpiredPremium} from '~/user/UserHelpers';
 
 const FETCH_USERS_BY_IDS_CQL = Users.selectCql({
 	where: Users.where.in('user_id', 'user_ids'),
@@ -75,21 +73,7 @@ export class UserDataRepository {
 			return null;
 		}
 
-		const user = new User(userRow);
-
-		if (shouldStripExpiredPremium(user)) {
-			try {
-				await this.readRepairExpiredPremium(user);
-				const repairedRow = await fetchOne<UserRow>(FETCH_USER_BY_ID_CQL, {
-					user_id: userId,
-				});
-				return repairedRow ? new User(repairedRow) : null;
-			} catch (error) {
-				Logger.warn({userId: user.id.toString(), error}, 'Failed to repair expired premium fields while reading user');
-			}
-		}
-
-		return user;
+		return new User(userRow);
 	}
 
 	async findUniqueAssert(userId: UserID): Promise<User> {
@@ -168,18 +152,4 @@ export class UserDataRepository {
 
 		await this.patchUser(userId, patch);
 	}
-
-	private async readRepairExpiredPremium(user: User): Promise<void> {
-		await this.patchUser(user.id, createPremiumClearPatch());
-	}
-}
-
-function createPremiumClearPatch(): UserPatch {
-	return {
-		premium_type: Db.clear<number | null>(),
-		premium_since: Db.clear<Date | null>(),
-		premium_until: Db.clear<Date | null>(),
-		premium_will_cancel: Db.clear<boolean | null>(),
-		premium_billing_cycle: Db.clear<string | null>(),
-	};
 }


### PR DESCRIPTION
this amends #24 due to a production outage caused by infinite recursion within sanitisation. by removing the automatic premium-strip/read-repair from findUnique, which used to call patchUser, which in turn called findUnique again, so any expired-premium row caused infinite recursion during bulk loads and sky-high CPU/memory.