### PR TITLE
fix: don't reset desktop notification preference on startup

### DIFF
--- a/fluxer_app/src/stores/NotificationStore.tsx
+++ b/fluxer_app/src/stores/NotificationStore.tsx
@@ -430,7 +430,9 @@ class NotificationStore {
 		try {
 			const granted = await NotificationUtils.isGranted();
 			runInAction(() => {
-				this.browserNotificationsEnabled = granted;
+				if (!granted) {
+					this.browserNotificationsEnabled = false;
+				}
 			});
 			if (granted) {
 				if (shouldManagePushSubscriptions()) {


### PR DESCRIPTION
## Summary

<!-- A few bullets is perfect: what changed, why it changed, and anything reviewers should pay attention to. -->

- **What:** Changed `refreshPermission()` in `NotificationStore` to only disable notifications when platform permission is revoked, instead of unconditionally setting the value
- **Why:** On desktop (Electron), `isGranted()` always returns `true`, so the preference was overwritten to "on" every app restart
- **Notes for reviewers:** kiss kiss

## How to verify

  1. Desktop: disable notifications in settings, close and reopen the app
  2. Desktop: enable notifications, close and reopen
  3. Web: with notifications disabled in-app and browser permission granted, reload

## Tests

<!-- List what you ran, or explain why tests weren’t added/changed. -->

- [ ] Added/updated tests (where it makes sense)
- [ ] Unit tests: no existing tests on notificationstore
- [ ] Integration tests: n/a
- [x] Manual verification: tested on desktop and web

## Checklist

- [x] PR targets `canary`
- [x] PR title follows Conventional Commits (mostly lowercase)
- [x] CI is green (or I’m actively addressing failures)
- [x] CLA signed (the bot will guide you on first PR)

## Screenshots / recordings (UI changes)

n/a