### PR TITLE
perf(api): replace polling for in-memory caches with signals

### DIFF
--- a/fluxer_api/src/App.ts
+++ b/fluxer_api/src/App.ts
@@ -263,6 +263,8 @@ app.route('/', routes);
 app.onError(AppErrorHandler);
 app.notFound(AppNotFoundHandler);
 
+const ipBanSubscriber = new Redis(Config.redis.url);
+ipBanCache.setRefreshSubscriber(ipBanSubscriber);
 await ipBanCache.initialize();
 
 initializeMetricsService(Config.metrics.host ?? null);

--- a/fluxer_api/src/admin/services/AdminUserService.ts
+++ b/fluxer_api/src/admin/services/AdminUserService.ts
@@ -159,6 +159,7 @@ export class AdminUserService {
 		this.banManagementService = new AdminBanManagementService({
 			adminRepository: deps.adminRepository,
 			auditService: deps.auditService,
+			cacheService: deps.cacheService,
 		});
 
 		this.registrationService = new AdminUserRegistrationService({

--- a/fluxer_api/src/constants/IpBan.ts
+++ b/fluxer_api/src/constants/IpBan.ts
@@ -17,17 +17,4 @@
  * along with Fluxer. If not, see <https://www.gnu.org/licenses/>.
  */
 
-export const FeatureFlags = {
-	MESSAGE_SCHEDULING: 'message_scheduling',
-	EXPRESSION_PACKS: 'expression_packs',
-} as const;
-
-export type FeatureFlag = (typeof FeatureFlags)[keyof typeof FeatureFlags];
-
-export const ALL_FEATURE_FLAGS: Array<FeatureFlag> = Object.values(FeatureFlags);
-
-export const FEATURE_FLAG_KEY_PREFIX = 'feature_flag:';
-export const FEATURE_FLAG_REDIS_KEY = 'feature_flags:config';
-export const FEATURE_FLAG_USER_CACHE_PREFIX = 'feature_flag:user';
-export const FEATURE_FLAG_USER_CACHE_TTL_SECONDS = 30;
-export const FEATURE_FLAG_REFRESH_CHANNEL = 'feature_flags:refresh';
+export const IP_BAN_REFRESH_CHANNEL = 'ip_bans:refresh';

--- a/fluxer_api/src/middleware/ServiceMiddleware.ts
+++ b/fluxer_api/src/middleware/ServiceMiddleware.ts
@@ -145,7 +145,8 @@ const cloudflarePurgeQueue: ICloudflarePurgeQueue = Config.cloudflare.purgeEnabl
 const assetDeletionQueue: IAssetDeletionQueue = new AssetDeletionQueue(redis);
 
 const featureFlagRepository = new FeatureFlagRepository();
-const featureFlagService = new FeatureFlagService(featureFlagRepository, cacheService);
+const featureFlagSubscriber = new Redis(Config.redis.url);
+const featureFlagService = new FeatureFlagService(featureFlagRepository, cacheService, featureFlagSubscriber);
 let featureFlagServiceInitialized = false;
 const snowflakeReservationRepository = new SnowflakeReservationRepository();
 const snowflakeReservationSubscriber = new Redis(Config.redis.url);

--- a/fluxer_api/src/rpc/RpcService.ts
+++ b/fluxer_api/src/rpc/RpcService.ts
@@ -289,7 +289,7 @@ export class RpcService {
 				return {
 					type: 'geoip_lookup',
 					data: {
-						country_code: geoip.countryCode,
+						country_code: geoip.countryCode ?? 'US',
 					},
 				};
 			}
@@ -689,7 +689,7 @@ export class RpcService {
 		let countryCode = 'US';
 		if (ip) {
 			const geoip = await lookupGeoip(ip);
-			countryCode = geoip.countryCode;
+			countryCode = geoip.countryCode ?? countryCode;
 		} else {
 			Logger.warn({context: 'rpc_geoip', reason: 'ip_missing'}, 'RPC session request missing IP for GeoIP');
 		}


### PR DESCRIPTION
by subscribing to a redis pubsub channel to know when to refresh from the database instead of refreshing periodically, we both reduce db load and allow for instantaneous rollouts of config changes.