### PR TITLE
fix(api): exempt bots from being considered unclaimed users

### DIFF
--- a/fluxer_api/src/auth/services/SudoVerificationService.ts
+++ b/fluxer_api/src/auth/services/SudoVerificationService.ts
@@ -97,7 +97,7 @@ async function verifySudoMode(
 		return {verified: true, sudoToken, method: 'mfa'};
 	}
 
-	const isUnclaimedAccount = !user.passwordHash;
+	const isUnclaimedAccount = user.isUnclaimedAccount();
 	if (isUnclaimedAccount && !hasMfa) {
 		return {verified: true, method: 'password'};
 	}

--- a/fluxer_api/src/channel/controllers/MessageController.ts
+++ b/fluxer_api/src/channel/controllers/MessageController.ts
@@ -306,7 +306,7 @@ export const MessageController = (app: HonoApp) => {
 			const channelId = createChannelID(ctx.req.valid('param').channel_id);
 			const requestCache = ctx.get('requestCache');
 
-			if (!user.passwordHash && !isPersonalNotesChannel({userId: user.id, channelId})) {
+			if (user.isUnclaimedAccount() && !isPersonalNotesChannel({userId: user.id, channelId})) {
 				throw new UnclaimedAccountRestrictedError('send messages');
 			}
 

--- a/fluxer_api/src/channel/controllers/MessageInteractionController.ts
+++ b/fluxer_api/src/channel/controllers/MessageInteractionController.ts
@@ -166,7 +166,7 @@ export const MessageInteractionController = (app: HonoApp) => {
 			const sessionId = ctx.req.valid('query').session_id;
 			const requestCache = ctx.get('requestCache');
 
-			if (!user.passwordHash && !isPersonalNotesChannel({userId: user.id, channelId})) {
+			if (user.isUnclaimedAccount() && !isPersonalNotesChannel({userId: user.id, channelId})) {
 				throw new UnclaimedAccountRestrictedError('add reactions');
 			}
 

--- a/fluxer_api/src/channel/services/CallService.ts
+++ b/fluxer_api/src/channel/services/CallService.ts
@@ -73,7 +73,7 @@ export class CallService {
 		}
 
 		const caller = await this.userRepository.findUnique(userId);
-		const isUnclaimedCaller = caller != null && !caller.passwordHash && !caller.isBot;
+		const isUnclaimedCaller = caller?.isUnclaimedAccount() ?? false;
 		if (isUnclaimedCaller && channel.type === ChannelTypes.DM) {
 			return {ringable: false};
 		}

--- a/fluxer_api/src/channel/services/DMPermissionValidator.ts
+++ b/fluxer_api/src/channel/services/DMPermissionValidator.ts
@@ -35,16 +35,12 @@ export class DMPermissionValidator {
 
 	async validate({recipients, userId}: {recipients: Array<User>; userId: UserID}): Promise<void> {
 		const senderUser = await this.deps.userRepository.findUnique(userId);
-		if (senderUser && !senderUser.passwordHash && !senderUser.isBot) {
+		if (senderUser && senderUser.isUnclaimedAccount()) {
 			throw new UnclaimedAccountRestrictedError('send direct messages');
 		}
 
 		const targetUser = recipients.find((recipient) => recipient.id !== userId);
 		if (!targetUser) return;
-
-		if (!targetUser.passwordHash && !targetUser.isBot) {
-			throw new UnclaimedAccountRestrictedError('receive direct messages');
-		}
 
 		const senderBlockedTarget = await this.deps.userRepository.getRelationship(
 			userId,

--- a/fluxer_api/src/models/User.ts
+++ b/fluxer_api/src/models/User.ts
@@ -139,6 +139,10 @@ export class User {
 		return checkIsPremium(this);
 	}
 
+	isUnclaimedAccount(): boolean {
+		return this.passwordHash === null && !this.isBot;
+	}
+
 	canUseGlobalExpressions(): boolean {
 		return this.isPremium() || this.isBot;
 	}

--- a/fluxer_api/src/oauth/ApplicationService.ts
+++ b/fluxer_api/src/oauth/ApplicationService.ts
@@ -135,7 +135,7 @@ export class ApplicationService {
 		const owner = await this.deps.userRepository.findUniqueAssert(args.ownerUserId);
 		const botIsPublic = args.botPublic ?? true;
 
-		if (!owner.passwordHash && !owner.isBot) {
+		if (owner.isUnclaimedAccount()) {
 			throw new UnclaimedAccountRestrictedError('create applications');
 		}
 

--- a/fluxer_api/src/stripe/services/StripeCheckoutService.ts
+++ b/fluxer_api/src/stripe/services/StripeCheckoutService.ts
@@ -218,7 +218,7 @@ export class StripeCheckoutService {
 	}
 
 	validateUserCanPurchase(user: User): void {
-		if (!user.passwordHash && !user.isBot) {
+		if (user.isUnclaimedAccount()) {
 			throw new UnclaimedAccountRestrictedError('make purchases');
 		}
 

--- a/fluxer_api/src/user/controllers/UserAccountController.ts
+++ b/fluxer_api/src/user/controllers/UserAccountController.ts
@@ -90,7 +90,7 @@ const requiresSensitiveUserVerification = (
 	data: UserUpdateRequest,
 	emailTokenProvided: boolean,
 ): boolean => {
-	const isUnclaimed = !user.passwordHash;
+	const isUnclaimed = user.isUnclaimedAccount();
 	const usernameChanged = data.username !== undefined && data.username !== user.username;
 	const discriminatorChanged = data.discriminator !== undefined && data.discriminator !== user.discriminator;
 	const emailChanged = data.email !== undefined && data.email !== user.email;
@@ -204,7 +204,7 @@ export const UserAccountController = (app: HonoApp) => {
 				throw InputValidationError.create('email', 'Email must be changed via email_token');
 			}
 			const emailTokenProvided = emailToken !== undefined;
-			const isUnclaimed = !user.passwordHash;
+			const isUnclaimed = user.isUnclaimedAccount();
 			if (isUnclaimed) {
 				const {username: _ignoredUsername, discriminator: _ignoredDiscriminator, ...rest} = userUpdateData;
 				userUpdateData = rest;

--- a/fluxer_api/src/user/services/EmailChangeService.ts
+++ b/fluxer_api/src/user/services/EmailChangeService.ts
@@ -60,7 +60,7 @@ export class EmailChangeService {
 	) {}
 
 	async start(user: User): Promise<StartEmailChangeResult> {
-		const isUnclaimed = !user.passwordHash;
+		const isUnclaimed = user.isUnclaimedAccount();
 		const hasEmail = !!user.email;
 		if (!hasEmail && !isUnclaimed) {
 			throw InputValidationError.create('email', 'You must have an email to change it.');

--- a/fluxer_api/src/user/services/UserAccountSecurityService.ts
+++ b/fluxer_api/src/user/services/UserAccountSecurityService.ts
@@ -60,7 +60,7 @@ export class UserAccountSecurityService {
 			invalidateAuthSessions: false,
 		};
 
-		const isUnclaimedAccount = !user.passwordHash;
+		const isUnclaimedAccount = user.isUnclaimedAccount();
 		const identityVerifiedViaSudo = sudoContext?.method === 'mfa' || sudoContext?.method === 'sudo_token';
 		const identityVerifiedViaPassword = sudoContext?.method === 'password';
 		const hasMfa = userHasMfa(user);

--- a/fluxer_api/src/user/services/UserChannelService.ts
+++ b/fluxer_api/src/user/services/UserChannelService.ts
@@ -480,15 +480,10 @@ export class UserChannelService {
 		}
 	}
 
-	private async validateDmPermission(userId: UserID, recipientId: UserID, recipientUser?: User | null): Promise<void> {
+	private async validateDmPermission(userId: UserID, recipientId: UserID, _recipientUser?: User | null): Promise<void> {
 		const senderUser = await this.userAccountRepository.findUnique(userId);
-		if (senderUser && !senderUser.passwordHash && !senderUser.isBot) {
+		if (senderUser && senderUser.isUnclaimedAccount()) {
 			throw new UnclaimedAccountRestrictedError('send direct messages');
-		}
-
-		const resolvedRecipient = recipientUser ?? (await this.userAccountRepository.findUnique(recipientId));
-		if (resolvedRecipient && !resolvedRecipient.passwordHash && !resolvedRecipient.isBot) {
-			throw new UnclaimedAccountRestrictedError('receive direct messages');
 		}
 
 		const userBlockedRecipient = await this.userRelationshipRepository.getRelationship(

--- a/fluxer_api/src/user/services/UserContentService.ts
+++ b/fluxer_api/src/user/services/UserContentService.ts
@@ -121,7 +121,7 @@ export class UserContentService {
 			throw new UnknownUserError();
 		}
 
-		if (!user.passwordHash && !user.isBot) {
+		if (user.isUnclaimedAccount()) {
 			throw new UnclaimedAccountRestrictedError('create beta codes');
 		}
 

--- a/fluxer_api/src/user/services/UserRelationshipService.ts
+++ b/fluxer_api/src/user/services/UserRelationshipService.ts
@@ -137,7 +137,7 @@ export class UserRelationshipService {
 		requestCache: RequestCache;
 	}): Promise<Relationship> {
 		const user = await this.userAccountRepository.findUnique(userId);
-		if (user && !user.passwordHash) {
+		if (user && user.isUnclaimedAccount()) {
 			throw new UnclaimedAccountRestrictedError('accept friend requests');
 		}
 
@@ -341,7 +341,7 @@ export class UserRelationshipService {
 		}
 
 		const requesterUser = await this.userAccountRepository.findUnique(userId);
-		if (requesterUser && !requesterUser.passwordHash) {
+		if (requesterUser && requesterUser.isUnclaimedAccount()) {
 			throw new UnclaimedAccountRestrictedError('send friend requests');
 		}
 

--- a/fluxer_api/src/voice/VoiceService.ts
+++ b/fluxer_api/src/voice/VoiceService.ts
@@ -116,7 +116,7 @@ export class VoiceService {
 			throw new UnknownChannelError();
 		}
 
-		const isUnclaimed = !user.passwordHash && !user.isBot;
+		const isUnclaimed = user.isUnclaimedAccount();
 		if (isUnclaimed) {
 			if (channel.type === ChannelTypes.DM) {
 				throw new UnclaimedAccountRestrictedError('join 1:1 voice calls');


### PR DESCRIPTION
also ensures that unclaimed users can receive dms still, just not send them.