### PR TITLE
fix: use displayName instead of username for placeholder

### DIFF
--- a/fluxer_app/src/components/modals/tabs/MyProfileTab.tsx
+++ b/fluxer_app/src/components/modals/tabs/MyProfileTab.tsx
@@ -657,7 +657,7 @@ const MyProfileTabComponent = observer(function MyProfileTabComponent({
 											<Input
 												{...form.register('nick')}
 												label={t`Community Nickname`}
-												placeholder={user.username}
+												placeholder={user.displayName}
 												maxLength={32}
 												value={form.watch('nick') || ''}
 												footer={


### PR DESCRIPTION
## Summary

- **What:** Replaces `user.username` with `user.displayName` in nickname setting placeholder
- **Why:** Parity with other username modals and clean signalling of active display name
- **Notes for reviewers:** N/A

## How to verify

1. Open Settings
2. Go to Profile -> Select a Server Profile
3. Observe placeholder for "Community Nickname" when empty

## Tests

No tests added or changed - this change mirrors the placeholder behavior used in [`ChangeNicknameModal`](https://github.com/fluxerapp/fluxer/blob/cb316085235723e68fce5b5b7f86befca8e47c09/fluxer_app/src/components/modals/ChangeNicknameModal.tsx#L49)

## Checklist

- [x] PR targets `canary`
- [x] PR title follows Conventional Commits (mostly lowercase)
- [x] CI is green (or I’m actively addressing failures)
- [x] CLA signed (the bot will guide you on first PR)

## Screenshots / recordings (UI changes)

*None provided.*