### PR TITLE
fix: removed the option to transfer ownership to bots in GuildMemberContextMenu

### DIFF
--- a/fluxer_app/src/components/uikit/ContextMenu/GuildMemberContextMenu.tsx
+++ b/fluxer_app/src/components/uikit/ContextMenu/GuildMemberContextMenu.tsx
@@ -85,7 +85,7 @@ export const GuildMemberContextMenu: React.FC<GuildMemberContextMenuProps> = obs
 		const targetHasModerateMembersPermission =
 			guildSnapshot !== undefined && PermissionUtils.can(Permissions.MODERATE_MEMBERS, user.id, guildSnapshot);
 		const canTimeout = !isCurrentUser && canModerateMembers && !targetHasModerateMembersPermission;
-		const canTransfer = !isCurrentUser && isOwner;
+		const canTransfer = !isCurrentUser && isOwner && !isBot;
 		const developerMode = UserSettingsStore.developerMode;
 
 		const hasManageNicknamesPermission = PermissionStore.can(Permissions.MANAGE_NICKNAMES, {guildId});
@@ -117,7 +117,7 @@ export const GuildMemberContextMenu: React.FC<GuildMemberContextMenuProps> = obs
 						))}
 				</MenuGroup>
 
-				{canTransfer && member && !isBot && (
+				{canTransfer && member && (
 					<MenuGroup>
 						<TransferOwnershipMenuItem guildId={guildId} user={user} member={member} onClose={onClose} />
 					</MenuGroup>

--- a/fluxer_app/src/components/uikit/ContextMenu/GuildMemberContextMenu.tsx
+++ b/fluxer_app/src/components/uikit/ContextMenu/GuildMemberContextMenu.tsx
@@ -117,7 +117,7 @@ export const GuildMemberContextMenu: React.FC<GuildMemberContextMenuProps> = obs
 						))}
 				</MenuGroup>
 
-				{canTransfer && member && (
+				{canTransfer && member && !isBot && (
 					<MenuGroup>
 						<TransferOwnershipMenuItem guildId={guildId} user={user} member={member} onClose={onClose} />
 					</MenuGroup>

--- a/fluxer_app/src/utils/CommandUtils.tsx
+++ b/fluxer_app/src/utils/CommandUtils.tsx
@@ -201,8 +201,8 @@ export async function executeCommand(command: ParsedCommand, channelId: string, 
 			}
 
 			const currentMember = GuildMemberStore.getMember(guildId, currentUserId);
-			const prevNickname = currentMember?.nick || UserStore.getCurrentUser()?.username || 'Unknown';
-			const newNickname = command.nickname || UserStore.getCurrentUser()?.username || 'Unknown';
+			const prevNickname = currentMember?.nick || UserStore.getCurrentUser()?.globalName || 'Unknown';
+			const newNickname = command.nickname || UserStore.getCurrentUser()?.globalName || 'Unknown';
 
 			await GuildMemberActionCreators.updateProfile(guildId, {
 				nick: command.nickname || null,
@@ -255,7 +255,7 @@ export async function executeCommand(command: ParsedCommand, channelId: string, 
 				await PrivateChannelActionCreators.openDMChannel(command.userId);
 			} catch (_error) {
 				const user = UserStore.getUser(command.userId);
-				const username = user?.username || 'user';
+				const username = user?.globalName || user?.username || 'user';
 
 				const systemMessage = createSystemMessage(
 					channelId,


### PR DESCRIPTION
addresses #192 

## Checklist

- [x] PR targets `canary`
- [x] PR title follows Conventional Commits (mostly lowercase)
- [ ] CI is green (or I’m actively addressing failures)
- [x] CLA signed (the bot will guide you on first PR)