### PR TITLE
fix(app): suppress details for channel delete audit logs

### DIFF
--- a/fluxer_app/src/utils/modals/guildTabs/GuildAuditLogTabUtils.ts
+++ b/fluxer_app/src/utils/modals/guildTabs/GuildAuditLogTabUtils.ts
@@ -139,6 +139,7 @@ const suppressedDetailActions = new Set<AuditLogActionType>([
 	AuditLogActionType.MESSAGE_BULK_DELETE,
 	AuditLogActionType.MESSAGE_PIN,
 	AuditLogActionType.MESSAGE_UNPIN,
+	AuditLogActionType.CHANNEL_DELETE,
 ]);
 
 const NotRenderedChangeKeys: Partial<Record<AuditLogTargetType, Record<string, true>>> = {


### PR DESCRIPTION
a simple solution to avoid rendering an attached nonsensical change list to simple channel delete audit log entries.