### PR TITLE
fix: correct typo in security section

### DIFF
--- a/fluxer_marketing/priv/security/en-US.md
+++ b/fluxer_marketing/priv/security/en-US.md
@@ -63,7 +63,7 @@ In addition, we generally do not prioritize low-impact reports (for example miss
 
 ## How to report
 
-Email your report to security@fluxer.ap.
+Email your report to security@fluxer.app.
 
 Please include:
 


### PR DESCRIPTION
## Summary

Changed `security@fluxer.ap` to `security@fluxer.app`

## Checklist

- [x] PR targets `canary`
- [x] PR title follows Conventional Commits (mostly lowercase)
- [ ] CI is green (or I’m actively addressing failures)
- [ ] CLA signed (the bot will guide you on first PR)