### PR TITLE
fix(docs): add missing network config to cloudflared compose override

### DIFF
--- a/fluxer_docs/docs/operator/get-started.md
+++ b/fluxer_docs/docs/operator/get-started.md
@@ -157,6 +157,13 @@ Keep these defaults unless you know you need to change them:
         command: tunnel run --token ${CLOUDFLARED_TOKEN:?set CLOUDFLARED_TOKEN}
         depends_on:
           - caddy
+				networks:
+					- fluxer
+					
+		networks:
+			fluxer:
+				external: true
+				name: fluxer_fluxer
     YAML
 
     export CLOUDFLARED_TOKEN='paste-your-tunnel-token-here'

--- a/fluxer_docs/docs/operator/get-started.md
+++ b/fluxer_docs/docs/operator/get-started.md
@@ -157,13 +157,13 @@ Keep these defaults unless you know you need to change them:
         command: tunnel run --token ${CLOUDFLARED_TOKEN:?set CLOUDFLARED_TOKEN}
         depends_on:
           - caddy
-				networks:
-					- fluxer
-					
-		networks:
-			fluxer:
-				external: true
-				name: fluxer_fluxer
+        networks:
+          - fluxer
+
+    networks:
+      fluxer:
+        external: true
+        name: fluxer_fluxer
     YAML
 
     export CLOUDFLARED_TOKEN='paste-your-tunnel-token-here'

--- a/fluxer_docs/docs/operator/get-started.md
+++ b/fluxer_docs/docs/operator/get-started.md
@@ -159,11 +159,6 @@ Keep these defaults unless you know you need to change them:
           - caddy
         networks:
           - fluxer
-
-    networks:
-      fluxer:
-        external: true
-        name: fluxer_fluxer
     YAML
 
     export CLOUDFLARED_TOKEN='paste-your-tunnel-token-here'


### PR DESCRIPTION
## Summary

- What changed: I've added a network config for the Cloudflared compose override snippet, will fix  #1045. 
- Why it is correct: Without specifying a network for Cloudflared to use, it defaults to `fluxer_default` and cannot reach Caddy. A 502 error is shown when you try to reach your self-hosted instance. Someone in Developers also confirmed they had to make this fix.
- Risk: I've tested this and confirmed it works. I suppose a risk is that it hasn't been tested thoroughly by others.

## Verification

- Tests run: 
- Manual checks:
- Screenshots or recordings:

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- AI was used to troubleshoot the initial problem but was not used for the fix.
