### PR TITLE
fix(api): correct timestamp usage

### DIFF
--- a/fluxer_api/src/models/CallInfo.ts
+++ b/fluxer_api/src/models/CallInfo.ts
@@ -26,7 +26,7 @@ export class CallInfo {
 
 	constructor(call: MessageCall) {
 		this.participantIds = call.participant_ids ?? new Set();
-		this.endedTimestamp = call.ended_timestamp ?? null;
+		this.endedTimestamp = call.ended_timestamp ? new Date(call.ended_timestamp) : null;
 	}
 
 	toMessageCall(): MessageCall {

--- a/fluxer_api/src/models/Embed.ts
+++ b/fluxer_api/src/models/Embed.ts
@@ -45,7 +45,7 @@ export class Embed {
 		this.title = embed.title ?? null;
 		this.description = embed.description ?? null;
 		this.url = embed.url ?? null;
-		this.timestamp = embed.timestamp ?? null;
+		this.timestamp = embed.timestamp ? new Date(embed.timestamp) : null;
 		this.color = embed.color ?? null;
 		this.author = embed.author ? new EmbedAuthor(embed.author) : null;
 		this.provider = embed.provider ? new EmbedProvider(embed.provider) : null;

--- a/fluxer_api/src/models/MessageSnapshot.ts
+++ b/fluxer_api/src/models/MessageSnapshot.ts
@@ -38,8 +38,8 @@ export class MessageSnapshot {
 
 	constructor(snapshot: CassandraMessageSnapshot) {
 		this.content = snapshot.content ?? null;
-		this.timestamp = snapshot.timestamp;
-		this.editedTimestamp = snapshot.edited_timestamp ?? null;
+		this.timestamp = new Date(snapshot.timestamp);
+		this.editedTimestamp = snapshot.edited_timestamp ? new Date(snapshot.edited_timestamp) : null;
 		this.mentionedUserIds = snapshot.mention_users ?? new Set();
 		this.mentionedRoleIds = snapshot.mention_roles ?? new Set();
 		this.mentionedChannelIds = snapshot.mention_channels ?? new Set();

--- a/fluxer_devops/cassandra/migrations/20260107131535_add_edited_timestamp_to_message_snapshot.cql
+++ b/fluxer_devops/cassandra/migrations/20260107131535_add_edited_timestamp_to_message_snapshot.cql
@@ -1,0 +1,1 @@
+ALTER TYPE fluxer.message_snapshot ADD edited_timestamp timestamp;


### PR DESCRIPTION
these timestamps may sometimes already be serialised as strings. the easiest solution for now is to accept both a date and a string. moreover, I realised I had a typo in the database schema for message snapshots for the "edited_timestamp" field. this adds the correct, non-typo version of the column to the schema.