### PR TITLE
fix(caddy): add private ranges to caddy config to resolve docker ip

### DIFF
--- a/deploy/self-hosting/Caddyfile
+++ b/deploy/self-hosting/Caddyfile
@@ -1,3 +1,9 @@
+{
+	servers {
+		trusted_proxies static private_ranges
+	}
+}
+
 {$FLUXER_CADDY_SITE_ADDRESS} {
 	encode zstd gzip
 


### PR DESCRIPTION
Add server configuration for trusted proxies in Caddyfile

- Fixes #1026
- Fixes #1059

## Summary

- What changed:
Added private_ranges to default Caddyfile
- Why it is correct:
Commonly used configuration for applications behind a reverse proxy (caddy).
- Risk:
Minimal

## Verification

- Tests run: docker compose up -d in pre-configured environment
- Manual checks: able to access remote deployment, ip changed to public ip
- Screenshots or recordings: 
<img width="1409" height="98" alt="partial-bewitched-akitainu" src="https://github.com/user-attachments/assets/38d2ce53-2338-4af7-8f37-44b06c680d1f" />
<img width="859" height="103" alt="acrobatic-gargantuan-americancrayfish" src="https://github.com/user-attachments/assets/6ba46e19-2dc3-4f43-969f-0e7ac0d0b3e0" />

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None
