### PR TITLE
fix(klipy): resolve embeds via the KLIPY API + graceful provider errors

### DIFF
--- a/fluxer_api/src/api/gif/KlipyGifProvider.ts
+++ b/fluxer_api/src/api/gif/KlipyGifProvider.ts
@@ -177,7 +177,7 @@ export class KlipyGifProvider implements IGifProvider {
 	}
 
 	private async fetchKlipyData(url: URL): Promise<unknown> {
-		let lastError: unknown = new Error('KLIPY API request failed');
+		let lastError = new Error('KLIPY API request failed');
 		for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
 			try {
 				const response = await fetch(url.toString(), {
@@ -203,15 +203,13 @@ export class KlipyGifProvider implements IGifProvider {
 				if (error instanceof ServiceUnavailableError) {
 					throw error;
 				}
-				lastError = error;
+				lastError = error instanceof Error ? error : new Error(String(error));
 			}
 			if (attempt < MAX_RETRIES - 1) {
 				await new Promise((resolve) => setTimeout(resolve, BACKOFF_BASE_DELAY * 2 ** attempt));
 			}
 		}
-		throw new ServiceUnavailableError({
-			message: lastError instanceof Error ? lastError.message : 'KLIPY API request failed',
-		});
+		throw new ServiceUnavailableError({message: lastError.message});
 	}
 
 	private async fetchAndTransformGifs(url: URL): Promise<Array<GifResponse>> {

--- a/fluxer_api/src/api/gif/KlipyGifProvider.ts
+++ b/fluxer_api/src/api/gif/KlipyGifProvider.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import {FLUXER_USER_AGENT} from '@fluxer/constants/src/Core';
+import {ServiceUnavailableError} from '@fluxer/errors/src/domains/core/ServiceUnavailableError';
 import type {GifCategoryTagResponse, GifMediaFormat, GifResponse} from '@fluxer/schema/src/domains/gif/GifSchemas';
 import type {ICacheService} from '@pkgs/cache/src/ICacheService';
 import {ms} from 'itty-time';
@@ -176,32 +177,41 @@ export class KlipyGifProvider implements IGifProvider {
 	}
 
 	private async fetchKlipyData(url: URL): Promise<unknown> {
+		let lastError: unknown = new Error('KLIPY API request failed');
 		for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
 			try {
 				const response = await fetch(url.toString(), {
 					headers: {'User-Agent': FLUXER_USER_AGENT},
 					signal: AbortSignal.timeout(ms('30 seconds')),
 				});
-				if (!response.ok) {
-					throw new Error(`Failed to fetch KLIPY data: ${response.statusText}`);
+				if (response.ok) {
+					const responseText = await FetchUtils.streamToStringWithLimit(response.body, {
+						maxBytes: EXTERNAL_RESPONSE_LIMITS.klipyApiBytes,
+						headers: response.headers,
+						url: response.url,
+						description: 'KLIPY API response',
+					});
+					return parseJsonUnknown(responseText);
 				}
-				const responseText = await FetchUtils.streamToStringWithLimit(response.body, {
-					maxBytes: EXTERNAL_RESPONSE_LIMITS.klipyApiBytes,
-					headers: response.headers,
-					url: response.url,
-					description: 'KLIPY API response',
-				});
-				return parseJsonUnknown(responseText);
+				if (response.status === 429 || (response.status >= 400 && response.status < 500)) {
+					throw new ServiceUnavailableError({
+						message: `KLIPY API request failed with status ${response.status}`,
+					});
+				}
+				lastError = new Error(`KLIPY API request failed with status ${response.status}`);
 			} catch (error) {
-				if (attempt < MAX_RETRIES - 1) {
-					const delay = BACKOFF_BASE_DELAY * 2 ** attempt;
-					await new Promise((resolve) => setTimeout(resolve, delay));
-				} else {
+				if (error instanceof ServiceUnavailableError) {
 					throw error;
 				}
+				lastError = error;
+			}
+			if (attempt < MAX_RETRIES - 1) {
+				await new Promise((resolve) => setTimeout(resolve, BACKOFF_BASE_DELAY * 2 ** attempt));
 			}
 		}
-		throw new Error('Exceeded maximum retries');
+		throw new ServiceUnavailableError({
+			message: lastError instanceof Error ? lastError.message : 'KLIPY API request failed',
+		});
 	}
 
 	private async fetchAndTransformGifs(url: URL): Promise<Array<GifResponse>> {

--- a/fluxer_api/src/api/gif/TenorGifProvider.ts
+++ b/fluxer_api/src/api/gif/TenorGifProvider.ts
@@ -137,7 +137,7 @@ export class TenorGifProvider implements IGifProvider {
 	}
 
 	private async fetchTenorData(url: URL): Promise<unknown> {
-		let lastError: unknown = new Error('Tenor API request failed');
+		let lastError = new Error('Tenor API request failed');
 		for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
 			try {
 				const response = await fetch(url.toString(), {
@@ -163,15 +163,13 @@ export class TenorGifProvider implements IGifProvider {
 				if (error instanceof ServiceUnavailableError) {
 					throw error;
 				}
-				lastError = error;
+				lastError = error instanceof Error ? error : new Error(String(error));
 			}
 			if (attempt < MAX_RETRIES - 1) {
 				await new Promise((resolve) => setTimeout(resolve, BACKOFF_BASE_DELAY * 2 ** attempt));
 			}
 		}
-		throw new ServiceUnavailableError({
-			message: lastError instanceof Error ? lastError.message : 'Tenor API request failed',
-		});
+		throw new ServiceUnavailableError({message: lastError.message});
 	}
 
 	private async fetchAndTransformGifs(url: URL): Promise<Array<GifResponse>> {

--- a/fluxer_api/src/api/gif/TenorGifProvider.ts
+++ b/fluxer_api/src/api/gif/TenorGifProvider.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import {FLUXER_USER_AGENT} from '@fluxer/constants/src/Core';
+import {ServiceUnavailableError} from '@fluxer/errors/src/domains/core/ServiceUnavailableError';
 import type {GifCategoryTagResponse, GifMediaFormat, GifResponse} from '@fluxer/schema/src/domains/gif/GifSchemas';
 import type {ICacheService} from '@pkgs/cache/src/ICacheService';
 import {ms} from 'itty-time';
@@ -136,32 +137,41 @@ export class TenorGifProvider implements IGifProvider {
 	}
 
 	private async fetchTenorData(url: URL): Promise<unknown> {
+		let lastError: unknown = new Error('Tenor API request failed');
 		for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
 			try {
 				const response = await fetch(url.toString(), {
 					headers: {'User-Agent': FLUXER_USER_AGENT},
 					signal: AbortSignal.timeout(ms('30 seconds')),
 				});
-				if (!response.ok) {
-					throw new Error(`Failed to fetch Tenor data: ${response.statusText}`);
+				if (response.ok) {
+					const responseText = await FetchUtils.streamToStringWithLimit(response.body, {
+						maxBytes: EXTERNAL_RESPONSE_LIMITS.tenorApiBytes,
+						headers: response.headers,
+						url: response.url,
+						description: 'Tenor API response',
+					});
+					return parseJsonUnknown(responseText);
 				}
-				const responseText = await FetchUtils.streamToStringWithLimit(response.body, {
-					maxBytes: EXTERNAL_RESPONSE_LIMITS.tenorApiBytes,
-					headers: response.headers,
-					url: response.url,
-					description: 'Tenor API response',
-				});
-				return parseJsonUnknown(responseText);
+				if (response.status === 429 || (response.status >= 400 && response.status < 500)) {
+					throw new ServiceUnavailableError({
+						message: `Tenor API request failed with status ${response.status}`,
+					});
+				}
+				lastError = new Error(`Tenor API request failed with status ${response.status}`);
 			} catch (error) {
-				if (attempt < MAX_RETRIES - 1) {
-					const delay = BACKOFF_BASE_DELAY * 2 ** attempt;
-					await new Promise((resolve) => setTimeout(resolve, delay));
-				} else {
+				if (error instanceof ServiceUnavailableError) {
 					throw error;
 				}
+				lastError = error;
+			}
+			if (attempt < MAX_RETRIES - 1) {
+				await new Promise((resolve) => setTimeout(resolve, BACKOFF_BASE_DELAY * 2 ** attempt));
 			}
 		}
-		throw new Error('Exceeded maximum retries');
+		throw new ServiceUnavailableError({
+			message: lastError instanceof Error ? lastError.message : 'Tenor API request failed',
+		});
 	}
 
 	private async fetchAndTransformGifs(url: URL): Promise<Array<GifResponse>> {

--- a/fluxer_api/src/api/infrastructure/NatsUnfurlerService.test.ts
+++ b/fluxer_api/src/api/infrastructure/NatsUnfurlerService.test.ts
@@ -70,6 +70,7 @@ describe('NatsUnfurlerService', () => {
 					bypass_cache: true,
 					cache_only: false,
 					youtube_api_key: null,
+					klipy_api_key: null,
 				},
 				timeout: 12000,
 			},

--- a/fluxer_api/src/api/infrastructure/NatsUnfurlerService.ts
+++ b/fluxer_api/src/api/infrastructure/NatsUnfurlerService.ts
@@ -19,6 +19,7 @@ interface NatsUnfurlRequest {
 	bypass_cache: boolean;
 	cache_only: boolean;
 	youtube_api_key: string | null;
+	klipy_api_key: string | null;
 }
 
 interface NatsUnfurlInnerResult {
@@ -59,6 +60,7 @@ export class NatsUnfurlerService extends IUnfurlerService {
 	constructor(
 		connectionManager: INatsConnectionManager,
 		private readonly resolveYoutubeApiKey: (() => Promise<string | null>) | null = null,
+		private readonly resolveKlipyApiKey: (() => Promise<string | null>) | null = null,
 	) {
 		super();
 		this.connectionManager = connectionManager;
@@ -77,6 +79,7 @@ export class NatsUnfurlerService extends IUnfurlerService {
 				bypass_cache: options.bypassCache === true,
 				cache_only: options.cacheOnly === true,
 				youtube_api_key: this.resolveYoutubeApiKey ? await this.resolveYoutubeApiKey() : null,
+				klipy_api_key: this.resolveKlipyApiKey ? await this.resolveKlipyApiKey() : null,
 			};
 			if (this.connectionManager.isClosed()) {
 				await this.connectionManager.connect();

--- a/fluxer_api/src/api/instance/InstanceConfigRepository.ts
+++ b/fluxer_api/src/api/instance/InstanceConfigRepository.ts
@@ -1232,6 +1232,11 @@ export class InstanceConfigRepository {
 		return integrations.youtube.api_key ?? normalizeSecretString(Config.youtube.apiKey);
 	}
 
+	async getEffectiveKlipyApiKey(): Promise<string | null> {
+		const integrations = await this.getInstanceIntegrationsConfig();
+		return integrations.gif.klipy_api_key ?? normalizeSecretString(Config.klipy.apiKey);
+	}
+
 	async getEffectiveCaptchaConfig(): Promise<InstanceCaptchaEffectiveConfig> {
 		const integrations = await this.getInstanceIntegrationsConfig();
 		const provider = integrations.captcha.provider ?? (Config.captcha.enabled ? Config.captcha.provider : 'none');

--- a/fluxer_api/src/api/middleware/ServiceSingletons.ts
+++ b/fluxer_api/src/api/middleware/ServiceSingletons.ts
@@ -357,7 +357,11 @@ const getDefaultUnfurlerService = singleton(() => {
 	void manager.connect().catch((error) => {
 		Logger.error({error}, '[nats-unfurl] Failed to establish NATS connection');
 	});
-	return new NatsUnfurlerService(manager, async () => getInstanceConfigRepository().getEffectiveYoutubeApiKey());
+	return new NatsUnfurlerService(
+		manager,
+		async () => getInstanceConfigRepository().getEffectiveYoutubeApiKey(),
+		async () => getInstanceConfigRepository().getEffectiveKlipyApiKey(),
+	);
 });
 
 export function getUnfurlerService(): IUnfurlerService {

--- a/fluxer_unfurl/src/resolvers/default_resolver.rs
+++ b/fluxer_unfurl/src/resolvers/default_resolver.rs
@@ -81,6 +81,7 @@ async fn resolve_html(ctx: &ResolveContext<'_>) -> anyhow::Result<ResolverResult
         media_proxy: ctx.media_proxy,
         static_cdn_endpoint: ctx.static_cdn_endpoint,
         youtube_api_key: ctx.youtube_api_key.clone(),
+        klipy_api_key: ctx.klipy_api_key.clone(),
     };
 
     if let Some(embeds) = activity_pub::try_resolve(

--- a/fluxer_unfurl/src/resolvers/fxtwitter.rs
+++ b/fluxer_unfurl/src/resolvers/fxtwitter.rs
@@ -1075,6 +1075,7 @@ mod tests {
             media_proxy,
             static_cdn_endpoint: "https://static.example.test",
             youtube_api_key: None,
+            klipy_api_key: None,
         }
     }
 

--- a/fluxer_unfurl/src/resolvers/klipy.rs
+++ b/fluxer_unfurl/src/resolvers/klipy.rs
@@ -10,6 +10,12 @@ use std::time::Duration;
 use url::Url;
 
 const KLIPY_FLIGHT_CHUNK_MAX_BYTES: usize = 512 * 1024;
+const KLIPY_API_BASE_URL: &str = "https://api.klipy.com/api/v1";
+const KLIPY_API_MAX_BYTES: usize = 512 * 1024;
+const KLIPY_API_TIMEOUT: Duration = Duration::from_secs(10);
+const KLIPY_SIZE_PREFERENCE: &[&str] = &["hd", "md", "sm", "xs"];
+const KLIPY_THUMBNAIL_FORMATS: &[&str] = &["webp", "gif"];
+const KLIPY_VIDEO_FORMATS: &[&str] = &["mp4", "webm"];
 
 pub struct KlipyResolver;
 
@@ -33,31 +39,9 @@ impl Resolver for KlipyResolver {
     }
 
     fn transform_url(&self, url: &Url) -> Option<Url> {
-        if !url
-            .host_str()
-            .is_some_and(|h| h.eq_ignore_ascii_case("klipy.com"))
-        {
-            return None;
-        }
-
-        let path = url.path();
-        static PATH_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
-            regex::Regex::new(r"^/(gif|gifs|clip|clips)/([^/]+)").expect("valid regex")
-        });
-        let caps = PATH_RE.captures(path)?;
-        let kind = caps.get(1)?.as_str();
-        let slug = caps.get(2)?.as_str();
-
-        let normalized_kind = if kind.starts_with("clip") {
-            "clips"
-        } else {
-            "gifs"
-        };
-
-        Url::parse(&format!(
-            "https://klipy.com/{normalized_kind}/{slug}/player"
-        ))
-        .ok()
+        let (kind, slug) = klipy_path(url)?;
+        let resource = klipy_resource(&kind);
+        Url::parse(&format!("https://klipy.com/{resource}/{slug}/player")).ok()
     }
 
     fn resolve<'a>(
@@ -65,24 +49,24 @@ impl Resolver for KlipyResolver {
         ctx: &'a ResolveContext<'_>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<ResolverResult>> + Send + 'a>> {
         Box::pin(async move {
-            let result = http_fetch::fetch_url(
-                &ctx.http_client,
-                ctx.url.as_str(),
-                http_fetch::DEFAULT_HTML_MAX_BYTES,
-                Duration::from_secs(10),
-            )
-            .await?;
+            let api_key = ctx.klipy_api_key.clone().or_else(klipy_api_key);
+            let formats = match api_key {
+                Some(key) => match resolve_media_via_api(ctx, &key).await {
+                    Ok(Some(formats)) => Some(formats),
+                    Ok(None) => resolve_media_via_scrape(ctx).await?,
+                    Err(err) => {
+                        tracing::warn!(
+                            error = %err,
+                            "KLIPY API resolution failed; falling back to page scrape"
+                        );
+                        resolve_media_via_scrape(ctx).await?
+                    }
+                },
+                None => resolve_media_via_scrape(ctx).await?,
+            };
 
-            if result.status != 200 {
+            let Some(formats) = formats else {
                 return Ok(ResolverResult { embeds: vec![] });
-            }
-
-            let html = String::from_utf8_lossy(&result.bytes);
-            let formats = match extract_klipy_media(&html) {
-                Some(formats) => formats,
-                None => {
-                    return Ok(ResolverResult { embeds: vec![] });
-                }
             };
 
             let mut embed = MessageEmbed::new("gifv");
@@ -128,6 +112,125 @@ async fn resolve_klipy_media(
         format.width,
         format.height,
     ))
+}
+
+fn klipy_path(url: &Url) -> Option<(String, String)> {
+    if !url
+        .host_str()
+        .is_some_and(|h| h.eq_ignore_ascii_case("klipy.com"))
+    {
+        return None;
+    }
+    static PATH_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"^/(gif|gifs|clip|clips)/([^/]+)").expect("valid regex")
+    });
+    let caps = PATH_RE.captures(url.path())?;
+    Some((
+        caps.get(1)?.as_str().to_owned(),
+        caps.get(2)?.as_str().to_owned(),
+    ))
+}
+
+fn klipy_resource(kind: &str) -> &'static str {
+    if kind.starts_with("clip") {
+        "clips"
+    } else {
+        "gifs"
+    }
+}
+
+fn klipy_api_key() -> Option<String> {
+    std::env::var("FLUXER_KLIPY_API_KEY")
+        .ok()
+        .filter(|key| !key.is_empty())
+        .or_else(|| {
+            std::env::var("KLIPY_API_KEY")
+                .ok()
+                .filter(|key| !key.is_empty())
+        })
+}
+
+async fn resolve_media_via_scrape(
+    ctx: &ResolveContext<'_>,
+) -> anyhow::Result<Option<KlipyMediaFormats>> {
+    let result = http_fetch::fetch_url(
+        &ctx.http_client,
+        ctx.url.as_str(),
+        http_fetch::DEFAULT_HTML_MAX_BYTES,
+        Duration::from_secs(10),
+    )
+    .await?;
+
+    if result.status != 200 {
+        return Ok(None);
+    }
+
+    let html = String::from_utf8_lossy(&result.bytes);
+    Ok(extract_klipy_media(&html))
+}
+
+async fn resolve_media_via_api(
+    ctx: &ResolveContext<'_>,
+    api_key: &str,
+) -> anyhow::Result<Option<KlipyMediaFormats>> {
+    let Some((kind, slug)) = klipy_path(&ctx.original_url) else {
+        return Ok(None);
+    };
+    let resource = klipy_resource(&kind);
+
+    let url = Url::parse(&format!("{KLIPY_API_BASE_URL}/{api_key}/{resource}/{slug}"))?;
+
+    let response = http_fetch::fetch_url(
+        &ctx.http_client,
+        url.as_str(),
+        KLIPY_API_MAX_BYTES,
+        KLIPY_API_TIMEOUT,
+    )
+    .await?;
+
+    if response.status != 200 {
+        tracing::warn!(
+            status = response.status,
+            "KLIPY API lookup returned non-200"
+        );
+        return Ok(None);
+    }
+
+    let payload: serde_json::Value = serde_json::from_slice(&response.bytes)?;
+    let Some(file) = payload.pointer("/data/file") else {
+        return Ok(None);
+    };
+
+    let thumbnail = pick_klipy_file_format(file, KLIPY_THUMBNAIL_FORMATS);
+    let video = pick_klipy_file_format(file, KLIPY_VIDEO_FORMATS);
+    if thumbnail.is_none() && video.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(KlipyMediaFormats { thumbnail, video }))
+}
+
+fn pick_klipy_file_format(file: &serde_json::Value, formats: &[&str]) -> Option<KlipyMediaFormat> {
+    for size in KLIPY_SIZE_PREFERENCE {
+        for format in formats {
+            if let Some(media) = extract_media_format(file.pointer(&format!("/{size}/{format}")))
+                && media.url.is_some()
+            {
+                return Some(media);
+            }
+        }
+    }
+    for format in formats {
+        if let Some(url) = file.get(*format).and_then(|v| v.as_str())
+            && !url.is_empty()
+        {
+            return Some(KlipyMediaFormat {
+                url: Some(url.to_owned()),
+                width: None,
+                height: None,
+            });
+        }
+    }
+    None
 }
 
 fn resolve_relative_url(base_url: &Url, media_url: &str) -> Option<String> {
@@ -359,5 +462,93 @@ mod tests {
     fn resolve_relative_url_rejects_non_http() {
         let base = Url::parse("https://klipy.com/gifs/test").unwrap();
         assert!(resolve_relative_url(&base, "ftp://evil.com/file").is_none());
+    }
+
+    #[test]
+    fn klipy_path_extracts_kind_and_slug() {
+        let (kind, slug) =
+            klipy_path(&Url::parse("https://klipy.com/gifs/funny-cat-123").unwrap()).unwrap();
+        assert_eq!(kind, "gifs");
+        assert_eq!(slug, "funny-cat-123");
+        assert!(klipy_path(&Url::parse("https://klipy.com/about").unwrap()).is_none());
+        assert!(klipy_path(&Url::parse("https://notklipy.com/gifs/x").unwrap()).is_none());
+    }
+
+    #[test]
+    fn klipy_resource_maps_kind_to_api_segment() {
+        assert_eq!(klipy_resource("gif"), "gifs");
+        assert_eq!(klipy_resource("gifs"), "gifs");
+        assert_eq!(klipy_resource("clip"), "clips");
+        assert_eq!(klipy_resource("clips"), "clips");
+    }
+
+    #[test]
+    fn pick_klipy_file_format_prefers_hd_and_format_order() {
+        let file = serde_json::json!({
+            "hd": {
+                "webp": {"url": "https://img.klipy.com/hd.webp", "width": 254, "height": 450},
+                "mp4": {"url": "https://img.klipy.com/hd.mp4", "width": 254, "height": 450}
+            },
+            "sm": {
+                "webp": {"url": "https://img.klipy.com/sm.webp", "width": 165, "height": 294}
+            }
+        });
+        let thumbnail = pick_klipy_file_format(&file, KLIPY_THUMBNAIL_FORMATS).unwrap();
+        assert_eq!(
+            thumbnail.url.as_deref(),
+            Some("https://img.klipy.com/hd.webp")
+        );
+        assert_eq!(thumbnail.width, Some(254));
+        assert_eq!(thumbnail.height, Some(450));
+        assert_eq!(
+            pick_klipy_file_format(&file, KLIPY_VIDEO_FORMATS)
+                .unwrap()
+                .url
+                .as_deref(),
+            Some("https://img.klipy.com/hd.mp4")
+        );
+    }
+
+    #[test]
+    fn pick_klipy_file_format_handles_clip_string_shape() {
+        let file = serde_json::json!({
+            "mp4": "https://img.klipy.com/c.mp4",
+            "gif": "https://img.klipy.com/c.gif",
+            "webp": "https://img.klipy.com/c.webp"
+        });
+        let thumbnail = pick_klipy_file_format(&file, KLIPY_THUMBNAIL_FORMATS).unwrap();
+        assert_eq!(
+            thumbnail.url.as_deref(),
+            Some("https://img.klipy.com/c.webp")
+        );
+        assert_eq!(thumbnail.width, None);
+        assert_eq!(
+            pick_klipy_file_format(&file, KLIPY_VIDEO_FORMATS)
+                .unwrap()
+                .url
+                .as_deref(),
+            Some("https://img.klipy.com/c.mp4")
+        );
+    }
+
+    #[test]
+    fn pick_klipy_file_format_falls_back_to_smaller_size() {
+        let file = serde_json::json!({
+            "sm": {"webp": {"url": "https://img.klipy.com/sm.webp", "width": 165, "height": 294}}
+        });
+        assert_eq!(
+            pick_klipy_file_format(&file, KLIPY_THUMBNAIL_FORMATS)
+                .unwrap()
+                .url
+                .as_deref(),
+            Some("https://img.klipy.com/sm.webp")
+        );
+        assert!(pick_klipy_file_format(&file, KLIPY_VIDEO_FORMATS).is_none());
+    }
+
+    #[test]
+    fn pick_klipy_file_format_none_when_empty() {
+        let file = serde_json::json!({});
+        assert!(pick_klipy_file_format(&file, KLIPY_THUMBNAIL_FORMATS).is_none());
     }
 }

--- a/fluxer_unfurl/src/resolvers/mod.rs
+++ b/fluxer_unfurl/src/resolvers/mod.rs
@@ -27,6 +27,7 @@ pub struct ResolveContext<'mp> {
     pub media_proxy: &'mp MediaProxyClient,
     pub static_cdn_endpoint: &'mp str,
     pub youtube_api_key: Option<String>,
+    pub klipy_api_key: Option<String>,
 }
 
 impl ResolveContext<'_> {

--- a/fluxer_unfurl/src/router_impl.rs
+++ b/fluxer_unfurl/src/router_impl.rs
@@ -125,6 +125,7 @@ mod tests {
             bypass_cache: false,
             cache_only,
             youtube_api_key: None,
+            klipy_api_key: None,
         }
     }
 

--- a/fluxer_unfurl/src/shard_impl.rs
+++ b/fluxer_unfurl/src/shard_impl.rs
@@ -91,6 +91,7 @@ impl UnfurlShard {
         url_str: &str,
         nsfw_mode: NsfwMode,
         youtube_api_key: Option<&str>,
+        klipy_api_key: Option<&str>,
     ) -> anyhow::Result<UnfurlResult> {
         let parsed = Url::parse(url_str)?;
 
@@ -104,6 +105,7 @@ impl UnfurlShard {
             media_proxy: &self.media_proxy,
             static_cdn_endpoint: &self.static_cdn_endpoint,
             youtube_api_key: youtube_api_key.map(str::to_owned),
+            klipy_api_key: klipy_api_key.map(str::to_owned),
         };
 
         if let Some(idx) = matched_resolver_idx {
@@ -204,6 +206,7 @@ impl ShardService for UnfurlShard {
                 bypass_cache,
                 cache_only,
                 ref youtube_api_key,
+                ref klipy_api_key,
             } => {
                 let nsfw = nsfw_mode.unwrap_or_default();
                 let cache_key = unfurl_cache_key(url, nsfw);
@@ -219,7 +222,12 @@ impl ShardService for UnfurlShard {
                 }
 
                 let result = match self
-                    .resolve_url(url, nsfw, youtube_api_key.as_deref())
+                    .resolve_url(
+                        url,
+                        nsfw,
+                        youtube_api_key.as_deref(),
+                        klipy_api_key.as_deref(),
+                    )
                     .await
                 {
                     Ok(r) => Arc::new(r),

--- a/fluxer_unfurl/src/types.rs
+++ b/fluxer_unfurl/src/types.rs
@@ -15,6 +15,8 @@ pub enum UnfurlRequest {
         cache_only: bool,
         #[serde(default)]
         youtube_api_key: Option<String>,
+        #[serde(default)]
+        klipy_api_key: Option<String>,
     },
     Invalidate {
         url: String,
@@ -203,12 +205,14 @@ mod tests {
                 bypass_cache,
                 cache_only,
                 youtube_api_key,
+                klipy_api_key,
             } => {
                 assert_eq!(url, "https://fxtwitter.com/example/status/1");
                 assert_eq!(nsfw_mode, Some(NsfwMode::Block));
                 assert!(!bypass_cache);
                 assert!(!cache_only);
                 assert!(youtube_api_key.is_none());
+                assert!(klipy_api_key.is_none());
             }
             UnfurlRequest::Invalidate { .. } => panic!("expected unfurl request"),
         }


### PR DESCRIPTION
## Summary

- **What changed:** 
  - KLIPY embeds now resolve via the KLIPY API (by slug) instead of scraping the Cloudflare-blocked klipy.com page. (fix #1046)
  - GIF search returns 503 instead of 500 when the provider is rate-limited.
- **Why it is correct:** 
klipy.com is 403 behind Cloudflare, so scraping can't work; the by-slug API returns the exact GIF. Key passed over NATS like youtube_api_key; page scrape kept as fallback.
- **Risk:** 
Low. Additive, no DB changes; unchanged when no KLIPY key is set.

## Verification

- Tests run: cargo test -p fluxer-unfurl (389 ok) + clippy; fluxer_api tsgo typecheck ok.
- Manual checks: built + deployed self-hosted — KLIPY GIFs embed, search returns 503 not 500 under rate limit.
- Screenshots or recordings: 
<img width="917" height="556" alt="Capture d’écran du 2026-06-18 12-13-23" src="https://github.com/user-attachments/assets/09692f85-8456-4651-8d2c-33638a3d9cd4" />

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- Yes, assisted by Claude, reviewed and tested by me.
