### PR TITLE
fix(admin): issue correct password reset tokens

### DIFF
--- a/fluxer_api/src/admin/services/AdminUserService.ts
+++ b/fluxer_api/src/admin/services/AdminUserService.ts
@@ -29,7 +29,6 @@ import type {IEmailService} from '~/infrastructure/IEmailService';
 import type {IGatewayService} from '~/infrastructure/IGatewayService';
 import type {PendingJoinInviteStore} from '~/infrastructure/PendingJoinInviteStore';
 import type {RedisBulkMessageDeletionQueueService} from '~/infrastructure/RedisBulkMessageDeletionQueueService';
-import type {SnowflakeService} from '~/infrastructure/SnowflakeService';
 import type {UserCacheService} from '~/infrastructure/UserCacheService';
 import type {InviteService} from '~/invite/InviteService';
 import type {BotMfaMirrorService} from '~/oauth/BotMfaMirrorService';
@@ -75,7 +74,6 @@ interface AdminUserServiceDeps {
 	userRepository: IUserRepository;
 	guildRepository: IGuildRepository;
 	discriminatorService: IDiscriminatorService;
-	snowflakeService: SnowflakeService;
 	authService: AuthService;
 	emailService: IEmailService;
 	entityAssetService: EntityAssetService;
@@ -135,7 +133,6 @@ export class AdminUserService {
 			userRepository: deps.userRepository,
 			authService: deps.authService,
 			emailService: deps.emailService,
-			snowflakeService: deps.snowflakeService,
 			auditService: deps.auditService,
 			updatePropagator: this.updatePropagator,
 			botMfaMirrorService: deps.botMfaMirrorService,


### PR DESCRIPTION
the admin operation for issuing password reset emails on behalf of users had diverged from the real implementation that's actually in use, and instead used a random snowflake for the token part instead of the 64-character random token that is being used normally. as such, attempting to use such a link would result in a validation error because the length was not exactly 64 characters as we assert, but way below that.