### PR TITLE
Add presence activities for RPC status

### DIFF
--- a/fluxer_app/src/features/gateway/transport/GatewayConnection.ts
+++ b/fluxer_app/src/features/gateway/transport/GatewayConnection.ts
@@ -152,7 +152,13 @@ class GatewayConnection {
 					if (!presence) {
 						return;
 					}
-					this.socket?.updatePresence(presence.status, presence.afk, presence.mobile, presence.custom_status);
+					this.socket?.updatePresence(
+						presence.status,
+						presence.afk,
+						presence.mobile,
+						presence.custom_status,
+						presence.activities,
+					);
 				},
 			);
 		});
@@ -273,6 +279,7 @@ class GatewayConnection {
 					afk: presence.afk,
 					mobile: presence.mobile,
 					custom_status: presence.custom_status,
+					activities: presence.activities,
 				},
 			}),
 			compression,

--- a/fluxer_app/src/features/gateway/transport/GatewaySocket.ts
+++ b/fluxer_app/src/features/gateway/transport/GatewaySocket.ts
@@ -18,6 +18,7 @@ import {Logger, LogLevel} from '@app/features/platform/utils/AppLogger';
 import {ExponentialBackoff} from '@app/features/platform/utils/RetryScheduler';
 import LayerManager from '@app/features/ui/state/LayerManager';
 import MobileLayout from '@app/features/ui/state/MobileLayout';
+import type {GatewayPresenceActivity} from '@app/features/gateway/types/GatewayPresenceTypes';
 import type {GatewayCustomStatusPayload} from '@app/features/user/state/CustomStatus';
 import MediaEngine from '@app/features/voice/engine/MediaEngineFacade';
 import type {GatewayErrorCode} from '@fluxer/constants/src/GatewayConstants';
