### PR TITLE
fix(embed): render forwarded embeds identically to real messages

### DIFF
--- a/fluxer_app/src/components/channel/MessageAttachments.module.css
+++ b/fluxer_app/src/components/channel/MessageAttachments.module.css
@@ -56,7 +56,11 @@
 }
 
 .attachmentsContainer {
-	margin-top: 0.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	align-items: flex-start;
+	margin-top: var(--message-container-gap, 0.25rem);
 }
 
 .forwardedSourceButton {

--- a/fluxer_app/src/components/channel/MessageAttachments.tsx
+++ b/fluxer_app/src/components/channel/MessageAttachments.tsx
@@ -196,7 +196,14 @@ const ForwardedMessageContent = observer(({message, snapshot}: {message: Message
 				{snapshot.embeds && snapshot.embeds.length > 0 && UserSettingsStore.getRenderEmbeds() && (
 					<div className={styles.attachmentsContainer}>
 						{snapshot.embeds.map((embed: MessageEmbed, index: number) => (
-							<Embed embed={embed} key={embed.id} message={message} embedIndex={index} onDelete={() => {}} />
+							<Embed
+								embed={embed}
+								key={embed.id}
+								message={message}
+								embedIndex={index}
+								contextualEmbeds={snapshot.embeds}
+								onDelete={() => {}}
+							/>
 						))}
 					</div>
 				)}


### PR DESCRIPTION
previously, merging of trailing contextual media for galleries did not work as expected in forwarded messages. there were also some layout issues where multiple rich embeds would stack horizontally instead of vertically, along with some minor spacing issues.