### PR TITLE
fix(search): make closed DM search work correctly

### DIFF
--- a/fluxer_admin/src/fluxer_admin/constants.gleam
+++ b/fluxer_admin/src/fluxer_admin/constants.gleam
@@ -69,6 +69,11 @@ pub const flag_app_store_reviewer = Flag(
   9_007_199_254_740_992,
 )
 
+pub const flag_dm_history_backfilled = Flag(
+  "DM_HISTORY_BACKFILLED",
+  18_014_398_509_481_984,
+)
+
 pub fn get_patchable_flags() -> List(Flag) {
   [
     flag_staff,
@@ -84,6 +89,7 @@ pub fn get_patchable_flags() -> List(Flag) {
     flag_pending_manual_verification,
     flag_used_mobile_client,
     flag_app_store_reviewer,
+    flag_dm_history_backfilled,
   ]
 }
 

--- a/fluxer_api/src/Tables.ts
+++ b/fluxer_api/src/Tables.ts
@@ -161,6 +161,7 @@ import {
 	USER_BY_USERNAME_COLUMNS,
 	USER_COLUMNS,
 	USER_CONTACT_CHANGE_LOG_COLUMNS,
+	USER_DM_HISTORY_COLUMNS,
 	USER_GUILD_SETTINGS_COLUMNS,
 	USER_HARVEST_COLUMNS,
 	USER_SETTINGS_COLUMNS,
@@ -171,6 +172,7 @@ import {
 	type UserByStripeSubscriptionIdRow,
 	type UserByUsernameRow,
 	type UserContactChangeLogRow,
+	type UserDmHistoryRow,
 	type UserGuildSettingsRow,
 	type UserHarvestRow,
 	type UserRow,
@@ -198,6 +200,12 @@ export const UsersPendingDeletion = defineTable<
 	name: 'users_pending_deletion',
 	columns: USERS_PENDING_DELETION_COLUMNS,
 	primaryKey: ['deletion_date', 'pending_deletion_at', 'user_id'],
+});
+
+export const UserDmHistory = defineTable<UserDmHistoryRow, 'user_id' | 'channel_id'>({
+	name: 'user_dm_history',
+	columns: USER_DM_HISTORY_COLUMNS,
+	primaryKey: ['user_id', 'channel_id'],
 });
 
 export const UserByUsername = defineTable<UserByUsernameRow, 'username' | 'discriminator' | 'user_id'>({

--- a/fluxer_api/src/channel/services/message/dmScopeUtils.ts
+++ b/fluxer_api/src/channel/services/message/dmScopeUtils.ts
@@ -54,6 +54,13 @@ export const getDmChannelIdsForScope = async ({
 		channelIdStrings.add(summary.channelId.toString());
 	}
 
+	if (scope === 'all_dms') {
+		const historicalIds = await userRepository.listHistoricalDmChannelIds(userId);
+		for (const channelId of historicalIds) {
+			channelIdStrings.add(channelId.toString());
+		}
+	}
+
 	if (includeChannelId) {
 		channelIdStrings.add(includeChannelId.toString());
 	}

--- a/fluxer_api/src/constants/User.ts
+++ b/fluxer_api/src/constants/User.ts
@@ -55,6 +55,7 @@ export const UserFlags = {
 	HAS_DISMISSED_PREMIUM_ONBOARDING: 1n << 51n,
 	USED_MOBILE_CLIENT: 1n << 52n,
 	APP_STORE_REVIEWER: 1n << 53n,
+	HAS_DM_HISTORY_BACKFILLED: 1n << 54n,
 } as const;
 
 export const PUBLIC_USER_FLAGS = UserFlags.STAFF | UserFlags.CTP_MEMBER | UserFlags.PARTNER | UserFlags.BUG_HUNTER;

--- a/fluxer_api/src/database/types/UserTypes.ts
+++ b/fluxer_api/src/database/types/UserTypes.ts
@@ -592,3 +592,12 @@ export const USERS_PENDING_DELETION_COLUMNS = [
 	'user_id',
 	'deletion_reason_code',
 ] as const satisfies ReadonlyArray<keyof UsersPendingDeletionRow>;
+
+export interface UserDmHistoryRow {
+	user_id: UserID;
+	channel_id: ChannelID;
+}
+
+export const USER_DM_HISTORY_COLUMNS = ['user_id', 'channel_id'] as const satisfies ReadonlyArray<
+	keyof UserDmHistoryRow
+>;

--- a/fluxer_api/src/user/repositories/IUserChannelRepository.ts
+++ b/fluxer_api/src/user/repositories/IUserChannelRepository.ts
@@ -32,6 +32,8 @@ export interface IUserChannelRepository {
 	listPrivateChannels(userId: UserID): Promise<Array<Channel>>;
 	deleteAllPrivateChannels(userId: UserID): Promise<void>;
 	listPrivateChannelSummaries(userId: UserID): Promise<Array<PrivateChannelSummary>>;
+	listHistoricalDmChannelIds(userId: UserID): Promise<Array<ChannelID>>;
+	recordHistoricalDmChannel(userId: UserID, channelId: ChannelID, isGroupDm: boolean): Promise<void>;
 
 	findExistingDmState(user1Id: UserID, user2Id: UserID): Promise<Channel | null>;
 	createDmChannelAndState(user1Id: UserID, user2Id: UserID, channelId: ChannelID): Promise<Channel>;

--- a/fluxer_api/src/user/repositories/UserRepository.ts
+++ b/fluxer_api/src/user/repositories/UserRepository.ts
@@ -435,6 +435,14 @@ export class UserRepository implements IUserRepositoryAggregate {
 		return this.channelRepo.listPrivateChannels(userId);
 	}
 
+	async listHistoricalDmChannelIds(userId: UserID): Promise<Array<ChannelID>> {
+		return this.channelRepo.listHistoricalDmChannelIds(userId);
+	}
+
+	async recordHistoricalDmChannel(userId: UserID, channelId: ChannelID, isGroupDm: boolean): Promise<void> {
+		return this.channelRepo.recordHistoricalDmChannel(userId, channelId, isGroupDm);
+	}
+
 	async listPrivateChannelSummaries(userId: UserID): Promise<Array<PrivateChannelSummary>> {
 		return this.channelRepo.listPrivateChannelSummaries(userId);
 	}

--- a/fluxer_devops/cassandra/migrations/20260106001944_user_dm_history.cql
+++ b/fluxer_devops/cassandra/migrations/20260106001944_user_dm_history.cql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS fluxer.user_dm_history (
+    user_id bigint,
+    channel_id bigint,
+    PRIMARY KEY ((user_id), channel_id)
+);


### PR DESCRIPTION
this PR tracks all your historical DMs, even closed ones, and adds a lazy backfill to sync any existing users.