### PR TITLE
feat(api): export scheduled messages as calendars

### DIFF
--- a/fluxer_api/src/api/channel/tests/ScheduledMessageTestUtils.ts
+++ b/fluxer_api/src/api/channel/tests/ScheduledMessageTestUtils.ts
@@ -85,6 +85,20 @@ export async function getScheduledMessages(
 	return json;
 }
 
+export async function exportScheduledMessagesCalendar(
+	harness: ApiTestHarness,
+	token: string,
+): Promise<{
+	response: Response;
+	text: string;
+}> {
+	const {response, text} = await createBuilder(harness, token)
+		.get('/users/@me/scheduled-messages/calendar.ics')
+		.expect(200)
+		.executeRaw();
+	return {response, text};
+}
+
 export async function getScheduledMessage(
 	harness: ApiTestHarness,
 	scheduledMessageId: string,
@@ -99,6 +113,22 @@ export async function getScheduledMessage(
 		return null;
 	}
 	return json as ScheduledMessageResponse;
+}
+
+export async function exportScheduledMessageCalendar(
+	harness: ApiTestHarness,
+	scheduledMessageId: string,
+	token: string,
+	expectedStatus: 200 | 404 = 200,
+): Promise<{
+	response: Response;
+	text: string;
+}> {
+	const {response, text} = await createBuilder(harness, token)
+		.get(`/users/@me/scheduled-messages/${scheduledMessageId}/calendar.ics`)
+		.expect(expectedStatus)
+		.executeRaw();
+	return {response, text};
 }
 
 export async function cancelScheduledMessage(

--- a/fluxer_api/src/api/channel/tests/ScheduledMessagesListLifecycle.test.ts
+++ b/fluxer_api/src/api/channel/tests/ScheduledMessagesListLifecycle.test.ts
@@ -7,6 +7,8 @@ import {type ApiTestHarness, createApiTestHarness} from '../../test/ApiTestHarne
 import {
 	cancelScheduledMessage,
 	createGuildChannel,
+	exportScheduledMessageCalendar,
+	exportScheduledMessagesCalendar,
 	getScheduledMessages,
 	grantStaffAccess,
 	scheduleMessage,
@@ -34,5 +36,43 @@ describe('Scheduled messages list lifecycle', () => {
 		const listAfterCancel = await getScheduledMessages(harness, owner.token);
 		const foundAfterCancel = listAfterCancel.some((entry) => entry.id === scheduled.id);
 		expect(foundAfterCancel).toBe(false);
+	});
+	it('exports scheduled messages as iCalendar', async () => {
+		const owner = await createTestAccount(harness);
+		const guild = await createGuild(harness, owner.token, 'scheduled-calendar');
+		await grantStaffAccess(harness, owner.userId);
+		const channel = await createGuildChannel(harness, owner.token, guild.id, 'scheduled-calendar');
+		const scheduled = await scheduleMessage(
+			harness,
+			channel.id,
+			owner.token,
+			'calendar, export\nline two',
+			new Date('2030-01-02T03:04:05.000Z'),
+		);
+
+		const {response, text} = await exportScheduledMessagesCalendar(harness, owner.token);
+
+		expect(response.headers.get('content-type')).toContain('text/calendar');
+		expect(response.headers.get('content-disposition')).toContain('fluxer-scheduled-messages.ics');
+		expect(text).toContain('BEGIN:VCALENDAR');
+		expect(text).toContain(`UID:fluxer-scheduled-message-${scheduled.id}@fluxer.app`);
+		expect(text).toContain('DTSTART:20300102T030405Z');
+		expect(text).toContain('SUMMARY:calendar\\, export\\nline two');
+	});
+	it('exports a single scheduled message as iCalendar', async () => {
+		const owner = await createTestAccount(harness);
+		const guild = await createGuild(harness, owner.token, 'scheduled-single-calendar');
+		await grantStaffAccess(harness, owner.userId);
+		const channel = await createGuildChannel(harness, owner.token, guild.id, 'scheduled-single-calendar');
+		const first = await scheduleMessage(harness, channel.id, owner.token, 'first exported message');
+		const second = await scheduleMessage(harness, channel.id, owner.token, 'second message');
+
+		const {response, text} = await exportScheduledMessageCalendar(harness, first.id, owner.token);
+
+		expect(response.headers.get('content-type')).toContain('text/calendar');
+		expect(response.headers.get('content-disposition')).toContain(`fluxer-scheduled-message-${first.id}.ics`);
+		expect(text).toContain(`UID:fluxer-scheduled-message-${first.id}@fluxer.app`);
+		expect(text).toContain('SUMMARY:first exported message');
+		expect(text).not.toContain(`UID:fluxer-scheduled-message-${second.id}@fluxer.app`);
 	});
 });

