### PR TITLE
fix(bootstrap): stop overwriting bluesky enabled flag during key generations

### DIFF
--- a/scripts/dev_bootstrap.sh
+++ b/scripts/dev_bootstrap.sh
@@ -395,8 +395,7 @@ generate_bluesky_oauth_keys() {
 
     jq --arg kid "dev-key-1" \
        --arg key_path "$key_path" \
-       '.auth.bluesky.enabled = true |
-        .auth.bluesky.logo_uri = "https://fluxerstatic.com/web/apple-touch-icon.png" |
+       '.auth.bluesky.logo_uri = "https://fluxerstatic.com/web/apple-touch-icon.png" |
         .auth.bluesky.tos_uri = "https://fluxer.app/terms" |
         .auth.bluesky.policy_uri = "https://fluxer.app/privacy" |
         .auth.bluesky.token_endpoint_auth_signing_alg = "ES256" |
@@ -407,7 +406,7 @@ generate_bluesky_oauth_keys() {
 
     if [ $? -eq 0 ]; then
         mv "$temp_config" "$config_path"
-        info "Bluesky OAuth configured with dev key (enabled: true)"
+        info "Bluesky OAuth dev key configured"
     else
         error "Failed to update config.json with Bluesky OAuth key"
         rm -f "$temp_config"


### PR DESCRIPTION
`generate_bluesky_oauth_keys` in `dev_bootstrap.sh `unconditionally set `.auth.bluesky.enabled = true` during key generation, overwriting the false that on-create.sh sets for devcontainers (Bluesky OAuth requires HTTPS, incompatible with the HTTP-only devcontainer setup). Removed the enabled override so bootstrap only generates keys without changing the flag. 

From what i understand, bluesky is enabled by default so the flag does not need to be set to true.