### PR TITLE
fix(app): suppress angle bracket-wrapped coded links

### DIFF
--- a/fluxer_app/src/utils/CodeLinkUtils.tsx
+++ b/fluxer_app/src/utils/CodeLinkUtils.tsx
@@ -18,6 +18,7 @@
  */
 
 import * as RegexUtils from '~/utils/RegexUtils';
+import {isLinkWrappedInAngleBrackets} from '~/utils/linkSuppressionUtils';
 
 export interface CodeLinkConfig {
 	shortHost: string;
@@ -61,6 +62,10 @@ export function findCodes(content: string | null, config: CodeLinkConfig): Array
 
 	let match: RegExpExecArray | null;
 	while ((match = pattern.exec(content)) !== null && codes.length < 10) {
+		const matchedText = match[0];
+		if (isLinkWrappedInAngleBrackets(content, match.index ?? 0, matchedText.length)) {
+			continue;
+		}
 		const code = match[1] || match[2];
 		if (code && !seenCodes.has(code)) {
 			seenCodes.add(code);
@@ -76,10 +81,17 @@ export function findCode(content: string | null, config: CodeLinkConfig): string
 
 	const pattern = createPattern(config);
 	pattern.lastIndex = 0;
-	const match = pattern.exec(content);
+	let match: RegExpExecArray | null;
+	while ((match = pattern.exec(content)) !== null) {
+		const matchedText = match[0];
+		if (isLinkWrappedInAngleBrackets(content, match.index ?? 0, matchedText.length)) {
+			continue;
+		}
 
-	if (match) {
-		return match[1] || match[2];
+		const code = match[1] || match[2];
+		if (code) {
+			return code;
+		}
 	}
 
 	return null;

--- a/fluxer_app/src/utils/linkSuppressionUtils.ts
+++ b/fluxer_app/src/utils/linkSuppressionUtils.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Fluxer Contributors
+ *
+ * This file is part of Fluxer.
+ *
+ * Fluxer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fluxer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Fluxer. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export function isLinkWrappedInAngleBrackets(
+	content: string,
+	matchStart: number,
+	matchLength: number,
+): boolean {
+	if (matchLength <= 0) return false;
+
+	const beforeIndex = matchStart - 1;
+	const afterIndex = matchStart + matchLength;
+
+	if (beforeIndex < 0 || afterIndex >= content.length) {
+		return false;
+	}
+
+	return content[beforeIndex] === '<' && content[afterIndex] === '>';
+}


### PR DESCRIPTION
before this PR, attempting to suppress invite links like `<https://fluxer.gg/abcd123>` would not actually do suppress it.