### PR TITLE
Enable SSO auto provision when general registration is disabled

### DIFF
--- a/fluxer_api/src/api/auth/services/SsoService.ts
+++ b/fluxer_api/src/api/auth/services/SsoService.ts
@@ -3,7 +3,6 @@
 import {createHash, randomBytes} from 'node:crypto';
 import {ProfileFieldPrivacyFlags} from '@fluxer/constants/src/UserConstants';
 import {ValidationErrorCodes} from '@fluxer/constants/src/ValidationErrorCodes';
-import {RegistrationClosedError} from '@fluxer/errors/src/domains/auth/RegistrationClosedError';
 import {RegistrationPendingApprovalError} from '@fluxer/errors/src/domains/auth/RegistrationPendingApprovalError';
 import {SsoRequiredError} from '@fluxer/errors/src/domains/auth/SsoRequiredError';
 import {ContentBlockedError} from '@fluxer/errors/src/domains/content/ContentBlockedError';
@@ -349,9 +348,6 @@ export class SsoService {
 			throw new SsoRequiredError();
 		}
 		const registrationConfig = await this.instanceConfigRepository.getRegistrationConfig();
-		if (registrationConfig.mode === 'closed') {
-			throw new RegistrationClosedError();
-		}
 		const pendingApproval = registrationConfig.mode === 'approval';
 		const user = await this.provisionUserFromClaims(claims, config, {pendingApproval});
 		if (pendingApproval) {


### PR DESCRIPTION
## Summary

- What changed: SSO auto provisiong works even when general registration is disabled
- Why it is correct: This is expected behaviour in SSO context.
- Risk: None

## Verification

- Tests run: None
- Manual checks: 
  - Registration disabled/SSO Auto Provisioning enabled/SSO Required enabled: Login with new SSO user. 
  - Registration disabled/SSO Auto Provisioning enabled/SSO Required disabled: Registration with none-SSO users not possible
  - Registration requires approval/SSO Auto Provisioning enabled/SSO Required enabled: Login with new SSO user - > Requires approval -> login after approval works.

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## Screen Recording
[Screencast_20260621_204921.webm](https://github.com/user-attachments/assets/670c9a3c-49c0-4055-8016-ce2fed7a2e2d)

## LLM Disclosure

- None. Code search and changes done organically by me.
