### PR TITLE
fix(api): Disallow banning nonexistent users

### DIFF
--- a/fluxer_api/src/api/guild/services/GuildModerationService.ts
+++ b/fluxer_api/src/api/guild/services/GuildModerationService.ts
@@ -76,7 +76,6 @@ export class GuildModerationService {
 			});
 		}
 		const targetUser = await this.userRepository.findUnique(targetId);
-		// Don't allow banning nonexistent users
 		if (!targetUser) {
 			throw new UnknownUserError();
 		}

--- a/fluxer_api/src/api/guild/services/GuildModerationService.ts
+++ b/fluxer_api/src/api/guild/services/GuildModerationService.ts
@@ -8,6 +8,7 @@ import {MissingPermissionsError} from '@fluxer/errors/src/domains/core/MissingPe
 import {BannedFromGuildError} from '@fluxer/errors/src/domains/guild/BannedFromGuildError';
 import {IpBannedFromGuildError} from '@fluxer/errors/src/domains/guild/IpBannedFromGuildError';
 import {UnknownGuildMemberError} from '@fluxer/errors/src/domains/guild/UnknownGuildMemberError';
+import {UnknownUserError} from '@fluxer/errors/src/domains/user/UnknownUserError';
 import {isSameIpDecisionMatch} from '@fluxer/ip_utils/src/IpAddress';
 import type {GuildBanResponse} from '@fluxer/schema/src/domains/guild/GuildMemberSchemas';
 import type {IpInfoService} from '@pkgs/geoip/src/IpInfoService';
@@ -26,7 +27,6 @@ import type {GuildAuditLogChange} from '../GuildAuditLogTypes';
 import {mapGuildBansToResponse} from '../GuildModel';
 import type {IGuildRepositoryAggregate} from '../repositories/IGuildRepositoryAggregate';
 import {GuildMemberSearchIndexService} from './member/GuildMemberSearchIndexService';
