### PR TITLE
fix(app): don't suppress toast when copying user id in popout

### DIFF
--- a/fluxer_app/src/components/popouts/UserAreaPopout.tsx
+++ b/fluxer_app/src/components/popouts/UserAreaPopout.tsx
@@ -322,7 +322,7 @@ export const UserAreaPopout = observer(() => {
 		if (!currentUser) {
 			return;
 		}
-		TextCopyActionCreators.copy(i18n, currentUser.tag, true);
+		TextCopyActionCreators.copy(i18n, currentUser.tag);
 	}, [currentUser, i18n]);
 
 	const openManageAccounts = React.useCallback(() => {

--- a/fluxer_app/src/components/popouts/UserAreaPopout.tsx
+++ b/fluxer_app/src/components/popouts/UserAreaPopout.tsx
@@ -315,7 +315,7 @@ export const UserAreaPopout = observer(() => {
 		if (!currentUserId) {
 			return;
 		}
-		TextCopyActionCreators.copy(i18n, currentUserId, true);
+		TextCopyActionCreators.copy(i18n, currentUserId);
 	}, [currentUserId, i18n]);
 
 	const handleCopyUserTag = React.useCallback(() => {


### PR DESCRIPTION
this was undesirable without any other form of success indicator in place.