### PR TITLE
fix: restore pointer events after guild delete

### DIFF
--- a/fluxer_app/src/components/modals/GuildDeleteModal.tsx
+++ b/fluxer_app/src/components/modals/GuildDeleteModal.tsx
@@ -34,7 +34,7 @@ export const GuildDeleteModal = observer(({guildId}: {guildId: string}) => {
 
 	const onSubmit = async () => {
 		await GuildActionCreators.remove(guildId);
-		ModalActionCreators.pop();
+		ModalActionCreators.popAll();
 		ToastActionCreators.createToast({type: 'success', children: t`Community deleted`});
 	};
 


### PR DESCRIPTION
## Summary

<!-- A few bullets is perfect: what changed, why it changed, and anything reviewers should pay attention to. -->

- **What:** Pops all modals after deleting a community
- **Why:** GuildSettingsModal remained orphaned on the modal stack, blocking pointer events
- **Notes for reviewers:** This PR fixes #77 

## How to verify

<!-- Concrete steps to validate the change. Include screenshots/recordings for UI changes when helpful. -->

1. Create a community
2. Open community settings
3. Delete the community
4. Enter password and confirm verification
5. The app should remain usable and page elements clickable

## Tests

<!-- List what you ran, or explain why tests weren’t added/changed. -->

- [ ] Added/updated tests (where it makes sense)
- [x] Unit tests: fluxer_app
- [ ] Integration tests:
- [x] Manual verification: ran build locally and verified correct behaviour after changes

## Checklist

- [x] PR targets `canary`
- [x] PR title follows Conventional Commits (mostly lowercase)
- [ ] CI is green (or I’m actively addressing failures)
- [x] CLA signed (the bot will guide you on first PR)

## Screenshots / recordings (UI changes)

<!-- Drag and drop images/videos here. -->
