### PR TITLE
fix: typo in language translation string

### DIFF
--- a/fluxer_app/src/locales/en-US/messages.po
+++ b/fluxer_app/src/locales/en-US/messages.po
@@ -10752,8 +10752,8 @@ msgid "Languages…"
 msgstr "Languages…"
 
 #: src/components/modals/utils/settingsConstants.tsx:225
-msgid "Languge & Time"
-msgstr "Languge & Time"
+msgid "Language & Time"
+msgstr "Language & Time"
 
 #: src/components/modals/tabs/ComponentGalleryTab/SelectionsTab.tsx:122
 msgid "Large"


### PR DESCRIPTION
## Summary

- **What:** Fix typo in settings
- **Why:** It's a typo
- **Notes for reviewers:** 

## Checklist

- [ ] PR targets `canary`
- [x] PR title follows Conventional Commits (mostly lowercase)
- [ ] CI is green (or I’m actively addressing failures)
- [ ] CLA signed (the bot will guide you on first PR)
