### PR TITLE
fix(app): improve UX for nested sidebars

### DIFF
--- a/fluxer_app/src/components/modals/components/DesktopChannelSettingsView.tsx
+++ b/fluxer_app/src/components/modals/components/DesktopChannelSettingsView.tsx
@@ -66,12 +66,24 @@ export const DesktopChannelSettingsView: React.FC<DesktopChannelSettingsViewProp
 			contentRef.current?.focus();
 		}, []);
 
+		const channelPermissionsOverrideOwnerId = React.useMemo(
+			() => `channel-permissions-${channel.id}`,
+			[channel.id],
+		);
+
 		const handleTabSelect = React.useCallback(
 			(tabType: ChannelSettingsTabType) => {
 				if (checkUnsavedChanges()) return;
+				if (
+					tabType === 'permissions' &&
+					SettingsSidebarStore.ownerId === channelPermissionsOverrideOwnerId &&
+					SettingsSidebarStore.isDismissed(channelPermissionsOverrideOwnerId)
+				) {
+					SettingsSidebarStore.activateOverride(channelPermissionsOverrideOwnerId);
+				}
 				onTabSelect(tabType);
 			},
-			[checkUnsavedChanges, onTabSelect],
+			[checkUnsavedChanges, onTabSelect, channelPermissionsOverrideOwnerId],
 		);
 
 		const handleDeleteChannel = React.useCallback(() => {
@@ -119,7 +131,7 @@ export const DesktopChannelSettingsView: React.FC<DesktopChannelSettingsViewProp
 										<Button
 											variant="secondary"
 											leftIcon={<ArrowLeftIcon className={styles.sidebarButtonIcon} />}
-											onClick={() => SettingsSidebarStore.setUseOverride(false)}
+											onClick={() => SettingsSidebarStore.dismissOverride()}
 										>
 											{t`Back to Settings`}
 										</Button>
@@ -134,12 +146,14 @@ export const DesktopChannelSettingsView: React.FC<DesktopChannelSettingsViewProp
 									exit={prefersReducedMotion ? {opacity: 1} : {opacity: 0}}
 									transition={prefersReducedMotion ? {duration: 0} : {duration: 0.2, ease: 'easeOut'}}
 								>
-									{SettingsSidebarStore.hasOverride && (
+									{SettingsSidebarStore.hasOverride &&
+										SettingsSidebarStore.ownerId === channelPermissionsOverrideOwnerId &&
+										!SettingsSidebarStore.isDismissed(channelPermissionsOverrideOwnerId) && (
 										<div className={styles.sidebarButtonWrapper}>
 											<Button
 												variant="secondary"
 												rightIcon={<ArrowRightIcon className={styles.sidebarButtonIcon} />}
-												onClick={() => SettingsSidebarStore.setUseOverride(true)}
+												onClick={() => SettingsSidebarStore.activateOverride(channelPermissionsOverrideOwnerId)}
 											>
 												{t`Back to Overrides`}
 											</Button>

--- a/fluxer_app/src/components/modals/components/DesktopGuildSettingsView.tsx
+++ b/fluxer_app/src/components/modals/components/DesktopGuildSettingsView.tsx
@@ -69,12 +69,21 @@ export const DesktopGuildSettingsView: React.FC<DesktopGuildSettingsViewProps> =
 			contentRef.current?.focus();
 		}, []);
 
+		const guildOverrideOwnerId = React.useMemo(() => `guild-roles-${guild.id}`, [guild.id]);
+
 		const handleTabSelect = React.useCallback(
 			(tabType: GuildSettingsTabType) => {
 				if (checkUnsavedChanges()) return;
+				if (
+					tabType === 'roles' &&
+					SettingsSidebarStore.ownerId === guildOverrideOwnerId &&
+					SettingsSidebarStore.isDismissed(guildOverrideOwnerId)
+				) {
+					SettingsSidebarStore.activateOverride(guildOverrideOwnerId);
+				}
 				onTabSelect(tabType);
 			},
-			[checkUnsavedChanges, onTabSelect],
+			[checkUnsavedChanges, onTabSelect, guildOverrideOwnerId],
 		);
 
 		const handleDeleteGuild = React.useCallback(() => {
@@ -134,7 +143,7 @@ export const DesktopGuildSettingsView: React.FC<DesktopGuildSettingsViewProps> =
 										<Button
 											variant="secondary"
 											leftIcon={<ArrowLeftIcon className={styles.sidebarButtonIcon} />}
-											onClick={() => SettingsSidebarStore.setUseOverride(false)}
+											onClick={() => SettingsSidebarStore.dismissOverride()}
 										>
 											{t`Back to Settings`}
 										</Button>
@@ -149,17 +158,19 @@ export const DesktopGuildSettingsView: React.FC<DesktopGuildSettingsViewProps> =
 									exit={prefersReducedMotion ? {opacity: 1} : {opacity: 0}}
 									transition={prefersReducedMotion ? {duration: 0} : {duration: 0.2, ease: 'easeOut'}}
 								>
-									{SettingsSidebarStore.hasOverride && (
-										<div className={styles.sidebarButtonWrapper}>
-											<Button
-												variant="secondary"
-												rightIcon={<ArrowRightIcon className={styles.sidebarButtonIcon} />}
-												onClick={() => SettingsSidebarStore.setUseOverride(true)}
-											>
-												{selectedTab === 'roles' ? t`Back to Roles` : t`Back to Overrides`}
-											</Button>
-										</div>
-									)}
+									{SettingsSidebarStore.hasOverride &&
+										SettingsSidebarStore.ownerId === guildOverrideOwnerId &&
+										!SettingsSidebarStore.isDismissed(guildOverrideOwnerId) && (
+											<div className={styles.sidebarButtonWrapper}>
+												<Button
+													variant="secondary"
+													rightIcon={<ArrowRightIcon className={styles.sidebarButtonIcon} />}
+													onClick={() => SettingsSidebarStore.activateOverride(guildOverrideOwnerId)}
+												>
+													{selectedTab === 'roles' ? t`Back to Roles` : t`Back to Overrides`}
+												</Button>
+											</div>
+										)}
 									{Object.entries(groupedSettingsTabs).map(([category, tabs]) => (
 										<SettingsModalSidebarCategory key={category}>
 											{category !== 'guild_settings' && (

--- a/fluxer_app/src/stores/SettingsSidebarStore.tsx
+++ b/fluxer_app/src/stores/SettingsSidebarStore.tsx
@@ -24,6 +24,7 @@ class SettingsSidebarStore {
 	ownerId: string | null = null;
 	overrideContent: React.ReactNode | null = null;
 	useOverride = false;
+	dismissedOwnerId: string | null = null;
 
 	constructor() {
 		makeAutoObservable(this, {overrideContent: observable.ref}, {autoBind: true});
@@ -36,7 +37,8 @@ class SettingsSidebarStore {
 	setOverride(ownerId: string, content: React.ReactNode, options?: {defaultOn?: boolean}): void {
 		this.ownerId = ownerId;
 		this.overrideContent = content;
-		if (options?.defaultOn) this.useOverride = true;
+		this.dismissedOwnerId = null;
+		this.useOverride = options?.defaultOn ?? false;
 	}
 
 	updateOverride(ownerId: string, content: React.ReactNode): void {
@@ -48,7 +50,15 @@ class SettingsSidebarStore {
 		if (ownerId && this.ownerId && this.ownerId !== ownerId) return;
 		this.ownerId = null;
 		this.overrideContent = null;
+		this.dismissedOwnerId = null;
 		this.useOverride = false;
+	}
+
+	dismissOverride(ownerId?: string): void {
+		if (ownerId && this.ownerId && this.ownerId !== ownerId) return;
+		const targetOwnerId = ownerId ?? this.ownerId;
+		this.useOverride = false;
+		this.dismissedOwnerId = targetOwnerId;
 	}
 
 	setUseOverride(value: boolean): void {
@@ -56,7 +66,23 @@ class SettingsSidebarStore {
 			this.useOverride = false;
 			return;
 		}
+		if (value) {
+			this.dismissedOwnerId = null;
+		}
 		this.useOverride = value;
+	}
+
+	activateOverride(ownerId?: string): void {
+		if (!this.hasOverride) return;
+		if (ownerId && this.ownerId && this.ownerId !== ownerId) return;
+		this.useOverride = true;
+		this.dismissedOwnerId = null;
+	}
+
+	isDismissed(ownerId?: string): boolean {
+		if (!this.dismissedOwnerId) return false;
+		if (!ownerId) return this.ownerId === this.dismissedOwnerId;
+		return ownerId === this.dismissedOwnerId;
 	}
 }
 


### PR DESCRIPTION
before this PR, a redundant "Back to Roles" button would be shown in the guild settings modal for instance, after having selected the roles tab to switch the sidebar contents to the roles list, and then pressing on "Back to Settings". it is much simpler to remove this button and make pressing the same tab you pressed on originally take you back to the role list again.