@@ -72,6 +73,7 @@ export interface GatewayPresence {
 	afk: boolean;
 	mobile: boolean;
 	custom_status?: GatewayCustomStatusPayload | null;
+	activities?: ReadonlyArray<GatewayPresenceActivity>;
 }
 
 export interface GatewayVoiceStateUpdateParams {
@@ -410,6 +412,7 @@ export class GatewaySocket extends EventEmitter<GatewaySocketEvents> {
 		afk?: boolean,
 		mobile?: boolean,
 		customStatus?: GatewayCustomStatusPayload | null,
+		activities?: ReadonlyArray<GatewayPresenceActivity>,
 	): void {
 		if (!this.isConnected()) return;
 		this.sendPayload({
@@ -419,6 +422,7 @@ export class GatewaySocket extends EventEmitter<GatewaySocketEvents> {
 				...(afk !== undefined && {afk}),
 				...(mobile !== undefined && {mobile}),
 				...(customStatus !== undefined && {custom_status: customStatus}),
+				...(activities !== undefined && {activities}),
 			},
 		});
 	}

--- a/fluxer_app/src/features/gateway/types/GatewayPresenceTypes.ts
+++ b/fluxer_app/src/features/gateway/types/GatewayPresenceTypes.ts
@@ -3,6 +3,16 @@
 import type {GatewayCustomStatusPayload} from '@app/features/user/state/CustomStatus';
 import type {UserPartial} from '@fluxer/schema/src/domains/user/UserResponseSchemas';
 
+export type GatewayPresenceActivityType = 'game' | 'music' | 'software';
+
+export interface GatewayPresenceActivity {
+	readonly type: GatewayPresenceActivityType;
+	readonly name: string;
+	readonly state?: string;
+	readonly details?: string;
+	readonly started_at?: number;
+}
+
 export interface PresenceRecord {
 	readonly guild_id?: string | null;
 	readonly user: UserPartial;
@@ -10,6 +20,7 @@ export interface PresenceRecord {
 	readonly afk?: boolean;
 	readonly mobile?: boolean;
 	readonly custom_status?: GatewayCustomStatusPayload | null;
+	readonly activities?: ReadonlyArray<GatewayPresenceActivity>;
 }
 
 export type Presence = PresenceRecord;

--- a/fluxer_app/src/features/presence/state/LocalPresence.ts
+++ b/fluxer_app/src/features/presence/state/LocalPresence.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type {AccountPresenceIntent} from '@app/features/auth/state/AccountStorage';
+import type {GatewayPresenceActivity} from '@app/features/gateway/types/GatewayPresenceTypes';
 import {deferUntilModulesLoaded} from '@app/features/platform/utils/DeferUntilModulesLoaded';
 import Idle from '@app/features/ui/state/Idle';
 import MobileLayout from '@app/features/ui/state/MobileLayout';
@@ -16,6 +17,7 @@ type Presence = Readonly<{
 	afk: boolean;
 	mobile: boolean;
 	custom_status: GatewayCustomStatusPayload | null;
+	activities: ReadonlyArray<GatewayPresenceActivity>;
 }>;
 
 export const ACCOUNT_PRESENCE_INTENT_MAX_AGE_MS = 60 * 1000;
@@ -42,6 +44,7 @@ class LocalPresence {
 	afk: boolean = false;
 	mobile: boolean = false;
 	customStatus: CustomStatus | null = null;
+	activities: Array<GatewayPresenceActivity> = [];
 	private restoredIntent: AccountPresenceIntent | null = null;
 
 	constructor() {
@@ -93,6 +96,7 @@ class LocalPresence {
 			afk: this.afk,
 			mobile: this.mobile,
 			custom_status: toGatewayCustomStatus(this.customStatus),
+			activities: this.activities,
 		};
 	}
 
@@ -131,11 +135,17 @@ class LocalPresence {
 		this.updatePresence();
 	}
 
+	setActivities(activities: ReadonlyArray<GatewayPresenceActivity>): void {
+		const normalized = this.normalizeActivities(activities);
+		if (this.activitiesKey(this.activities) === this.activitiesKey(normalized)) return;
+		this.activities = normalized;
+	}
+
 	get presenceKey(): string {
 		const hydrated = userSettings?.isHydrated() ? '1' : '0';
 		const afk = this.afk ? '1' : '0';
 		const mobile = this.mobile ? '1' : '0';
-		return `hydrated:${hydrated}|${this.status}|${customStatusToKey(this.customStatus)}|afk:${afk}|mobile:${mobile}`;
+		return `hydrated:${hydrated}|${this.status}|${customStatusToKey(this.customStatus)}|afk:${afk}|mobile:${mobile}|activities:${this.activitiesKey(this.activities)}`;
 	}
 
 	private computeAfk(idleSince: number, isMobile: boolean, settings: LocalPresenceUserSettings | null): boolean {
@@ -183,6 +193,27 @@ class LocalPresence {
 			return null;
 		}
 		return normalizeStatus(status);
+	}
+
+	private normalizeActivities(activities: ReadonlyArray<GatewayPresenceActivity>): Array<GatewayPresenceActivity> {
+		return activities
+			.filter((activity) => activity.name.trim().length > 0)
+			.slice(0, 4)
+			.map((activity) => ({...activity}));
+	}
+
+	private activitiesKey(activities: ReadonlyArray<GatewayPresenceActivity>): string {
+		return activities
+			.map((activity) =>
+				[
+					activity.type,
+					activity.name,
+					activity.state ?? '',
+					activity.details ?? '',
+					activity.started_at?.toString() ?? '',
+				].join(':'),
+			)
+			.join('|');
 	}
 }
 

--- a/fluxer_app/src/features/presence/state/Presence.ts
+++ b/fluxer_app/src/features/presence/state/Presence.ts
@@ -3,7 +3,7 @@
 import Authentication from '@app/features/auth/state/Authentication';
 import Channels from '@app/features/channel/state/Channels';
 import type {GuildReadyData} from '@app/features/gateway/types/GatewayGuildTypes';
-import type {Presence as WirePresence} from '@app/features/gateway/types/GatewayPresenceTypes';
+import type {GatewayPresenceActivity, Presence as WirePresence} from '@app/features/gateway/types/GatewayPresenceTypes';
 import Guilds from '@app/features/guild/state/Guilds';
 import GuildMembers from '@app/features/member/state/GuildMembers';
 import MemberSidebar from '@app/features/member/state/MemberSidebar';
@@ -30,6 +30,7 @@ interface FlattenedPresence {
 	mobile?: boolean;
 	guildIds: Set<string>;
 	customStatus: CustomStatus | null;
+	activities: ReadonlyArray<GatewayPresenceActivity>;
 }
 
 type StatusListener = (userId: string, status: StatusType, isMobile: boolean) => void;
@@ -40,6 +41,7 @@ class Presence {
 	private remotePresenceCountsByGuild = new Map<string, number>();
 	private remotePresenceCountVersionByGuild = observable.map<string, number>();
 	private customStatuses = new Map<string, CustomStatus | null>();
+	private activities = new Map<string, ReadonlyArray<GatewayPresenceActivity>>();
 	statuses = new Map<string, StatusType>();
 	presenceVersion = 0;
 	private statusListeners: Map<string, Set<StatusListener>> = new Map();
@@ -65,7 +67,11 @@ class Presence {
 		);
 		deferUntilModulesLoaded(() => {
 			reaction(
-				() => ({status: LocalPresence.status, customStatus: LocalPresence.customStatus}),
+				() => ({
+					status: LocalPresence.status,
+					customStatus: LocalPresence.customStatus,
+					activities: LocalPresence.activities,
+				}),
 				() => this.syncLocalPresence(),
 			);
 		});
@@ -160,6 +166,13 @@ class Presence {
 
 	getCustomStatus(userId: string): CustomStatus | null {
 		return this.customStatuses.get(userId) ?? null;
+	}
+
+	getActivities(userId: string): ReadonlyArray<GatewayPresenceActivity> {
+		if (userId === Authentication.currentUserId) {
+			return LocalPresence.activities;
+		}
+		return this.activities.get(userId) ?? [];
 	}
 
 	getPresenceCount(guildId: string): number {
@@ -266,9 +279,11 @@ class Presence {
 		this.remotePresenceCountVersionByGuild.clear();
 		this.statuses.clear();
 		this.customStatuses.clear();
+		this.activities.clear();
 		this.bumpPresenceVersion();
 		this.statuses.set(user.id, localStatus);
 		this.customStatuses.set(user.id, localCustomStatus);
+		this.activities.set(user.id, LocalPresence.activities);
 		const userGuildIds = new Map<string, Set<string>>();
 		const meContextUserIds = this.buildMeContextUserIds(user.id);
 		for (const guild of guilds) {
@@ -298,12 +313,14 @@ class Presence {
 			...Array.from(this.presences.keys()),
 			...Array.from(this.statuses.keys()),
 			...Array.from(this.customStatuses.keys()),
+			...Array.from(this.activities.keys()),
 		]);
 		this.presences.clear();
 		this.remotePresenceCountsByGuild.clear();
 		this.remotePresenceCountVersionByGuild.clear();
 		this.statuses.clear();
 		this.customStatuses.clear();
+		this.activities.clear();
 		this.bumpPresenceVersion();
 		for (const userId of previousUserIds) {
 			this.notifyStatusListeners(userId, StatusTypes.OFFLINE, false);
@@ -367,7 +384,7 @@ class Presence {
 	}
 
 	handlePresenceUpdate(presence: WirePresence): void {
-		const {guild_id: guildIdRaw, user, status, afk, mobile, custom_status: customStatusPayload} = presence;
+		const {guild_id: guildIdRaw, user, status, afk, mobile, custom_status: customStatusPayload, activities} = presence;
 		const normalizedStatus = normalizeStatus(status);
 		const userId = user.id;
 		const customStatus = fromGatewayCustomStatus(customStatusPayload);
@@ -390,10 +407,12 @@ class Presence {
 				mobile,
 				guildIds,
 				customStatus,
+				activities: activities ?? [],
 			};
 			this.presences.set(userId, flattened);
 			this.addPresenceCounts(flattened);
 			this.customStatuses.set(userId, customStatus);
+			this.activities.set(userId, flattened.activities);
 			this.updateStatusFromPresence(userId, flattened);
 			this.bumpPresenceVersion();
 			queueMicrotask(() => CustomStatusEmitter.emitPresenceChange(userId));
@@ -416,7 +435,9 @@ class Presence {
 			existing.mobile = mobile;
 		}
 		existing.customStatus = customStatus;
+		existing.activities = activities ?? [];
 		this.customStatuses.set(userId, customStatus);
+		this.activities.set(userId, existing.activities);
 		if (normalizedStatus === StatusTypes.OFFLINE && guildIdRaw == null) {
 			existing.guildIds.delete(ME);
 			if (existing.guildIds.size === 0) {
@@ -430,7 +451,7 @@ class Presence {
 	}
 
 	private handleReadyPresence(presence: WirePresence, initialGuildIds?: Set<string>, hasMeContext = false): void {
-		const {user, status, afk, mobile, custom_status: customStatusPayload} = presence;
+		const {user, status, afk, mobile, custom_status: customStatusPayload, activities} = presence;
 		const normalizedStatus = normalizeStatus(status);
 		const customStatus = fromGatewayCustomStatus(customStatusPayload);
 		const userId = user.id;
@@ -449,10 +470,12 @@ class Presence {
 			mobile,
 			guildIds,
 			customStatus,
+			activities: activities ?? [],
 		};
 		this.presences.set(userId, flattened);
 		this.addPresenceCounts(flattened);
 		this.customStatuses.set(userId, customStatus);
+		this.activities.set(userId, flattened.activities);
 		this.updateStatusFromPresence(userId, flattened);
 		this.bumpPresenceVersion();
 		queueMicrotask(() => CustomStatusEmitter.emitPresenceChange(userId));
@@ -489,6 +512,7 @@ class Presence {
 		}
 		const localStatus = LocalPresence.getStatus();
 		const localCustomStatus = LocalPresence.customStatus;
+		const localActivities = LocalPresence.activities;
 		MemberSidebar.handleLocalPresenceUpdate(userId, localStatus, localCustomStatus);
 		const oldStatus = this.statuses.get(userId);
 		let changed = false;
@@ -498,6 +522,7 @@ class Presence {
 			changed = true;
 		}
 		this.customStatuses.set(userId, localCustomStatus);
+		this.activities.set(userId, localActivities);
 		changed = true;
 		if (changed) {
 			this.bumpPresenceVersion();
@@ -564,6 +589,7 @@ class Presence {
 		}
 		this.presences.delete(userId);
 		this.customStatuses.delete(userId);
+		this.activities.delete(userId);
 		this.bumpPresenceVersion();
 		const oldStatus = this.statuses.get(userId);
 		if (oldStatus === undefined) {

--- a/fluxer_gateway/src/gateway/gateway_handler_dispatch.erl
+++ b/fluxer_gateway/src/gateway/gateway_handler_dispatch.erl
@@ -28,6 +28,8 @@
 
 -define(REQUEST_WORKER_TIMEOUT_MS, 10000).
 -define(MAX_REQUEST_WORKERS, 4).
+-define(MAX_PRESENCE_ACTIVITIES, 4).
+-define(MAX_PRESENCE_ACTIVITY_TEXT_BYTES, 128).
 
 -type request_worker_type() ::
     request_guild_members | request_guild_counts | request_channel_member_counts | lazy_request.
@@ -210,7 +212,7 @@ parse_presence_status(StatusRaw, Data) ->
         Afk = presence_boolean(<<"afk">>, Data),
         Mobile = presence_boolean(<<"mobile">>, Data),
         Base = #{status => AdjustedStatus, afk => Afk, mobile => Mobile},
-        Result = maybe_add_custom_status(Base, Data),
+        Result = maybe_add_activities(maybe_add_custom_status(Base, Data), Data),
         {ok, Result}
     catch
         error:function_clause -> {error, invalid_presence}
@@ -229,6 +231,79 @@ maybe_add_custom_status(Base, Data) ->
         {ok, CS} -> Base#{<<"custom_status">> => CS};
         error -> Base
     end.
+
+-spec maybe_add_activities(map(), map()) -> map().
+maybe_add_activities(Base, Data) ->
+    case maps:find(<<"activities">>, Data) of
+        {ok, Activities} when is_list(Activities) ->
+            Base#{<<"activities">> => normalize_presence_activities(Activities)};
+        {ok, null} ->
+            Base#{<<"activities">> => []};
+        _ ->
+            Base
+    end.
+
+-spec normalize_presence_activities([term()]) -> [map()].
+normalize_presence_activities(Activities) ->
+    lists:sublist(
+        [Activity || {ok, Activity} <- [normalize_presence_activity(Item) || Item <- Activities]],
+        ?MAX_PRESENCE_ACTIVITIES
+    ).
+
+-spec normalize_presence_activity(term()) -> {ok, map()} | error.
+normalize_presence_activity(Activity) when is_map(Activity) ->
+    Type = normalize_activity_type(maps:get(<<"type">>, Activity, undefined)),
+    Name = normalize_activity_text(maps:get(<<"name">>, Activity, undefined)),
+    case {Type, Name} of
+        {Type, Name} when is_binary(Type), is_binary(Name) ->
+            {ok,
+                maybe_put_activity_integer(
+                    <<"started_at">>,
+                    maps:get(<<"started_at">>, Activity, undefined),
+                    maybe_put_activity_text(
+                        <<"details">>,
+                        maps:get(<<"details">>, Activity, undefined),
+                        maybe_put_activity_text(
+                            <<"state">>, maps:get(<<"state">>, Activity, undefined), #{
+                                <<"type">> => Type, <<"name">> => Name
+                            }
+                        )
+                    )
+                )};
+        _ ->
+            error
+    end;
+normalize_presence_activity(_) ->
+    error.
+
+-spec normalize_activity_type(term()) -> binary() | undefined.
+normalize_activity_type(<<"game">>) -> <<"game">>;
+normalize_activity_type(<<"music">>) -> <<"music">>;
+normalize_activity_type(<<"software">>) -> <<"software">>;
+normalize_activity_type(_) -> undefined.
+
+-spec normalize_activity_text(term()) -> binary() | undefined.
+normalize_activity_text(Value) when
+    is_binary(Value),
+    Value =/= <<>>,
+    byte_size(Value) =< ?MAX_PRESENCE_ACTIVITY_TEXT_BYTES
+->
+    Value;
+normalize_activity_text(_) ->
+    undefined.
+
+-spec maybe_put_activity_text(binary(), term(), map()) -> map().
+maybe_put_activity_text(Key, Value, Activity) ->
+    case normalize_activity_text(Value) of
+        Text when is_binary(Text) -> Activity#{Key => Text};
+        undefined -> Activity
+    end.
+
+-spec maybe_put_activity_integer(binary(), term(), map()) -> map().
+maybe_put_activity_integer(Key, Value, Activity) when is_integer(Value), Value >= 0 ->
+    Activity#{Key => Value};
+maybe_put_activity_integer(_Key, _Value, Activity) ->
+    Activity.
 
 -spec adjust_status(atom()) -> atom().
 adjust_status(offline) -> invisible;

--- a/fluxer_gateway/src/guild/guild_member_list_connected.erl
+++ b/fluxer_gateway/src/guild/guild_member_list_connected.erl
@@ -32,7 +32,8 @@ default_presence() ->
     #{
         <<"status">> => <<"offline">>,
         <<"mobile">> => false,
-        <<"afk">> => false
+        <<"afk">> => false,
+        <<"activities">> => []
     }.
 
 -spec resolve_presence_for_user(guild_state(), user_id()) -> map().

--- a/fluxer_gateway/src/guild/guild_presence.erl
+++ b/fluxer_gateway/src/guild/guild_presence.erl
@@ -84,7 +84,8 @@ build_presence_map(Payload, Member) ->
     Afk = maps:get(<<"afk">>, Payload, false),
     MemberUser = maps:get(<<"user">>, Member, #{}),
     CustomStatus = maps:get(<<"custom_status">>, Payload, null),
-    presence_payload:build(MemberUser, NormalizedStatusBin, Mobile, Afk, CustomStatus).
+    Activities = maps:get(<<"activities">>, Payload, []),
+    presence_payload:build(MemberUser, NormalizedStatusBin, Mobile, Afk, CustomStatus, Activities).
 
 -spec maybe_handle_offline(atom(), user_id(), guild_state()) -> guild_state().
 maybe_handle_offline(offline, UserId, State) ->

--- a/fluxer_gateway/src/presence/presence_broadcast.erl
+++ b/fluxer_gateway/src/presence/presence_broadcast.erl
@@ -181,7 +181,8 @@ build_presence_external(State) ->
         status => ExternalStatus,
         mobile => maps:get(<<"mobile">>, Payload, false),
         afk => maps:get(<<"afk">>, Payload, false),
-        custom_status => maps:get(<<"custom_status">>, Payload, null)
+        custom_status => maps:get(<<"custom_status">>, Payload, null),
+        activities => maps:get(<<"activities">>, Payload, [])
     },
     {Payload, CurrentExternal, ExternalStatus}.
 
@@ -208,9 +209,10 @@ build_presence_payload(State) ->
     Status = presence_status:get_current_status(Sessions),
     Mobile = presence_status:get_flattened_mobile(Sessions),
     Afk = presence_status:get_flattened_afk(Sessions),
+    Activities = presence_status:get_flattened_activities(Sessions),
     UserData = maps:get(user_data, State, #{}),
     CustomStatus = maps:get(custom_status, State, null),
-    presence_payload:build(UserData, Status, Mobile, Afk, CustomStatus).
+    presence_payload:build(UserData, Status, Mobile, Afk, CustomStatus, Activities).
 
 -spec dispatch_foreign_presence(user_id(), map(), state()) -> {noreply, state()}.
 dispatch_foreign_presence(TargetId, Payload, State) ->

--- a/fluxer_gateway/src/presence/presence_payload.erl
+++ b/fluxer_gateway/src/presence/presence_payload.erl
@@ -3,22 +3,23 @@
 -module(presence_payload).
 -typing([eqwalizer]).
 
--export([build/5]).
+-export([build/6]).
 
 -export_type([status/0, custom_status/0]).
 
 -type status() :: online | offline | idle | dnd | invisible | binary().
 -type custom_status() :: map() | null.
 
--spec build(map(), status(), boolean(), boolean(), custom_status()) -> map().
-build(UserData, Status, Mobile, Afk, CustomStatus) ->
+-spec build(map(), status(), boolean(), boolean(), custom_status(), [map()]) -> map().
+build(UserData, Status, Mobile, Afk, CustomStatus, Activities) ->
     StatusBin = ensure_status_binary(Status),
     #{
         <<"user">> => user_utils:normalize_user(UserData),
         <<"status">> => StatusBin,
         <<"mobile">> => Mobile,
         <<"afk">> => Afk,
-        <<"custom_status">> => custom_status_for(StatusBin, CustomStatus)
+        <<"custom_status">> => custom_status_for(StatusBin, CustomStatus),
+        <<"activities">> => activities_for(StatusBin, Activities)
     }.
 
 -spec ensure_status_binary(term()) -> binary().
@@ -40,6 +41,14 @@ custom_status_for(_StatusBin, CustomStatus) -> normalize_custom_status(CustomSta
 normalize_custom_status(null) -> null;
 normalize_custom_status(CustomStatus) when is_map(CustomStatus) -> CustomStatus;
 normalize_custom_status(_) -> null.
+
+-spec activities_for(binary(), term()) -> [map()].
+activities_for(<<"offline">>, _Activities) -> [];
+activities_for(<<"invisible">>, _Activities) -> [];
+activities_for(_StatusBin, Activities) when is_list(Activities) ->
+    [Activity || Activity <- Activities, is_map(Activity)];
+activities_for(_StatusBin, _Activities) ->
+    [].
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -74,6 +83,10 @@ custom_status_for_invisible_test() ->
 custom_status_for_null_test() ->
     ?assertEqual(null, custom_status_for(<<"online">>, null)).
 
+activities_for_visible_test() ->
+    Activity = #{<<"type">> => <<"game">>, <<"name">> => <<"Flux Racer">>},
+    ?assertEqual([Activity], activities_for(<<"online">>, [Activity])).
+
 normalize_custom_status_test() ->
     ?assertEqual(null, normalize_custom_status(null)),
     ?assertEqual(#{<<"text">> => <<"hi">>}, normalize_custom_status(#{<<"text">> => <<"hi">>})),
@@ -83,14 +96,16 @@ normalize_custom_status_test() ->
 build_invisible_atom_normalized_to_offline_test() ->
     User = #{<<"id">> => <<"1">>, <<"username">> => <<"Test">>},
     CustomStatus = #{<<"text">> => <<"hello">>},
-    Result = build(User, invisible, false, false, CustomStatus),
+    Result = build(User, invisible, false, false, CustomStatus, [#{<<"name">> => <<"Game">>}]),
     ?assertEqual(<<"offline">>, maps:get(<<"status">>, Result)),
-    ?assertEqual(null, maps:get(<<"custom_status">>, Result)).
+    ?assertEqual(null, maps:get(<<"custom_status">>, Result)),
+    ?assertEqual([], maps:get(<<"activities">>, Result)).
 
 build_invisible_binary_normalized_to_offline_test() ->
     User = #{<<"id">> => <<"1">>, <<"username">> => <<"Test">>},
     CustomStatus = #{<<"text">> => <<"hello">>},
-    Result = build(User, <<"invisible">>, false, false, CustomStatus),
+    Result = build(User, <<"invisible">>, false, false, CustomStatus, [#{<<"name">> => <<"Game">>}]),
     ?assertEqual(<<"offline">>, maps:get(<<"status">>, Result)),
-    ?assertEqual(null, maps:get(<<"custom_status">>, Result)).
+    ?assertEqual(null, maps:get(<<"custom_status">>, Result)),
+    ?assertEqual([], maps:get(<<"activities">>, Result)).
 -endif.

--- a/fluxer_gateway/src/presence/presence_session.erl
+++ b/fluxer_gateway/src/presence/presence_session.erl
@@ -21,6 +21,7 @@
     status := status(),
     afk := boolean(),
     mobile := boolean(),
+    activities := [map()],
     pid := pid(),
     mref := reference(),
     socket_pid := pid() | undefined
@@ -39,6 +40,7 @@ handle_session_connect(Request, Pid, State) ->
     Status = normalize_status(maps:get(status, Request, offline)),
     Afk = normalize_boolean(maps:get(afk, Request, false)),
     Mobile = normalize_boolean(maps:get(mobile, Request, false)),
+    Activities = normalize_activities(maps:get(<<"activities">>, Request, [])),
     SocketPid = normalize_socket_pid(maps:get(socket_pid, Request, undefined)),
     Sessions = maps:get(sessions, State),
     case maps:get(SessionId, Sessions, undefined) of
@@ -49,6 +51,7 @@ handle_session_connect(Request, Pid, State) ->
                 status => Status,
                 afk => Afk,
                 mobile => Mobile,
+                activities => Activities,
                 pid => Pid,
                 mref => Ref,
                 socket_pid => SocketPid
@@ -59,7 +62,7 @@ handle_session_connect(Request, Pid, State) ->
             {reply, {ok, SessionsData}, NewState};
         Existing ->
             {UpdatedSession, NewState0} = refresh_existing_session(
-                Existing, Pid, Status, Afk, Mobile, SocketPid, State
+                Existing, Pid, Status, Afk, Mobile, Activities, SocketPid, State
             ),
             NewSessions = Sessions#{SessionId => UpdatedSession},
             NewState = NewState0#{sessions => NewSessions},
@@ -68,15 +71,16 @@ handle_session_connect(Request, Pid, State) ->
     end.
 
 -spec refresh_existing_session(
-    session_entry(), pid(), status(), boolean(), boolean(), pid() | undefined, state()
+    session_entry(), pid(), status(), boolean(), boolean(), [map()], pid() | undefined, state()
 ) -> {session_entry(), state()}.
-refresh_existing_session(Existing, Pid, Status, Afk, Mobile, SocketPid, State) ->
+refresh_existing_session(Existing, Pid, Status, Afk, Mobile, Activities, SocketPid, State) ->
     {Ref, State1} = refresh_monitor(Existing, Pid, State),
     {
         Existing#{
             status => Status,
             afk => Afk,
             mobile => Mobile,
+            activities => Activities,
             pid => Pid,
             mref => Ref,
             socket_pid => SocketPid
@@ -108,8 +112,11 @@ handle_presence_update(Request, State) ->
             Mobile = normalize_boolean(
                 maps:get(mobile, Request, maps:get(mobile, Session, false))
             ),
+            Activities = normalize_activities(
+                maps:get(<<"activities">>, Request, maps:get(activities, Session, []))
+            ),
             handle_session_presence_change(
-                SessionId, Session, Status, Afk, Mobile, Sessions, State
+                SessionId, Session, Status, Afk, Mobile, Activities, Sessions, State
             )
     end.
 
@@ -119,26 +126,28 @@ handle_presence_update(Request, State) ->
     status(),
     boolean(),
     boolean(),
+    [map()],
     sessions(),
     state()
 ) -> {noreply, state()}.
-handle_session_presence_change(SessionId, Session, Status, Afk, Mobile, Sessions, State) ->
-    case session_presence_changed(Session, Status, Afk, Mobile) of
+handle_session_presence_change(SessionId, Session, Status, Afk, Mobile, Activities, Sessions, State) ->
+    case session_presence_changed(Session, Status, Afk, Mobile, Activities) of
         false ->
             {noreply, State};
         true ->
-            UpdatedSession = Session#{status => Status, afk => Afk, mobile => Mobile},
+            UpdatedSession = Session#{status => Status, afk => Afk, mobile => Mobile, activities => Activities},
             NewSessions = Sessions#{SessionId => UpdatedSession},
             NewState = State#{sessions => NewSessions},
             dispatch_sessions_replace(NewState),
             {noreply, NewState}
     end.
 
--spec session_presence_changed(session_entry(), status(), boolean(), boolean()) -> boolean().
-session_presence_changed(Session, Status, Afk, Mobile) ->
+-spec session_presence_changed(session_entry(), status(), boolean(), boolean(), [map()]) -> boolean().
+session_presence_changed(Session, Status, Afk, Mobile, Activities) ->
     maps:get(status, Session) =/= Status orelse
         maps:get(afk, Session, false) =/= Afk orelse
-        maps:get(mobile, Session, false) =/= Mobile.
+        maps:get(mobile, Session, false) =/= Mobile orelse
+        maps:get(activities, Session, []) =/= Activities.
 
 -spec dispatch_sessions_replace(state()) -> ok.
 dispatch_sessions_replace(State) ->
@@ -209,6 +218,12 @@ normalize_boolean(_) -> false.
 -spec normalize_socket_pid(term()) -> pid() | undefined.
 normalize_socket_pid(Pid) when is_pid(Pid) -> Pid;
 normalize_socket_pid(_) -> undefined.
+
+-spec normalize_activities(term()) -> [map()].
+normalize_activities(Activities) when is_list(Activities) ->
+    [Activity || Activity <- Activities, is_map(Activity)];
+normalize_activities(_) ->
+    [].
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -282,6 +297,44 @@ handle_presence_update_unchanged_session_is_noop_test() ->
             ?assert(false)
     after 50 ->
         ok
+    end.
+
+handle_presence_update_updates_activities_test() ->
+    flush_test_messages(),
+    SessionId = <<"s1">>,
+    Activity = #{<<"type">> => <<"game">>, <<"name">> => <<"Flux Racer">>},
+    State = #{
+        sessions => #{
+            SessionId => #{
+                session_id => SessionId,
+                status => online,
+                afk => false,
+                mobile => false,
+                activities => [],
+                pid => self(),
+                mref => make_ref(),
+                socket_pid => undefined
+            }
+        }
+    },
+    {noreply, NewState} = handle_presence_update(
+        #{
+            session_id => SessionId,
+            status => online,
+            afk => false,
+            mobile => false,
+            <<"activities">> => [Activity]
+        },
+        State
+    ),
+    UpdatedSession = maps:get(SessionId, maps:get(sessions, NewState)),
+    ?assertEqual([Activity], maps:get(activities, UpdatedSession)),
+    receive
+        {'$gen_cast', {dispatch, sessions_replace, SessionsData}} ->
+            AllSession = hd(SessionsData),
+            ?assertEqual([Activity], maps:get(<<"activities">>, AllSession))
+    after 1000 ->
+        ?assert(false)
     end.
 
 handle_session_connect_existing_session_refreshes_status_test() ->

--- a/fluxer_gateway/src/presence/presence_status.erl
+++ b/fluxer_gateway/src/presence/presence_status.erl
@@ -7,6 +7,7 @@
     get_current_status/1,
     get_flattened_mobile/1,
     get_flattened_afk/1,
+    get_flattened_activities/1,
     collect_sessions_for_replace/1
 ]).
 
@@ -14,8 +15,11 @@
 
 -type session_id() :: binary().
 -type status() :: online | offline | idle | dnd | invisible.
--type session_entry() :: #{status := status(), afk := boolean(), mobile := boolean(), _ => _}.
+-type session_entry() :: #{
+    status := status(), afk := boolean(), mobile := boolean(), activities => [map()], _ => _
+}.
 -type sessions() :: #{session_id() => session_entry()}.
+-define(MAX_FLATTENED_ACTIVITIES, 4).
 
 -spec get_current_status(sessions()) -> status().
 get_current_status(Sessions) ->
@@ -64,6 +68,27 @@ get_flattened_afk(Sessions) ->
         false -> all_sessions_afk(Sessions)
     end.
 
+-spec get_flattened_activities(sessions()) -> [map()].
+get_flattened_activities(Sessions) ->
+    lists:sublist(
+        lists:flatmap(fun session_activities_for_presence/1, maps:values(Sessions)),
+        ?MAX_FLATTENED_ACTIVITIES
+    ).
+
+-spec session_activities_for_presence(session_entry()) -> [map()].
+session_activities_for_presence(Session) ->
+    case maps:get(status, Session, offline) of
+        offline -> [];
+        invisible -> [];
+        _ -> normalize_activities(maps:get(activities, Session, []))
+    end.
+
+-spec normalize_activities(term()) -> [map()].
+normalize_activities(Activities) when is_list(Activities) ->
+    [Activity || Activity <- Activities, is_map(Activity)];
+normalize_activities(_) ->
+    [].
+
 -spec all_sessions_afk(sessions()) -> boolean().
 all_sessions_afk(Sessions) ->
     case maps:size(Sessions) of
@@ -80,12 +105,14 @@ collect_sessions_for_replace(Sessions) ->
     Status = get_current_status(Sessions),
     Mobile = get_flattened_mobile(Sessions),
     Afk = get_flattened_afk(Sessions),
+    Activities = get_flattened_activities(Sessions),
     BaseSessions = [
         #{
             <<"session_id">> => <<"all">>,
             <<"status">> => constants:status_type_atom(Status),
             <<"mobile">> => Mobile,
-            <<"afk">> => Afk
+            <<"afk">> => Afk,
+            <<"activities">> => Activities
         }
     ],
     SessionEntries = maps:fold(
@@ -95,7 +122,8 @@ collect_sessions_for_replace(Sessions) ->
                     <<"session_id">> => SessionId,
                     <<"status">> => constants:status_type_atom(maps:get(status, Session)),
                     <<"afk">> => maps:get(afk, Session, false),
-                    <<"mobile">> => maps:get(mobile, Session, false)
+                    <<"mobile">> => maps:get(mobile, Session, false),
+                    <<"activities">> => maps:get(activities, Session, [])
                 }
                 | Acc
             ]
@@ -195,6 +223,15 @@ get_flattened_afk_mobile_overrides_test() ->
 
 get_flattened_afk_empty_test() ->
     ?assertEqual(false, get_flattened_afk(#{})).
+
+get_flattened_activities_visible_sessions_test() ->
+    Game = #{<<"type">> => <<"game">>, <<"name">> => <<"Flux Racer">>},
+    Music = #{<<"type">> => <<"music">>, <<"name">> => <<"Playlist">>},
+    Sessions = #{
+        <<"s1">> => #{status => online, afk => false, mobile => false, activities => [Game]},
+        <<"s2">> => #{status => invisible, afk => false, mobile => false, activities => [Music]}
+    },
+    ?assertEqual([Game], get_flattened_activities(Sessions)).
 
 collect_sessions_for_replace_test() ->
     Sessions = #{

--- a/fluxer_gateway/src/session/session.erl
+++ b/fluxer_gateway/src/session/session.erl
@@ -40,6 +40,7 @@
     resume_status => status(),
     afk => boolean(),
     mobile => boolean(),
+    activities => [map()],
     presence_pid => pid() | undefined,
     presence_mref => reference() | undefined,
     socket_pid => pid() | undefined,

--- a/fluxer_gateway/src/session/session_connection_presence.erl
+++ b/fluxer_gateway/src/session/session_connection_presence.erl
@@ -58,7 +58,8 @@ build_presence_request(State) when is_map(State) ->
         status => maps:get(status, State),
         friend_ids => FriendIds,
         group_dm_recipients => DmRecipients,
-        custom_status => maps:get(custom_status, State, null)
+        custom_status => maps:get(custom_status, State, null),
+        <<"activities">> => maps:get(activities, State, [])
     }.
 
 -spec do_session_connect(pid(), attempt(), session_state()) ->
@@ -68,6 +69,7 @@ do_session_connect(Pid, Attempt, State) when is_map(State) ->
     Status = maps:get(status, State),
     Afk = maps:get(afk, State),
     Mobile = maps:get(mobile, State),
+    Activities = maps:get(activities, State, []),
     SocketPid = maps:get(socket_pid, State, undefined),
     FriendIds = presence_targets:friend_ids_from_state(State),
     DmRecipients = presence_targets:dm_recipients_from_state(State),
@@ -113,6 +115,7 @@ try_session_connect(
         status => Status,
         afk => Afk,
         mobile => Mobile,
+        <<"activities">> => Activities,
         socket_pid => SocketPid
     },
     ConnectStartedAt = gateway_timings:start(),

--- a/fluxer_gateway/src/session/session_init.erl
+++ b/fluxer_gateway/src/session/session_init.erl
@@ -201,6 +201,7 @@ extract_core_fields(
         resume_status => maps:get(resume_status, D, Status),
         afk => maps:get(afk, D, false),
         mobile => maps:get(mobile, D, false),
+        activities => normalize_activities(maps:get(activities, D, [])),
         presence_pid => undefined,
         presence_mref => undefined,
         socket_pid => SocketPid,
@@ -217,6 +218,12 @@ extract_core_fields(
         is_staff => IsStaff,
         e2ee_capable => maps:get(e2ee_capable, D, false)
     }.
+
+-spec normalize_activities(term()) -> [map()].
+normalize_activities(Activities) when is_list(Activities) ->
+    [Activity || Activity <- Activities, is_map(Activity)];
+normalize_activities(_) ->
+    [].
 
 -spec extract_extra_fields(map(), map() | undefined) -> map().
 extract_extra_fields(D, Ready) ->

--- a/fluxer_gateway/src/session/session_lifecycle.erl
+++ b/fluxer_gateway/src/session/session_lifecycle.erl
@@ -441,8 +441,10 @@ handle_presence_update_cast(Update, State) ->
     NewStatus = maps:get(status, Update, Status),
     NewAfk = maps:get(afk, Update, Afk),
     NewMobile = maps:get(mobile, Update, Mobile),
+    NewActivities = normalize_activities(maps:get(<<"activities">>, Update, maps:get(activities, State, []))),
     NewState = maybe_update_resume_status(
-        NewStatus, State#{status => NewStatus, afk => NewAfk, mobile => NewMobile}
+        NewStatus,
+        State#{status => NewStatus, afk => NewAfk, mobile => NewMobile, activities => NewActivities}
     ),
     send_presence_update(State, SessionId, NewStatus, NewAfk, NewMobile, Update),
     {noreply, NewState}.
@@ -468,8 +470,19 @@ send_presence_update(#{presence_pid := Pid}, SessionId, NewStatus, NewAfk, NewMo
             {ok, CS} -> BaseMsg#{<<"custom_status">> => CS};
             error -> BaseMsg
         end,
-    gen_server:cast(Pid, {presence_update, Msg}),
+    MsgWithActivities =
+        case maps:find(<<"activities">>, Update) of
+            {ok, Activities} -> Msg#{<<"activities">> => Activities};
+            error -> Msg
+        end,
+    gen_server:cast(Pid, {presence_update, MsgWithActivities}),
     ok.
+
+-spec normalize_activities(term()) -> [map()].
+normalize_activities(Activities) when is_list(Activities) ->
+    [Activity || Activity <- Activities, is_map(Activity)];
+normalize_activities(_) ->
+    [].
 
 -spec handle_initial_global_presences([map()], session_state()) -> {noreply, session_state()}.
 handle_initial_global_presences(Presences, State) ->
@@ -500,6 +513,7 @@ serialize_state(State) ->
         resume_status => maps:get(resume_status, State, maps:get(status, State)),
         afk => maps:get(afk, State),
         mobile => maps:get(mobile, State),
+        activities => maps:get(activities, State, []),
         buffer => maps:get(buffer, State),
         ready => maps:get(ready, State),
         bot => maps:get(bot, State, false),
@@ -532,6 +546,7 @@ serialize_transfer_identity(State) ->
         resume_status => maps:get(resume_status, State, maps:get(status, State)),
         afk => maps:get(afk, State),
         mobile => maps:get(mobile, State),
+        activities => maps:get(activities, State, []),
         socket_pid => undefined,
         guilds => session_init:normalize_guild_ids(maps:keys(maps:get(guilds, State, #{}))),
         ready => maps:get(ready, State),

--- a/fluxer_gateway/src/session/session_manager_shard_drain.erl
+++ b/fluxer_gateway/src/session/session_manager_shard_drain.erl
@@ -22,6 +22,8 @@
 
 -define(IDENTIFY_FLAG_DEBOUNCE_MESSAGE_REACTIONS, 16#2).
 -define(SESSION_RPC_RETRY_CONFIG, {1, 1000, 10000, 500}).
+-define(MAX_PRESENCE_ACTIVITIES, 4).
+-define(MAX_PRESENCE_ACTIVITY_TEXT_BYTES, 128).
 
 -type session_id() :: binary().
 -type session_ref() :: {pid(), reference()}.
@@ -186,6 +188,7 @@ build_session_data(Data, IdentifyData, Version, SocketPid, SessionId, UserDataMa
         status => session_manager_shard_lookup:parse_presence(Data, IdentifyData),
         afk => extract_afk(Presence),
         mobile => extract_mobile(Presence, Properties),
+        activities => extract_activities(Presence),
         socket_pid => SocketPid,
         guilds => filter_guild_ids_for_identify(Data, IdentifyData),
         ready => build_ready_data_for_session(Data),
@@ -272,6 +275,77 @@ extract_afk(P) when is_map(P) ->
     is_truthy(map_utils:get_safe(P, <<"afk">>, false));
 extract_afk(_) ->
     false.
+
+-spec extract_activities(term()) -> [map()].
+extract_activities(Presence) when is_map(Presence) ->
+    case map_utils:get_safe(Presence, <<"activities">>, []) of
+        Activities when is_list(Activities) -> normalize_activities(Activities);
+        _ -> []
+    end;
+extract_activities(_) ->
+    [].
+
+-spec normalize_activities([term()]) -> [map()].
+normalize_activities(Activities) ->
+    lists:sublist(
+        [Activity || {ok, Activity} <- [normalize_activity(Item) || Item <- Activities]],
+        ?MAX_PRESENCE_ACTIVITIES
+    ).
+
+-spec normalize_activity(term()) -> {ok, map()} | error.
+normalize_activity(Activity) when is_map(Activity) ->
+    Type = normalize_activity_type(map_utils:get_safe(Activity, <<"type">>, undefined)),
+    Name = normalize_activity_text(map_utils:get_safe(Activity, <<"name">>, undefined)),
+    case {Type, Name} of
+        {Type, Name} when is_binary(Type), is_binary(Name) ->
+            {ok,
+                maybe_put_activity_integer(
+                    <<"started_at">>,
+                    map_utils:get_safe(Activity, <<"started_at">>, undefined),
+                    maybe_put_activity_text(
+                        <<"details">>,
+                        map_utils:get_safe(Activity, <<"details">>, undefined),
+                        maybe_put_activity_text(
+                            <<"state">>, map_utils:get_safe(Activity, <<"state">>, undefined), #{
+                                <<"type">> => Type, <<"name">> => Name
+                            }
+                        )
+                    )
+                )};
+        _ ->
+            error
+    end;
+normalize_activity(_) ->
+    error.
+
+-spec normalize_activity_type(term()) -> binary() | undefined.
+normalize_activity_type(<<"game">>) -> <<"game">>;
+normalize_activity_type(<<"music">>) -> <<"music">>;
+normalize_activity_type(<<"software">>) -> <<"software">>;
+normalize_activity_type(_) -> undefined.
+
+-spec normalize_activity_text(term()) -> binary() | undefined.
+normalize_activity_text(Value) when
+    is_binary(Value),
+    Value =/= <<>>,
+    byte_size(Value) =< ?MAX_PRESENCE_ACTIVITY_TEXT_BYTES
+->
+    Value;
+normalize_activity_text(_) ->
+    undefined.
+
+-spec maybe_put_activity_text(binary(), term(), map()) -> map().
+maybe_put_activity_text(Key, Value, Activity) ->
+    case normalize_activity_text(Value) of
+        Text when is_binary(Text) -> Activity#{Key => Text};
+        undefined -> Activity
+    end.
+
+-spec maybe_put_activity_integer(binary(), term(), map()) -> map().
+maybe_put_activity_integer(Key, Value, Activity) when is_integer(Value), Value >= 0 ->
+    Activity#{Key => Value};
+maybe_put_activity_integer(_Key, _Value, Activity) ->
+    Activity.
 
 -spec is_truthy(term()) -> boolean().
 is_truthy(true) -> true;

--- a/fluxer_gateway/test/gateway_handler_tests.erl
+++ b/fluxer_gateway/test/gateway_handler_tests.erl
@@ -292,6 +292,41 @@ validate_presence_data_valid_test() ->
     {ok, Result} = gateway_handler_dispatch:validate_presence_data(Data),
     ?assertEqual(online, maps:get(status, Result)).
 
+validate_presence_data_activities_test() ->
+    Data = #{
+        <<"status">> => <<"online">>,
+        <<"activities">> => [
+            #{
+                <<"type">> => <<"game">>,
+                <<"name">> => <<"Flux Racer">>,
+                <<"state">> => <<"In match">>,
+                <<"details">> => <<"Ranked">>,
+                <<"started_at">> => 123
+            },
+            #{<<"type">> => <<"invalid">>, <<"name">> => <<"Dropped">>},
+            #{<<"type">> => <<"music">>, <<"name">> => <<"Playlist">>}
+        ]
+    },
+    {ok, Result} = gateway_handler_dispatch:validate_presence_data(Data),
+    ?assertEqual(
+        [
+            #{
+                <<"type">> => <<"game">>,
+                <<"name">> => <<"Flux Racer">>,
+                <<"state">> => <<"In match">>,
+                <<"details">> => <<"Ranked">>,
+                <<"started_at">> => 123
+            },
+            #{<<"type">> => <<"music">>, <<"name">> => <<"Playlist">>}
+        ],
+        maps:get(<<"activities">>, Result)
+    ).
+
+validate_presence_data_invalid_activities_clear_test() ->
+    Data = #{<<"status">> => <<"online">>, <<"activities">> => null},
+    {ok, Result} = gateway_handler_dispatch:validate_presence_data(Data),
+    ?assertEqual([], maps:get(<<"activities">>, Result)).
+
 validate_presence_data_missing_status_test() ->
     ?assertEqual(
         {error, invalid_presence},


### PR DESCRIPTION
## Summary
- add a bounded activities payload to gateway presence updates
- persist session activities and include them in presence broadcasts, member lists, and session replace payloads
- expose activity data through client presence state for RPC/game/music/software integrations

## Tests
- git diff --check
- not run: Erlang/rebar3 is unavailable in this environment
- not run: TypeScript typecheck; dependency install skipped after low-disk infrastructure failure

Bounty issue: fluxerapp/fluxer-meta#8