### PR TITLE
fix(admin): treat 204 as successful

### DIFF
--- a/fluxer_admin/src/fluxer_admin/api/common.gleam
+++ b/fluxer_admin/src/fluxer_admin/api/common.gleam
@@ -104,6 +104,7 @@ pub fn admin_post_with_audit(
 
   case httpc.send(req) {
     Ok(resp) if resp.status == 200 -> Ok(Nil)
+    Ok(resp) if resp.status == 204 -> Ok(Nil)
     Ok(resp) if resp.status == 401 -> Error(Unauthorized)
     Ok(resp) if resp.status == 403 -> {
       let message_decoder = {


### PR DESCRIPTION
some admin endpoints returned a 204. this is, of course, just as successful of a status code as 200.