### PR TITLE
fix(app): Make some modals use GenericErrorModal instead of ConfirmModal

### DIFF
--- a/fluxer_app/src/features/app/components/alerts/FeatureTemporarilyDisabledModal.tsx
+++ b/fluxer_app/src/features/app/components/alerts/FeatureTemporarilyDisabledModal.tsx
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
+import {GenericErrorModal} from './GenericErrorModal';
 
 const FEATURE_TEMPORARILY_DISABLED_DESCRIPTOR = msg({
 	message: 'Feature temporarily disabled',
@@ -17,13 +16,9 @@ const THIS_FEATURE_HAS_BEEN_TEMPORARILY_DISABLED_PLEASE_TRY_DESCRIPTOR = msg({
 export const FeatureTemporarilyDisabledModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(FEATURE_TEMPORARILY_DISABLED_DESCRIPTOR)}
-			description={i18n._(THIS_FEATURE_HAS_BEEN_TEMPORARILY_DISABLED_PLEASE_TRY_DESCRIPTOR)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(THIS_FEATURE_HAS_BEEN_TEMPORARILY_DISABLED_PLEASE_TRY_DESCRIPTOR)}
 			data-flx="app.feature-temporarily-disabled-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/app/components/alerts/MaxBookmarksModal.tsx
+++ b/fluxer_app/src/features/app/components/alerts/MaxBookmarksModal.tsx
@@ -3,7 +3,7 @@
 import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
 import {PREMIUM_PRODUCT_NAME} from '@app/features/app/config/I18nDisplayConstants';
 import {Limits} from '@app/features/app/utils/UserLimits';
-import {CLOSE_DESCRIPTOR, UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {CLOSE_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import * as PremiumModalCommands from '@app/features/premium/commands/PremiumModalCommands';
 import {shouldShowPremiumFeatures} from '@app/features/premium/utils/PremiumUtils';
 import type {User} from '@app/features/user/models/User';
@@ -11,6 +11,7 @@ import {MAX_BOOKMARKS_PREMIUM} from '@fluxer/constants/src/LimitConstants';
 import {msg, plural} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
+import {GenericErrorModal} from './GenericErrorModal';
 
 const BOOKMARK_LIMIT_REACHED_DESCRIPTOR = msg({
 	message: 'Bookmark limit reached',
@@ -56,26 +57,18 @@ export const MaxBookmarksModal = observer(({user}: MaxBookmarksModalProps) => {
 	);
 	if (!showPremium) {
 		return (
-			<ConfirmModal
+			<GenericErrorModal
 				title={i18n._(BOOKMARK_LIMIT_REACHED_DESCRIPTOR)}
-				description={i18n._(YOU_VE_REACHED_THE_MAXIMUM_NUMBER_OF_BOOKMARKS_DESCRIPTOR, {bookmarksText})}
-				primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-				onPrimary={() => {}}
-				secondaryText={false}
-				hideCloseButton
+				message={i18n._(YOU_VE_REACHED_THE_MAXIMUM_NUMBER_OF_BOOKMARKS_DESCRIPTOR, {bookmarksText})}
 				data-flx="app.max-bookmarks-modal.confirm-modal"
 			/>
 		);
 	}
 	if (!canUpgradeBookmarks) {
 		return (
-			<ConfirmModal
+			<GenericErrorModal
 				title={i18n._(BOOKMARK_LIMIT_REACHED_DESCRIPTOR)}
-				description={i18n._(YOU_VE_REACHED_THE_MAXIMUM_NUMBER_OF_BOOKMARKS_2_DESCRIPTOR, {bookmarksText})}
-				primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-				onPrimary={() => {}}
-				secondaryText={false}
-				hideCloseButton
+				message={i18n._(YOU_VE_REACHED_THE_MAXIMUM_NUMBER_OF_BOOKMARKS_2_DESCRIPTOR, {bookmarksText})}
 				data-flx="app.max-bookmarks-modal.confirm-modal--2"
 			/>
 		);

--- a/fluxer_app/src/features/app/components/alerts/MaxFavoriteMemesModal.tsx
+++ b/fluxer_app/src/features/app/components/alerts/MaxFavoriteMemesModal.tsx
@@ -3,7 +3,7 @@
 import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
 import {PREMIUM_PRODUCT_NAME} from '@app/features/app/config/I18nDisplayConstants';
 import {Limits} from '@app/features/app/utils/UserLimits';
-import {CLOSE_DESCRIPTOR, UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {CLOSE_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import * as PremiumModalCommands from '@app/features/premium/commands/PremiumModalCommands';
 import {shouldShowPremiumFeatures} from '@app/features/premium/utils/PremiumUtils';
 import Users from '@app/features/user/state/Users';
@@ -11,6 +11,7 @@ import {MAX_FAVORITE_MEMES_PREMIUM} from '@fluxer/constants/src/LimitConstants';
 import {msg, plural} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
+import {GenericErrorModal} from './GenericErrorModal';
 
 const SAVED_MEDIA_LIMIT_REACHED_DESCRIPTOR = msg({
 	message: 'Saved media limit reached',
@@ -50,13 +51,9 @@ export const MaxFavoriteMemesModal = observer(() => {
 	);
 	if (!showPremium) {
 		return (
-			<ConfirmModal
+			<GenericErrorModal
 				title={i18n._(SAVED_MEDIA_LIMIT_REACHED_DESCRIPTOR)}
-				description={i18n._(YOU_VE_REACHED_THE_MAXIMUM_LIMIT_OF_THIS_DESCRIPTOR, {freeItemsText})}
-				primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-				onPrimary={() => {}}
-				secondaryText={false}
-				hideCloseButton
+				message={i18n._(YOU_VE_REACHED_THE_MAXIMUM_LIMIT_OF_THIS_DESCRIPTOR, {freeItemsText})}
 				data-flx="app.max-favorite-memes-modal.confirm-modal"
 			/>
 		);

--- a/fluxer_app/src/features/app/components/alerts/RoleNameBlankModal.tsx
+++ b/fluxer_app/src/features/app/components/alerts/RoleNameBlankModal.tsx
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
+import { GenericErrorModal } from './GenericErrorModal';
 
 const ROLE_NAME_CANNOT_BE_BLANK_DESCRIPTOR = msg({
 	message: 'Role name is required',
@@ -17,13 +16,9 @@ const YOU_CANNOT_SAVE_A_ROLE_WITH_A_BLANK_DESCRIPTOR = msg({
 export const RoleNameBlankModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(ROLE_NAME_CANNOT_BE_BLANK_DESCRIPTOR)}
-			description={i18n._(YOU_CANNOT_SAVE_A_ROLE_WITH_A_BLANK_DESCRIPTOR)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(YOU_CANNOT_SAVE_A_ROLE_WITH_A_BLANK_DESCRIPTOR)}
 			data-flx="app.role-name-blank-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/app/components/alerts/RoleNameBlankModal.tsx
+++ b/fluxer_app/src/features/app/components/alerts/RoleNameBlankModal.tsx
@@ -3,7 +3,7 @@
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
-import { GenericErrorModal } from './GenericErrorModal';
+import {GenericErrorModal} from './GenericErrorModal';
 
 const ROLE_NAME_CANNOT_BE_BLANK_DESCRIPTOR = msg({
 	message: 'Role name is required',

--- a/fluxer_app/src/features/app/components/alerts/TemporaryInviteRequiresPresenceModal.tsx
+++ b/fluxer_app/src/features/app/components/alerts/TemporaryInviteRequiresPresenceModal.tsx
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
+import {GenericErrorModal} from './GenericErrorModal';
 
 const GATEWAY_CONNECTION_REQUIRED_DESCRIPTOR = msg({
 	message: 'Gateway connection required',
@@ -18,13 +17,9 @@ const YOU_MUST_BE_CONNECTED_TO_THE_GATEWAY_TO_DESCRIPTOR = msg({
 export const TemporaryInviteRequiresPresenceModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(GATEWAY_CONNECTION_REQUIRED_DESCRIPTOR)}
-			description={i18n._(YOU_MUST_BE_CONNECTED_TO_THE_GATEWAY_TO_DESCRIPTOR)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(YOU_MUST_BE_CONNECTED_TO_THE_GATEWAY_TO_DESCRIPTOR)}
 			data-flx="app.temporary-invite-requires-presence-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/app/components/layout/ChannelListContent.tsx
+++ b/fluxer_app/src/features/app/components/layout/ChannelListContent.tsx
@@ -2,7 +2,6 @@
 
 import {Routes} from '@app/app/Routes';
 import Accessibility from '@app/features/accessibility/state/Accessibility';
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
 import {ChannelItem} from '@app/features/app/components/layout/ChannelItem';
 import channelItemStyles from '@app/features/app/components/layout/ChannelItem.module.css';
 import {ChannelItemContent} from '@app/features/app/components/layout/ChannelItemContent';
@@ -28,7 +27,7 @@ import {useRovingFocusList} from '@app/features/app/hooks/useRovingFocusList';
 import Channels from '@app/features/channel/state/Channels';
 import * as GuildCommands from '@app/features/guild/commands/GuildCommands';
 import type {Guild} from '@app/features/guild/models/Guild';
-import {MEMBERS_DESCRIPTOR, UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {MEMBERS_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {isKeyboardActivationKey} from '@app/features/input/utils/KeyboardUtils';
 import * as RouterUtils from '@app/features/navigation/utils/RouterUtils';
 import Permission from '@app/features/permissions/state/Permission';
@@ -58,6 +57,7 @@ import {observer} from 'mobx-react-lite';
 import type {MotionValue} from 'motion';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useDragLayer} from 'react-dnd';
+import {GenericErrorModal} from '../alerts/GenericErrorModal';
 
 const CATEGORY_FULL_DESCRIPTOR = msg({
 	message: 'Category full',
@@ -185,15 +185,11 @@ export const ChannelListContent = observer(({guild, scrollY}: {guild: Guild; scr
 					if (failureCode(error) === APIErrorCodes.MAX_CATEGORY_CHANNELS) {
 						ModalCommands.push(
 							ModalCommands.modal(() => (
-								<ConfirmModal
+								<GenericErrorModal
 									title={i18n._(CATEGORY_FULL_DESCRIPTOR)}
-									description={i18n._(THIS_CATEGORY_ALREADY_CONTAINS_THE_MAXIMUM_OF_CHANNELS_DESCRIPTOR, {
+									message={i18n._(THIS_CATEGORY_ALREADY_CONTAINS_THE_MAXIMUM_OF_CHANNELS_DESCRIPTOR, {
 										maxChannelsPerCategory: MAX_CHANNELS_PER_CATEGORY,
 									})}
-									primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-									onPrimary={() => {}}
-									secondaryText={false}
-									hideCloseButton
 									data-flx="app.channel-list-content.handle-channel-drop.confirm-modal"
 								/>
 							)),

--- a/fluxer_app/src/features/auth/components/ContentBlockedHandler.tsx
+++ b/fluxer_app/src/features/auth/components/ContentBlockedHandler.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {OKAY_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import * as ModalCommands from '@app/features/ui/commands/ModalCommands';
 import {modal} from '@app/features/ui/commands/ModalCommands';
 import {msg} from '@lingui/core/macro';
@@ -21,13 +20,9 @@ const YOUR_ACTION_COULD_NOT_BE_COMPLETED_BECAUSE_IT_DESCRIPTOR = msg({
 const ContentBlockedModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(CONTENT_BLOCKED_DESCRIPTOR)}
-			description={i18n._(YOUR_ACTION_COULD_NOT_BE_COMPLETED_BECAUSE_IT_DESCRIPTOR)}
-			primaryText={i18n._(OKAY_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(YOUR_ACTION_COULD_NOT_BE_COMPLETED_BECAUSE_IT_DESCRIPTOR)}
 			data-flx="auth.content-blocked-handler.content-blocked-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/expressions/utils/AnimatedAvifModalUtils.tsx
+++ b/fluxer_app/src/features/expressions/utils/AnimatedAvifModalUtils.tsx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {AVIF_FORMAT_LABEL} from '@app/features/app/config/I18nDisplayConstants';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import * as ModalCommands from '@app/features/ui/commands/ModalCommands';
 import {modal} from '@app/features/ui/commands/ModalCommands';
 import type {I18n} from '@lingui/core';
@@ -21,16 +20,13 @@ interface ShowAnimatedAvifUnsupportedModalOptions {
 export function showAnimatedAvifUnsupportedModal({i18n}: ShowAnimatedAvifUnsupportedModalOptions): void {
 	ModalCommands.push(
 		modal(() => (
-			<ConfirmModal
+			<GenericErrorModal
 				title={i18n._(ANIMATED_NOT_SUPPORTED_DESCRIPTOR, {avifFormatLabel: AVIF_FORMAT_LABEL})}
-				description={
+				message={
 					<Trans>
 						Animated {AVIF_FORMAT_LABEL} files aren't supported. Upload a static {AVIF_FORMAT_LABEL} file instead.
 					</Trans>
 				}
-				primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-				primaryVariant="primary"
-				onPrimary={() => {}}
 				data-flx="expressions.animated-avif-modal-utils.show-animated-avif-unsupported-modal.confirm-modal"
 			/>
 		)),

--- a/fluxer_app/src/features/guild/components/alerts/GuildAtCapacityModal.tsx
+++ b/fluxer_app/src/features/guild/components/alerts/GuildAtCapacityModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -17,13 +16,9 @@ const THIS_COMMUNITY_HAS_REACHED_ITS_MAXIMUM_MEMBER_LIMIT_DESCRIPTOR = msg({
 export const GuildAtCapacityModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(COMMUNITY_AT_CAPACITY_DESCRIPTOR)}
-			description={i18n._(THIS_COMMUNITY_HAS_REACHED_ITS_MAXIMUM_MEMBER_LIMIT_DESCRIPTOR)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(THIS_COMMUNITY_HAS_REACHED_ITS_MAXIMUM_MEMBER_LIMIT_DESCRIPTOR)}
 			data-flx="guild.guild-at-capacity-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/guild/components/alerts/MaxGuildsModal.tsx
+++ b/fluxer_app/src/features/guild/components/alerts/MaxGuildsModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import type {User} from '@app/features/user/models/User';
 import {msg, plural} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
@@ -20,9 +19,9 @@ export const MaxGuildsModal = observer(({user}: MaxGuildsModalProps) => {
 	const {i18n} = useLingui();
 	const maxGuilds = user.maxGuilds;
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(TOO_MANY_COMMUNITIES_DESCRIPTOR)}
-			description={plural(
+			message={plural(
 				{count: maxGuilds},
 				{
 					one: "You've reached the maximum number of communities you can join (# community). Leave a community before joining another one.",
@@ -30,10 +29,6 @@ export const MaxGuildsModal = observer(({user}: MaxGuildsModalProps) => {
 						"You've reached the maximum number of communities you can join (# communities). Leave a community before joining another one.",
 				},
 			)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
 			data-flx="guild.max-guilds-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/guild/components/alerts/NewAccountGuildLimitModal.tsx
+++ b/fluxer_app/src/features/guild/components/alerts/NewAccountGuildLimitModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {OKAY_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -17,13 +16,9 @@ const NEW_ACCOUNTS_ARE_LIMITED_TO_JOINING_10_COMMUNITIES_DESCRIPTOR = msg({
 export const NewAccountGuildLimitModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(SLOW_DOWN_DESCRIPTOR)}
-			description={i18n._(NEW_ACCOUNTS_ARE_LIMITED_TO_JOINING_10_COMMUNITIES_DESCRIPTOR)}
-			primaryText={i18n._(OKAY_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(NEW_ACCOUNTS_ARE_LIMITED_TO_JOINING_10_COMMUNITIES_DESCRIPTOR)}
 			data-flx="guild.new-account-guild-limit-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/guild/components/modals/guild_tabs/GuildEmojiTab.tsx
+++ b/fluxer_app/src/features/guild/components/modals/guild_tabs/GuildEmojiTab.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
 import {GlobalLimits} from '@app/features/app/utils/GlobalLimits';
 import {EmojiListHeader, EmojiListItem} from '@app/features/emoji/components/emojis/EmojiListItem';
@@ -18,7 +19,7 @@ import styles from '@app/features/guild/components/modals/guild_tabs/GuildEmojiT
 import {UploadDropZone} from '@app/features/guild/components/UploadDropZone';
 import {UploadSlotInfo} from '@app/features/guild/components/UploadSlotInfo';
 import Guilds from '@app/features/guild/state/Guilds';
-import {OKAY_DESCRIPTOR, UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {OKAY_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {openFilePicker} from '@app/features/messaging/utils/FilePickerUtils';
 import {formatFileSize} from '@app/features/messaging/utils/FileUtils';
 import Permission from '@app/features/permissions/state/Permission';
@@ -251,11 +252,9 @@ const GuildEmojiTab: React.FC<{guildId: string}> = observer(function GuildEmojiT
 			if (availableSlots <= 0) {
 				ModalCommands.push(
 					modal(() => (
-						<ConfirmModal
+						<GenericErrorModal
 							title={i18n._(NO_EMOJI_SLOTS_AVAILABLE_DESCRIPTOR)}
-							description={i18n._(EMOJI_SLOTS_FULL_DESCRIPTION_DESCRIPTOR)}
-							primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-							onPrimary={() => {}}
+							message={i18n._(EMOJI_SLOTS_FULL_DESCRIPTION_DESCRIPTOR)}
 							data-flx="guild.guild-tabs.guild-emoji-tab.handle-file-select.confirm-modal"
 						/>
 					)),

--- a/fluxer_app/src/features/guild/components/modals/guild_tabs/GuildStickersTab.tsx
+++ b/fluxer_app/src/features/guild/components/modals/guild_tabs/GuildStickersTab.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
 import {StatusSlate} from '@app/features/app/components/dialogs/shared/StatusSlate';
 import {GlobalLimits} from '@app/features/app/utils/GlobalLimits';
@@ -18,11 +19,7 @@ import styles from '@app/features/guild/components/modals/guild_tabs/GuildSticke
 import {UploadDropZone} from '@app/features/guild/components/UploadDropZone';
 import {UploadSlotInfo} from '@app/features/guild/components/UploadSlotInfo';
 import Guilds from '@app/features/guild/state/Guilds';
-import {
-	OKAY_DESCRIPTOR,
-	TRY_AGAIN_DESCRIPTOR,
-	UNDERSTOOD_DESCRIPTOR,
-} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {OKAY_DESCRIPTOR, TRY_AGAIN_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {openFilePicker} from '@app/features/messaging/utils/FilePickerUtils';
 import {formatFileSize} from '@app/features/messaging/utils/FileUtils';
 import Permission from '@app/features/permissions/state/Permission';
@@ -163,11 +160,9 @@ const GuildStickersTab: React.FC<{guildId: string}> = observer(function GuildSti
 	const showNoStickerSlotsModal = useCallback(() => {
 		ModalCommands.push(
 			modal(() => (
-				<ConfirmModal
+				<GenericErrorModal
 					title={i18n._(NO_STICKER_SLOTS_AVAILABLE_DESCRIPTOR)}
-					description={i18n._(STICKER_SLOTS_FULL_DESCRIPTION_DESCRIPTOR)}
-					primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-					onPrimary={() => {}}
+					message={i18n._(STICKER_SLOTS_FULL_DESCRIPTION_DESCRIPTOR)}
 					data-flx="guild.guild-tabs.guild-stickers-tab.no-sticker-slots-confirm-modal"
 				/>
 			)),

--- a/fluxer_app/src/features/invite/components/alerts/InvitesDisabledModal.tsx
+++ b/fluxer_app/src/features/invite/components/alerts/InvitesDisabledModal.tsx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {PRODUCT_NAME} from '@app/features/app/config/I18nDisplayConstants';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -27,17 +26,13 @@ interface InvitesDisabledModalProps {
 export const InvitesDisabledModal = observer(({isRaidDetected = false}: InvitesDisabledModalProps) => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(INVITES_PAUSED_DESCRIPTOR)}
-			description={
+			message={
 				isRaidDetected
 					? i18n._(DETECTED_A_POTENTIAL_RAID_IN_THIS_COMMUNITY_SO_DESCRIPTOR, {productName: PRODUCT_NAME})
 					: i18n._(COMMUNITY_ADMINS_HAVE_PAUSED_INVITES_SO_YOU_CAN_DESCRIPTOR)
 			}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
 			data-flx="invite.invites-disabled-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/messaging/components/alerts/AttachmentPermissionDeniedModal.tsx
+++ b/fluxer_app/src/features/messaging/components/alerts/AttachmentPermissionDeniedModal.tsx
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {
-	CANNOT_SEND_MESSAGES_IN_CHANNEL_DESCRIPTOR,
-	UNDERSTOOD_DESCRIPTOR,
-} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
+import {CANNOT_SEND_MESSAGES_IN_CHANNEL_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {msg} from '@lingui/core/macro';
 import {Trans, useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -46,13 +43,9 @@ export const AttachmentPermissionDeniedModal = observer(
 			i18n._(CANNOT_SEND_MESSAGES_IN_CHANNEL_DESCRIPTOR)
 		);
 		return (
-			<ConfirmModal
+			<GenericErrorModal
 				title={title}
-				description={description}
-				primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-				onPrimary={() => {}}
-				secondaryText={false}
-				hideCloseButton
+				message={description}
 				data-flx="messaging.attachment-permission-denied-modal.confirm-modal"
 			/>
 		);

--- a/fluxer_app/src/features/messaging/components/alerts/AttachmentUploadConnectivityModal.tsx
+++ b/fluxer_app/src/features/messaging/components/alerts/AttachmentUploadConnectivityModal.tsx
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {ExternalLink} from '@app/features/app/components/shared/ExternalLink';
 import {PRODUCT_NAME, SUPPORT_EMAIL, SUPPORT_EMAIL_MAILTO} from '@app/features/app/config/I18nDisplayConstants';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {MULTIPART_ATTACHMENT_FALLBACK_MAX_REQUEST_SIZE} from '@app/features/messaging/utils/AttachmentUploadFallbackUtils';
 import {formatFileSize} from '@app/features/messaging/utils/FileUtils';
 import {msg} from '@lingui/core/macro';
@@ -18,9 +17,9 @@ export const AttachmentUploadConnectivityModal = observer(() => {
 	const {i18n} = useLingui();
 	const fallbackSizeFormatted = formatFileSize(MULTIPART_ATTACHMENT_FALLBACK_MAX_REQUEST_SIZE);
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(ATTACHMENT_UPLOAD_UNAVAILABLE_DESCRIPTOR)}
-			description={
+			message={
 				<Trans>
 					We couldn't reach the attachment upload service. {PRODUCT_NAME} can fall back to the standard upload path for
 					messages up to {fallbackSizeFormatted} total, but these attachments exceed that combined limit and can't be
@@ -34,10 +33,6 @@ export const AttachmentUploadConnectivityModal = observer(() => {
 					if this keeps happening.
 				</Trans>
 			}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
 			data-flx="messaging.attachment-upload-connectivity-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/messaging/components/alerts/FileSizeTooLargeModal.tsx
+++ b/fluxer_app/src/features/messaging/components/alerts/FileSizeTooLargeModal.tsx
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
 import {PREMIUM_PRODUCT_NAME} from '@app/features/app/config/I18nDisplayConstants';
 import {Limits} from '@app/features/app/utils/UserLimits';
-import {
-	CANCEL_DESCRIPTOR,
-	GET_PREMIUM_DESCRIPTOR,
-	UNDERSTOOD_DESCRIPTOR,
-} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {CANCEL_DESCRIPTOR, GET_PREMIUM_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {formatFileSize} from '@app/features/messaging/utils/FileUtils';
 import * as PremiumModalCommands from '@app/features/premium/commands/PremiumModalCommands';
 import {shouldShowPremiumFeatures} from '@app/features/premium/utils/PremiumUtils';
@@ -76,13 +73,9 @@ export const FileSizeTooLargeModal = observer(({oversizedFileCount}: FileSizeToo
 		: i18n._(ONE_OR_MORE_FILES_YOU_RE_TRYING_TO_DESCRIPTOR, {maxSizeFormatted});
 	if (!showPremium || !canUpgradeAttachmentLimit) {
 		return (
-			<ConfirmModal
+			<GenericErrorModal
 				title={i18n._(FILE_SIZE_TOO_LARGE_DESCRIPTOR)}
-				description={!showPremium ? `${baseDescription} ${i18n._(INSTANCE_ADMIN_LIMIT_DESCRIPTOR)}` : baseDescription}
-				primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-				onPrimary={() => {}}
-				secondaryText={false}
-				hideCloseButton
+				message={!showPremium ? `${baseDescription} ${i18n._(INSTANCE_ADMIN_LIMIT_DESCRIPTOR)}` : baseDescription}
 				data-flx="messaging.file-size-too-large-modal.confirm-modal"
 			/>
 		);

--- a/fluxer_app/src/features/messaging/components/alerts/MessageDeleteTooQuickModal.tsx
+++ b/fluxer_app/src/features/messaging/components/alerts/MessageDeleteTooQuickModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {OKAY_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -17,13 +16,9 @@ const WAIT_A_MOMENT_BEFORE_DELETING_MORE_MESSAGES_DESCRIPTOR = msg({
 export const MessageDeleteTooQuickModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(YOU_RE_DELETING_MESSAGES_TOO_QUICKLY_DESCRIPTOR)}
-			description={i18n._(WAIT_A_MOMENT_BEFORE_DELETING_MORE_MESSAGES_DESCRIPTOR)}
-			primaryText={i18n._(OKAY_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(WAIT_A_MOMENT_BEFORE_DELETING_MORE_MESSAGES_DESCRIPTOR)}
 			data-flx="messaging.message-delete-too-quick-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/messaging/components/alerts/TooManyAttachmentsModal.tsx
+++ b/fluxer_app/src/features/messaging/components/alerts/TooManyAttachmentsModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import Users from '@app/features/user/state/Users';
 import {msg, plural} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
@@ -16,19 +15,15 @@ export const TooManyAttachmentsModal = observer(() => {
 	const currentUser = Users.currentUser;
 	const maxAttachments = currentUser?.maxAttachmentsPerMessage ?? 10;
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(WHOA_THIS_IS_HEAVY_DESCRIPTOR)}
-			description={plural(
+			message={plural(
 				{count: maxAttachments},
 				{
 					one: 'You can only upload # file at a time. Try again with fewer files.',
 					other: 'You can only upload # files at a time. Try again with fewer files.',
 				},
 			)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
 			data-flx="messaging.too-many-attachments-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/messaging/components/alerts/TooManyReactionsModal.tsx
+++ b/fluxer_app/src/features/messaging/components/alerts/TooManyReactionsModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -17,13 +16,9 @@ const THIS_IS_ONE_HEAVY_MESSAGE_SOME_REACTIONS_NEED_DESCRIPTOR = msg({
 export const TooManyReactionsModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(WHOA_THIS_IS_HEAVY_DESCRIPTOR)}
-			description={i18n._(THIS_IS_ONE_HEAVY_MESSAGE_SOME_REACTIONS_NEED_DESCRIPTOR)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(THIS_IS_ONE_HEAVY_MESSAGE_SOME_REACTIONS_NEED_DESCRIPTOR)}
 			data-flx="messaging.too-many-reactions-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/moderation/components/alerts/MatureContentRejectedModal.tsx
+++ b/fluxer_app/src/features/moderation/components/alerts/MatureContentRejectedModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -18,13 +17,9 @@ const THIS_CHANNEL_IS_NOT_MARKED_FOR_MATURE_CONTENT_DESCRIPTOR = msg({
 export const MatureContentRejectedModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(MATURE_CONTENT_NOT_ALLOWED_DESCRIPTOR)}
-			description={i18n._(THIS_CHANNEL_IS_NOT_MARKED_FOR_MATURE_CONTENT_DESCRIPTOR)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(THIS_CHANNEL_IS_NOT_MARKED_FOR_MATURE_CONTENT_DESCRIPTOR)}
 			data-flx="moderation.mature-content-rejected-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/moderation/components/alerts/UserBannedFromGuildModal.tsx
+++ b/fluxer_app/src/features/moderation/components/alerts/UserBannedFromGuildModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -17,13 +16,9 @@ const YOU_ARE_BANNED_FROM_THIS_COMMUNITY_AND_CANNOT_DESCRIPTOR = msg({
 export const UserBannedFromGuildModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(YOU_RE_BANNED_DESCRIPTOR)}
-			description={i18n._(YOU_ARE_BANNED_FROM_THIS_COMMUNITY_AND_CANNOT_DESCRIPTOR)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(YOU_ARE_BANNED_FROM_THIS_COMMUNITY_AND_CANNOT_DESCRIPTOR)}
 			data-flx="moderation.user-banned-from-guild-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/moderation/components/alerts/UserIpBannedFromGuildModal.tsx
+++ b/fluxer_app/src/features/moderation/components/alerts/UserIpBannedFromGuildModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -17,13 +16,9 @@ const YOUR_IP_ADDRESS_IS_BANNED_FROM_THIS_COMMUNITY_DESCRIPTOR = msg({
 export const UserIpBannedFromGuildModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(YOUR_IP_IS_BANNED_DESCRIPTOR)}
-			description={i18n._(YOUR_IP_ADDRESS_IS_BANNED_FROM_THIS_COMMUNITY_DESCRIPTOR)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(YOUR_IP_ADDRESS_IS_BANNED_FROM_THIS_COMMUNITY_DESCRIPTOR)}
 			data-flx="moderation.user-ip-banned-from-guild-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/permissions/system/components/MediaPermissionBlockedModal.tsx
+++ b/fluxer_app/src/features/permissions/system/components/MediaPermissionBlockedModal.tsx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {PRODUCT_NAME} from '@app/features/app/config/I18nDisplayConstants';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {isDesktop} from '@app/features/ui/utils/NativeUtils';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
@@ -74,13 +73,9 @@ export const MediaPermissionBlockedModal = observer(({kind}: {kind: MediaPermiss
 	const {i18n} = useLingui();
 	const desktop = isDesktop();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(titleDescriptorForKind(kind))}
-			description={i18n._(bodyDescriptorForKind(kind, desktop), {productName: PRODUCT_NAME})}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(bodyDescriptorForKind(kind, desktop), {productName: PRODUCT_NAME})}
 			data-flx="permissions.media-permission-blocked-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/slowmode/components/alerts/SlowmodeRateLimitedModal.tsx
+++ b/fluxer_app/src/features/slowmode/components/alerts/SlowmodeRateLimitedModal.tsx
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {
 	MINUTES_AND_SECONDS_DURATION_DESCRIPTOR,
 	MINUTES_DURATION_PLURAL_DESCRIPTOR,
-	OKAY_DESCRIPTOR,
 	SECONDS_DURATION_PLURAL_DESCRIPTOR,
 } from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {msg} from '@lingui/core/macro';
@@ -39,13 +38,9 @@ export const SlowmodeRateLimitedModal = observer(({retryAfter}: SlowmodeRateLimi
 		return i18n._(MINUTES_AND_SECONDS_DURATION_DESCRIPTOR, {minutes, seconds: remainingSeconds});
 	};
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(SLOWMODE_ACTIVE_DESCRIPTOR)}
-			description={i18n._(SLOWMODE_WAIT_DURATION_DESCRIPTOR, {duration: formatTime(retryAfter)})}
-			primaryText={i18n._(OKAY_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(SLOWMODE_WAIT_DURATION_DESCRIPTOR, {duration: formatTime(retryAfter)})}
 			data-flx="slowmode.slowmode-rate-limited-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/user/components/modals/tabs/my_profile_tab/AvatarUploader.tsx
+++ b/fluxer_app/src/features/user/components/modals/tabs/my_profile_tab/AvatarUploader.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
 import {
 	ANIMATED_AVATAR_FORMATS,
@@ -33,7 +34,6 @@ import {
 	FAILED_TO_PROCESS_CROPPED_IMAGE_DESCRIPTOR,
 	GET_PREMIUM_DESCRIPTOR,
 	INVALID_IMAGE_TRY_ANOTHER_DESCRIPTOR,
-	UNDERSTOOD_DESCRIPTOR,
 } from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {openFilePicker} from '@app/features/messaging/utils/FilePickerUtils';
 import * as PremiumModalCommands from '@app/features/premium/commands/PremiumModalCommands';
@@ -233,16 +233,14 @@ export const AvatarUploader = observer(
 					} else {
 						ModalCommands.push(
 							modal(() => (
-								<ConfirmModal
+								<GenericErrorModal
 									title={i18n._(ANIMATED_AVATARS_NOT_AVAILABLE_DESCRIPTOR)}
-									description={
+									message={
 										<Trans>
 											Animated avatars ({ANIMATED_AVATAR_FORMATS}) are not available on this instance. Upload a static
 											image instead.
 										</Trans>
 									}
-									primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-									onPrimary={() => {}}
 									data-flx="user.my-profile-tab.avatar-uploader.handle-avatar-upload.confirm-modal--2"
 								/>
 							)),

--- a/fluxer_app/src/features/voice/components/alerts/ScreenShareFailedModal.tsx
+++ b/fluxer_app/src/features/voice/components/alerts/ScreenShareFailedModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -19,13 +18,9 @@ const SCREEN_SHARING_FAILED_BODY_DESCRIPTOR = msg({
 export const ScreenShareFailedModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(SCREEN_SHARING_FAILED_DESCRIPTOR)}
-			description={i18n._(SCREEN_SHARING_FAILED_BODY_DESCRIPTOR)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(SCREEN_SHARING_FAILED_BODY_DESCRIPTOR)}
 			data-flx="voice.screen-share-failed-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/voice/components/alerts/ScreenShareUnsupportedModal.tsx
+++ b/fluxer_app/src/features/voice/components/alerts/ScreenShareUnsupportedModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -26,17 +25,13 @@ export const ScreenShareUnsupportedModal = observer(
 	({variant = 'unsupported'}: {variant?: 'unsupported' | 'portal-empty'}) => {
 		const {i18n} = useLingui();
 		return (
-			<ConfirmModal
+			<GenericErrorModal
 				title={i18n._(SCREEN_SHARING_NOT_SUPPORTED_DESCRIPTOR)}
-				description={i18n._(
+				message={i18n._(
 					variant === 'portal-empty'
 						? SCREEN_SHARING_PORTAL_EMPTY_DESCRIPTOR
 						: SCREEN_SHARING_IS_NOT_SUPPORTED_ON_THIS_DEVICE_DESCRIPTOR,
 				)}
-				primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-				onPrimary={() => {}}
-				secondaryText={false}
-				hideCloseButton
 				data-flx="voice.screen-share-unsupported-modal.confirm-modal"
 			/>
 		);

--- a/fluxer_app/src/features/voice/components/alerts/TtsUnsupportedModal.tsx
+++ b/fluxer_app/src/features/voice/components/alerts/TtsUnsupportedModal.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {msg} from '@lingui/core/macro';
 import {useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
@@ -19,13 +18,9 @@ const TEXT_TO_SPEECH_IS_NOT_SUPPORTED_BY_YOUR_DESCRIPTOR = msg({
 export const TtsUnsupportedModal = observer(() => {
 	const {i18n} = useLingui();
 	return (
-		<ConfirmModal
+		<GenericErrorModal
 			title={i18n._(TEXT_TO_SPEECH_NOT_SUPPORTED_DESCRIPTOR)}
-			description={i18n._(TEXT_TO_SPEECH_IS_NOT_SUPPORTED_BY_YOUR_DESCRIPTOR)}
-			primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-			onPrimary={() => {}}
-			secondaryText={false}
-			hideCloseButton
+			message={i18n._(TEXT_TO_SPEECH_IS_NOT_SUPPORTED_BY_YOUR_DESCRIPTOR)}
 			data-flx="voice.tts-unsupported-modal.confirm-modal"
 		/>
 	);

--- a/fluxer_app/src/features/voice/engine/v2/VoiceEngineV2AppScreenShareExecutionAdapter.tsx
+++ b/fluxer_app/src/features/voice/engine/v2/VoiceEngineV2AppScreenShareExecutionAdapter.tsx
@@ -2,6 +2,7 @@
 
 import assert from 'node:assert/strict';
 import i18n from '@app/app/I18n';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 import {SoundType} from '@app/features/notification/utils/SoundUtils';
 import * as ModalCommands from '@app/features/ui/commands/ModalCommands';
 import * as SoundCommands from '@app/features/ui/commands/SoundCommands';
@@ -100,7 +101,6 @@ import {
 	type TrackPublishOptions,
 	type VideoCodec,
 } from 'livekit-client';
-import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 
 export type {NativeScreenShareReconnectSnapshot} from '@app/features/voice/engine/v2/VoiceEngineV2AppScreenShareReconnect';
 export type {DeviceScreenShareCaptureOptions} from '@app/features/voice/engine/voice_screen_share_manager/shared';

--- a/fluxer_app/src/features/voice/engine/v2/VoiceEngineV2AppScreenShareExecutionAdapter.tsx
+++ b/fluxer_app/src/features/voice/engine/v2/VoiceEngineV2AppScreenShareExecutionAdapter.tsx
@@ -2,8 +2,6 @@
 
 import assert from 'node:assert/strict';
 import i18n from '@app/app/I18n';
-import {ConfirmModal} from '@app/features/app/components/dialogs/ConfirmModal';
-import {UNDERSTOOD_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import {SoundType} from '@app/features/notification/utils/SoundUtils';
 import * as ModalCommands from '@app/features/ui/commands/ModalCommands';
 import * as SoundCommands from '@app/features/ui/commands/SoundCommands';
@@ -102,6 +100,7 @@ import {
 	type TrackPublishOptions,
 	type VideoCodec,
 } from 'livekit-client';
+import {GenericErrorModal} from '@app/features/app/components/alerts/GenericErrorModal';
 
 export type {NativeScreenShareReconnectSnapshot} from '@app/features/voice/engine/v2/VoiceEngineV2AppScreenShareReconnect';
 export type {DeviceScreenShareCaptureOptions} from '@app/features/voice/engine/voice_screen_share_manager/shared';
@@ -524,12 +523,9 @@ class VoiceEngineV2AppScreenShareExecutionAdapter extends Store {
 	showScreenShareEndedModalInternal(description: string): void {
 		ModalCommands.pushWithKey(
 			ModalCommands.modal(() => (
-				<ConfirmModal
+				<GenericErrorModal
 					title={i18n._(SCREEN_SHARE_ENDED_DESCRIPTOR)}
-					description={description}
-					primaryText={i18n._(UNDERSTOOD_DESCRIPTOR)}
-					onPrimary={() => {}}
-					secondaryText={false}
+					message={description}
 					data-flx="voice.screen-share-manager.screen-share-ended-modal"
 				/>
 			)),


### PR DESCRIPTION
## Summary

- What changed: Multiple modals (error modals) use `GenericErrorModal` instead of `ConfirmModal` now. Some of those modals literally reimplemented `GenericErrorModal` while some didn't literally reimplement it and instead had both a "Cancel" and a "Confirm" button (and an X at the top). This change also makes it so that the "Cancel" button and the "X" in the top right are removed (because all of those buttons do the exact same thing, so it is confusing).
- Why it is correct: This keeps the UI exactly the same or even improves it in some cases. It's a rather trivial change to make, too.
- Risk: I may have made a typo or incorrectly identified one modal as reimplementing `GenericErrorModal` when it didn't, or accidentally removed `data-flx` from some modal. This is unlikely though.

## Verification

- Tests run: yes
- Manual checks: I have tested a select few modals, but not all. Some I didn't test because they are difficult to reach (for example the "feature temporarily disabled" modal), and most others because the changes are trivial.
- Screenshots or recordings:

An example of a modal that stayed exactly the same:
<img width="465" height="221" alt="Screenshot_20260616_171141" src="https://github.com/user-attachments/assets/d7640667-af61-4f57-889e-cac05a3c38d6" />

An example of a modal where the UI/UX was improved by removing the "Cancel" and "X" buttons:
<img width="465" height="221" alt="Screenshot_20260616_172245" src="https://github.com/user-attachments/assets/cbac6a63-2675-4bcd-90e8-9a856d69609a" />
(before ^)
<img width="467" height="221" alt="Screenshot_20260616_172353" src="https://github.com/user-attachments/assets/aade0198-dcf2-49e0-96f8-01b54bb1a351" />
(after ^)

## Checklist

- [X] I understand every change in this PR.
- [X] I can explain what it does and why it is correct.
- [X] I disclosed any LLM coding help below.

## LLM Disclosure

- None
