### PR TITLE
fix(app): make login account selector use clickable rows

### DIFF
--- a/fluxer_app/src/components/auth/AuthLoginLayout.tsx
+++ b/fluxer_app/src/components/auth/AuthLoginLayout.tsx
@@ -201,6 +201,7 @@ const AuthLoginLayout = observer(function AuthLoginLayout({
 				error={switchError}
 				disabled={isSwitching}
 				showInstance
+				clickableRows
 				onSelectAccount={handleSelectExistingAccount}
 				onAddAccount={handleAddAnotherAccount}
 			/>


### PR DESCRIPTION
without this prop set, you'd have to press a kebab menu to be able to select the option to use the account. not only was this incompatible with mobile devices, but it also adds one extra click and reduces the click target dimensions for no good reason.