### PR TITLE
fix(app): application create flow + duplicate sudo

### DIFF
--- a/fluxer_app/src/components/modals/tabs/ApplicationsTab/ApplicationDetail.tsx
+++ b/fluxer_app/src/components/modals/tabs/ApplicationsTab/ApplicationDetail.tsx
@@ -417,6 +417,7 @@ export const ApplicationDetail: React.FC<ApplicationDetailProps> = observer(
 				} else {
 					setBotToken(res.body.token ?? null);
 				}
+				sudo.finalize();
 				ToastActionCreators.createToast({
 					type: 'success',
 					children:

--- a/fluxer_app/src/hooks/useSudo.ts
+++ b/fluxer_app/src/hooks/useSudo.ts
@@ -29,5 +29,9 @@ export const useSudo = () => {
 		return await SudoPromptStore.requestVerification();
 	}, []);
 
-	return {require};
+	const finalize = useCallback(() => {
+		SudoPromptStore.handleTokenReceived(null);
+	}, []);
+
+	return {require, finalize};
 };


### PR DESCRIPTION
the application create modal was out of sync with the usual patterns we follow in the app, including lacking a footer. moreover, we had not properly finalised sudo mode in our manual useSudo integration for rolling new secrets, making it prompt for sudo verification yet another time despite being completed.