--- a/fluxer_api/src/api/user/UserCalendarExport.ts
+++ b/fluxer_api/src/api/user/UserCalendarExport.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {ScheduledMessage} from '../models/ScheduledMessage';
+
+const CRLF = '\r\n';
+const DEFAULT_EVENT_DURATION_MS = 30 * 60 * 1000;
+
+function formatIcsDate(date: Date): string {
+	return date
+		.toISOString()
+		.replace(/[-:]/g, '')
+		.replace(/\.\d{3}Z$/, 'Z');
+}
+
+function escapeIcsText(value: string): string {
+	return value
+		.replace(/\\/g, '\\\\')
+		.replace(/\r\n|\r|\n/g, '\\n')
+		.replace(/;/g, '\\;')
+		.replace(/,/g, '\\,');
+}
+
+function scheduledMessageSummary(message: ScheduledMessage): string {
+	const content = message.payload.content?.trim();
+	if (!content) return 'Scheduled Fluxer message';
+	return content.length > 80 ? `${content.slice(0, 77)}...` : content;
+}
+
+function scheduledMessageDescription(message: ScheduledMessage): string {
+	const parts = [`Channel: ${message.channelId.toString()}`, `Status: ${message.status}`];
+	if (message.payload.content?.trim()) {
+		parts.push(`Content: ${message.payload.content.trim()}`);
+	}
+	return parts.join('\n');
+}
+
+function buildEvent(message: ScheduledMessage): Array<string> {
+	const startsAt = message.scheduledAt;
+	const endsAt = new Date(startsAt.getTime() + DEFAULT_EVENT_DURATION_MS);
+	return [
+		'BEGIN:VEVENT',
+		`UID:fluxer-scheduled-message-${message.id.toString()}@fluxer.app`,
+		`DTSTAMP:${formatIcsDate(message.createdAt)}`,
+		`DTSTART:${formatIcsDate(startsAt)}`,
+		`DTEND:${formatIcsDate(endsAt)}`,
+		`SUMMARY:${escapeIcsText(scheduledMessageSummary(message))}`,
+		`DESCRIPTION:${escapeIcsText(scheduledMessageDescription(message))}`,
+		'END:VEVENT',
+	];
+}
+
+export function buildScheduledMessagesCalendar(messages: Array<ScheduledMessage>): string {
+	const lines = [
+		'BEGIN:VCALENDAR',
+		'VERSION:2.0',
+		'PRODID:-//Fluxer//Scheduled Messages//EN',
+		'CALSCALE:GREGORIAN',
+		'METHOD:PUBLISH',
+		'X-WR-CALNAME:Fluxer Scheduled Messages',
+		...messages.flatMap((message) => buildEvent(message)),
+		'END:VCALENDAR',
+	];
+	return `${lines.join(CRLF)}${CRLF}`;
+}

--- a/fluxer_api/src/api/user/controllers/UserScheduledMessageController.ts
+++ b/fluxer_api/src/api/user/controllers/UserScheduledMessageController.ts
@@ -16,6 +16,13 @@ import {OpenAPI} from '../../middleware/ResponseTypeMiddleware';
 import {RateLimitConfigs} from '../../RateLimitConfig';
 import type {HonoApp, HonoEnv} from '../../types/HonoEnv';
 import {Validator} from '../../Validator';
