### PR TITLE
fix(app): stream overlay pointer events

### DIFF
--- a/fluxer_app/src/components/voice/VoiceParticipantTile.module.css
+++ b/fluxer_app/src/components/voice/VoiceParticipantTile.module.css
@@ -29,7 +29,7 @@
 	justify-content: center;
 	background-color: rgb(0 0 0 / 0.7);
 	z-index: 10;
-	pointer-events: none;
+	pointer-events: auto;
 	border-radius: var(--radius-lg);
 }
 


### PR DESCRIPTION
a big update is coming very soon, but I was asked to make some quick fixes in advance. here's one of them: you should now be able to press on screenshares properly again.