### PR TITLE
fix: changed user.username to user.globalName for command feedbacks

### DIFF
--- a/fluxer_app/src/utils/CommandUtils.tsx
+++ b/fluxer_app/src/utils/CommandUtils.tsx
@@ -201,8 +201,8 @@ export async function executeCommand(command: ParsedCommand, channelId: string, 
 			}
 
 			const currentMember = GuildMemberStore.getMember(guildId, currentUserId);
-			const prevNickname = currentMember?.nick || UserStore.getCurrentUser()?.username || 'Unknown';
-			const newNickname = command.nickname || UserStore.getCurrentUser()?.username || 'Unknown';
+			const prevNickname = currentMember?.nick || UserStore.getCurrentUser()?.globalName || 'Unknown';
+			const newNickname = command.nickname || UserStore.getCurrentUser()?.globalName || 'Unknown';
 
 			await GuildMemberActionCreators.updateProfile(guildId, {
 				nick: command.nickname || null,
@@ -255,7 +255,7 @@ export async function executeCommand(command: ParsedCommand, channelId: string, 
 				await PrivateChannelActionCreators.openDMChannel(command.userId);
 			} catch (_error) {
 				const user = UserStore.getUser(command.userId);
-				const username = user?.username || 'user';
+				const username = user?.globalName || user?.username || 'user';
 
 				const systemMessage = createSystemMessage(
 					channelId,


### PR DESCRIPTION
## Summary

Just made the /nick and /msg commands use globalName instead of usernames. I am assuming globalName is the "display name".

## Checklist

- [x] PR targets `canary`
- [x] PR title follows Conventional Commits (mostly lowercase)
- [ ] CI is green (or I’m actively addressing failures)
- [ ] CLA signed (the bot will guide you on first PR)