### PR TITLE
fix: add `/admin/` under SKIP_CONTENT_FILTER[...] array

### DIFF
--- a/fluxer_api/src/api/middleware/ContentFilterMiddleware.ts
+++ b/fluxer_api/src/api/middleware/ContentFilterMiddleware.ts
@@ -71,6 +71,7 @@ const SKIP_FIELD_SUFFIXES = [
 	'_tokens',
 ] as const;
 const SKIP_CONTENT_FILTER_PATH_PARTS = [
+	'/admin/',
 	'/auth/',
 	'/oauth2/',
 	'/reports/dsa/email/',

--- a/fluxer_api/src/api/middleware/ContentFilterMiddleware.ts
+++ b/fluxer_api/src/api/middleware/ContentFilterMiddleware.ts
@@ -71,7 +71,12 @@ const SKIP_FIELD_SUFFIXES = [
 	'_tokens',
 ] as const;
 const SKIP_CONTENT_FILTER_PATH_PARTS = [
-	'/admin/',
+	'/admin/audit-logs/search',
+	'/admin/guilds/search',
+	'/admin/messages/search',
+	'/admin/reports/search',
+	'/admin/users/lookup',
+	'/admin/users/search',
 	'/auth/',
 	'/oauth2/',
 	'/reports/dsa/email/',


### PR DESCRIPTION
This fixes an issue where you can't check or delete banned phrases, because the admin panel was going through the content check.

## Summary

- What changed: This fixes an issue where you can't check or delete banned phrases, because the admin panel was going through the content check.
- Why it is correct: There is already an array of paths where this should not be applied
- Risk: None, unless there are POST/PUT/PATCH endpoints that have /admin/ as path that are user accessible.

## Verification

- Tests run: None
- Manual checks: None
- Screenshots or recordings:


## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None