+import {buildScheduledMessagesCalendar} from '../UserCalendarExport';
+
+function sendCalendar(ctx: Context<HonoEnv>, body: string, filename: string) {
+	ctx.header('Content-Type', 'text/calendar; charset=utf-8');
+	ctx.header('Content-Disposition', `attachment; filename="${filename}"`);
+	return ctx.body(body, 200);
+}
 
 export function UserScheduledMessageController(app: HonoApp) {
 	app.get(
@@ -44,6 +51,28 @@ export function UserScheduledMessageController(app: HonoApp) {
 		},
 	);
 	app.get(
+		'/users/@me/scheduled-messages/calendar.ics',
+		RateLimitMiddleware(RateLimitConfigs.USER_SAVED_MESSAGES_READ),
+		LoginRequired,
+		DefaultUserOnly,
+		OpenAPI({
+			operationId: 'export_scheduled_messages_calendar',
+			summary: 'Export scheduled messages as iCalendar',
+			responseSchema: null,
+			statusCode: 200,
+			security: ['bearerToken', 'sessionToken'],
+			tags: ['Users'],
+			description:
+				'Exports scheduled messages for the current user as an iCalendar file that can be imported into external calendar providers.',
+		}),
+		async (ctx: Context<HonoEnv>) => {
+			const userId = ctx.get('user').id;
+			const scheduledMessageService = ctx.get('scheduledMessageService');
+			const scheduledMessages = await scheduledMessageService.listScheduledMessages(userId);
+			return sendCalendar(ctx, buildScheduledMessagesCalendar(scheduledMessages), 'fluxer-scheduled-messages.ics');
+		},
+	);
+	app.get(
 		'/users/@me/scheduled-messages/:scheduled_message_id',
 		RateLimitMiddleware(RateLimitConfigs.USER_SAVED_MESSAGES_READ),
 		LoginRequired,
@@ -68,6 +97,37 @@ export function UserScheduledMessageController(app: HonoApp) {
 				throw new UnknownMessageError();
 			}
 			return ctx.json(scheduledMessage.toResponse(), 200);
+		},
+	);
+	app.get(
+		'/users/@me/scheduled-messages/:scheduled_message_id/calendar.ics',
+		RateLimitMiddleware(RateLimitConfigs.USER_SAVED_MESSAGES_READ),
+		LoginRequired,
+		DefaultUserOnly,
+		Validator('param', ScheduledMessageIdParam),
+		OpenAPI({
+			operationId: 'export_scheduled_message_calendar',
+			summary: 'Export a scheduled message as iCalendar',
+			responseSchema: null,
+			statusCode: 200,
+			security: ['bearerToken', 'sessionToken'],
+			tags: ['Users'],
+			description:
+				'Exports one scheduled message for the current user as an iCalendar file that can be imported into external calendar providers.',
+		}),
+		async (ctx) => {
+			const userId = ctx.get('user').id;
+			const scheduledMessageId = createMessageID(ctx.req.valid('param').scheduled_message_id);
+			const scheduledMessageService = ctx.get('scheduledMessageService');
+			const scheduledMessage = await scheduledMessageService.getScheduledMessage(userId, scheduledMessageId);
+			if (!scheduledMessage) {
+				throw new UnknownMessageError();
+			}
+			return sendCalendar(
+				ctx,
+				buildScheduledMessagesCalendar([scheduledMessage]),
+				`fluxer-scheduled-message-${scheduledMessage.id.toString()}.ics`,
+			);
 		},
 	);
 	app.delete(

--- a/fluxer_api/src/api/user/tests/UserCalendarExport.test.ts
+++ b/fluxer_api/src/api/user/tests/UserCalendarExport.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {describe, expect, it} from 'vitest';
+import {createChannelID, createMessageID, createUserID} from '../../BrandedTypes';
+import {ScheduledMessage} from '../../models/ScheduledMessage';
+import {buildScheduledMessagesCalendar} from '../UserCalendarExport';
+
+describe('UserCalendarExport', () => {
+	it('builds an iCalendar file from scheduled messages', () => {
+		const calendar = buildScheduledMessagesCalendar([
+			new ScheduledMessage({
+				userId: createUserID(1n),
+				id: createMessageID(2n),
+				channelId: createChannelID(3n),
+				scheduledAt: new Date('2030-01-02T03:04:05.000Z'),
+				scheduledLocalAt: '2030-01-02T03:04:05',
+				timezone: 'UTC',
+				payload: {
+					content: 'calendar, export\nline two',
+				},
+				createdAt: new Date('2029-12-31T00:00:00.000Z'),
+			}),
+		]);
+
+		expect(calendar).toContain('BEGIN:VCALENDAR\r\n');
+		expect(calendar).toContain('VERSION:2.0\r\n');
+		expect(calendar).toContain('UID:fluxer-scheduled-message-2@fluxer.app\r\n');
+		expect(calendar).toContain('DTSTAMP:20291231T000000Z\r\n');
+		expect(calendar).toContain('DTSTART:20300102T030405Z\r\n');
+		expect(calendar).toContain('SUMMARY:calendar\\, export\\nline two\r\n');
+		expect(calendar).toContain('DESCRIPTION:Channel: 3\\nStatus: pending\\nContent: calendar\\, export\\nline two\r\n');
+		expect(calendar.endsWith('END:VCALENDAR\r\n')).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- What changed: added iCalendar export endpoints for the current user's scheduled messages, including all scheduled messages and a single scheduled message export.
- Why it is correct: it reuses the existing scheduled message service and formats already-owned scheduled message data as a standard `.ics` calendar file for external calendar import.
- Risk: low to medium. This adds read-only export endpoints and calendar formatting, but it does not add public subscription tokens or persistent calendar state.

## Verification

- Tests and checks run:
  - `pnpm.cmd --filter fluxer_api typecheck`
  - `pnpm.cmd exec biome check fluxer_api/src/api/user/UserCalendarExport.ts fluxer_api/src/api/user/controllers/UserScheduledMessageController.ts fluxer_api/src/api/user/tests/UserCalendarExport.test.ts fluxer_api/src/api/channel/tests/ScheduledMessageTestUtils.ts fluxer_api/src/api/channel/tests/ScheduledMessagesListLifecycle.test.ts`
  - `git diff --check`
  - `pnpm.cmd exec tsx -e "import {buildScheduledMessagesCalendar} from './fluxer_api/src/api/user/UserCalendarExport.ts'; ..."`
- Direct calendar validation confirmed:
  - the generated file starts with `BEGIN:VCALENDAR`
  - scheduled dates are formatted as UTC iCalendar timestamps, for example `DTSTART:20300102T030405Z`
  - commas and newlines in event text are escaped for iCalendar text fields
  - each scheduled message receives a stable `UID:fluxer-scheduled-message-<id>@fluxer.app`
- Local test-suite note:
  - a focused `pnpm.cmd --filter fluxer_api test -- src/api/user/tests/UserCalendarExport.test.ts` attempt hung in the repository's global API Vitest setup on this machine, so I validated the pure calendar builder directly with `tsx` and kept the broader checks above.
- Screenshots or recordings:
  - not applicable; backend API change only.

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- I used Codex for repository navigation, implementation assistance, and validation command execution. I reviewed the generated changes before submitting.

Refs fluxerapp/fluxer-meta#21.
