### PR TITLE
fix(stripe): invalid cql query for gift processing

### DIFF
--- a/fluxer_api/src/Tables.ts
+++ b/fluxer_api/src/Tables.ts
@@ -560,10 +560,15 @@ export const GiftCodesByCreator = defineTable<GiftCodeByCreatorRow, 'created_by_
 	primaryKey: ['created_by_user_id', 'code'],
 });
 
-export const GiftCodesByPaymentIntent = defineTable<GiftCodeByPaymentIntentRow, 'stripe_payment_intent_id'>({
+export const GiftCodesByPaymentIntent = defineTable<
+	GiftCodeByPaymentIntentRow,
+	'stripe_payment_intent_id' | 'code',
+	'stripe_payment_intent_id'
+>({
 	name: 'gift_codes_by_payment_intent',
 	columns: GIFT_CODE_BY_PAYMENT_INTENT_COLUMNS,
-	primaryKey: ['stripe_payment_intent_id'],
+	primaryKey: ['stripe_payment_intent_id', 'code'],
+	partitionKey: ['stripe_payment_intent_id'],
 });
 
 export const GiftCodesByRedeemer = defineTable<GiftCodeByRedeemerRow, 'redeemed_by_user_id' | 'code'>({


### PR DESCRIPTION
sadly this one slipped through when I refactored away from raw CQL queries to using a custom-built query builder, where the schema definition didn't match the actual schema. as such, new gift purchases resulted in errors. this will fix it and allow for clean replays of the stripe webhooks.