-import {UnknownUserError} from '@fluxer/errors/src/domains/user/UnknownUserError';
 
 export class GuildModerationService {
 	private readonly searchIndexService: GuildMemberSearchIndexService;
@@ -56,10 +56,6 @@ export class GuildModerationService {
 		auditLogReason?: string | null,
 	): Promise<void> {
 		const {userId, guildId, targetId, deleteMessageDays, reason, banDurationSeconds, skipGuildAuditLog} = params;
-		const targetUser = await this.userRepository.findUnique(targetId);
-		if (!targetUser) {
-			throw new UnknownUserError();
-		}
 		const hasPermission = await this.gatewayService.checkPermission({
 			guildId,
 			userId,
@@ -67,6 +63,10 @@ export class GuildModerationService {
 		});
 		if (!hasPermission) throw new MissingPermissionsError();
 		if (userId === targetId) throw new UnknownGuildMemberError();
+		const targetUser = await this.userRepository.findUnique(targetId);
+		if (!targetUser) {
+			throw new UnknownUserError();
+		}
 		const targetMember = await this.guildRepository.getMember(guildId, targetId);
 		if (targetMember) {
 			const canManage = await this.gatewayService.checkTargetMember({guildId, userId, targetUserId: targetId});

--- a/fluxer_api/src/api/guild/services/GuildModerationService.ts
+++ b/fluxer_api/src/api/guild/services/GuildModerationService.ts
@@ -56,6 +56,10 @@ export class GuildModerationService {
 		auditLogReason?: string | null,
 	): Promise<void> {
 		const {userId, guildId, targetId, deleteMessageDays, reason, banDurationSeconds, skipGuildAuditLog} = params;
+		const targetUser = await this.userRepository.findUnique(targetId);
+		if (!targetUser) {
+			throw new UnknownUserError();
+		}
 		const hasPermission = await this.gatewayService.checkPermission({
 			guildId,
 			userId,
@@ -74,10 +78,6 @@ export class GuildModerationService {
 				userId: targetId.toString(),
 				days: deleteMessageDays,
 			});
-		}
-		const targetUser = await this.userRepository.findUnique(targetId);
-		if (!targetUser) {
-			throw new UnknownUserError();
 		}
 		const targetIp = targetUser.lastActiveIp || null;
 		const targetEmail = targetUser.email?.toLowerCase() || null;

--- a/fluxer_api/src/api/guild/services/GuildModerationService.ts
+++ b/fluxer_api/src/api/guild/services/GuildModerationService.ts
@@ -26,6 +26,7 @@ import type {GuildAuditLogChange} from '../GuildAuditLogTypes';
 import {mapGuildBansToResponse} from '../GuildModel';
 import type {IGuildRepositoryAggregate} from '../repositories/IGuildRepositoryAggregate';
 import {GuildMemberSearchIndexService} from './member/GuildMemberSearchIndexService';
+import {UnknownUserError} from '@fluxer/errors/src/domains/user/UnknownUserError';
 
 export class GuildModerationService {
 	private readonly searchIndexService: GuildMemberSearchIndexService;
@@ -75,8 +76,12 @@ export class GuildModerationService {
 			});
 		}
 		const targetUser = await this.userRepository.findUnique(targetId);
-		const targetIp = targetUser?.lastActiveIp || null;
-		const targetEmail = targetUser?.email?.toLowerCase() || null;
+		// Don't allow banning nonexistent users
+		if (!targetUser) {
+			throw new UnknownUserError();
+		}
+		const targetIp = targetUser.lastActiveIp || null;
+		const targetEmail = targetUser.email?.toLowerCase() || null;
 		let expiresAt: Date | null = null;
 		if (banDurationSeconds && banDurationSeconds > 0) {
 			expiresAt = new Date(Date.now() + banDurationSeconds * 1000);

--- a/fluxer_api/src/api/guild/tests/GuildMemberManagement.test.ts
+++ b/fluxer_api/src/api/guild/tests/GuildMemberManagement.test.ts
@@ -186,6 +186,24 @@ describe('Guild Member Management', () => {
 			.expect(HTTP_STATUS.NO_CONTENT)
 			.execute();
 	});
+	test('should ban non-member from guild', async () => {
+		const {owner, guild} = await setupTestGuildWithMembers(harness, 1);
+		const nonMember = await createTestAccount(harness);
+		await createBuilder(harness, owner.token)
+			.put(`/guilds/${guild.id}/bans/${nonMember.userId}`)
+			.body({})
+			.expect(HTTP_STATUS.NO_CONTENT)
+			.execute();
+	});
+	test('should disallow banning nonexistent user from guild', async () => {
+		const {owner, guild} = await setupTestGuildWithMembers(harness, 1);
+		const nonExistentId = '1234567890123456789';
+		await createBuilder(harness, owner.token)
+			.put(`/guilds/${guild.id}/bans/${nonExistentId}`)
+			.body({})
+			.expect(HTTP_STATUS.NO_CONTENT)
+			.execute();
+	});
 	test('should fall back to audit log reason header when ban reason is omitted', async () => {
 		const {owner, members, guild} = await setupTestGuildWithMembers(harness, 1);
 		const member = members[0];

--- a/fluxer_api/src/api/guild/tests/GuildMemberManagement.test.ts
+++ b/fluxer_api/src/api/guild/tests/GuildMemberManagement.test.ts
@@ -201,7 +201,7 @@ describe('Guild Member Management', () => {
 		await createBuilder(harness, owner.token)
 			.put(`/guilds/${guild.id}/bans/${nonExistentId}`)
 			.body({})
-			.expect(HTTP_STATUS.NO_CONTENT)
+			.expect(HTTP_STATUS.NOT_FOUND)
 			.execute();
 	});
 	test('should fall back to audit log reason header when ban reason is omitted', async () => {


### PR DESCRIPTION
## Summary

- What changed: `GuildModerationService::banMember` will now throw a `UnknownUserError` if the user doesn't exist. The affected API endpoints are `PUT /guilds/:guild_id/bans/:user_id` and `POST /admin/guilds/ban-member`.
- Why it is correct: This closes #1056 . Banning a nonexistent user does nothing.
- Risk: /

## Verification

- Tests run:
- Manual checks: I tested that this works (see below).
- Screenshots or recordings:

This will be shown now when using `/ban` with a mention that contains a nonexistent user ID:
<img width="455" height="94" alt="image" src="https://github.com/user-attachments/assets/97399034-bac7-4cff-ad92-14e39c1f1742" />

## Checklist

- [X] I understand every change in this PR.
- [X] I can explain what it does and why it is correct.
- [X] I disclosed any LLM coding help below.

## LLM Disclosure

- None