### PR TITLE
fix(gateway): restore Docker logging — remove /dev/null redirect and logger handler

### DIFF
--- a/fluxer_gateway/config/sys.config.template
+++ b/fluxer_gateway/config/sys.config.template
@@ -3,7 +3,7 @@
     {kernel, [
         {logger_level, warning},
         {logger, [
-            {handler, default, undefined}
+            {handler, default, logger_std_h, #{}}
         ]}
     ]},
     {sasl, [

--- a/fluxer_gateway/scripts/docker_entrypoint.sh
+++ b/fluxer_gateway/scripts/docker_entrypoint.sh
@@ -13,4 +13,4 @@ export FLUXER_ERLANG_COOKIE
 export FLUXER_ERLANG_DIST_PORT
 export RELX_REPLACE_OS_VARS="${RELX_REPLACE_OS_VARS:-true}"
 
-exec /opt/fluxer_gateway/bin/fluxer_gateway foreground >/dev/null 2>&1
+exec /opt/fluxer_gateway/bin/fluxer_gateway foreground


### PR DESCRIPTION
## Problem

Self-hosted instances report the gateway container appearing non-functional (`docker compose logs gateway` shows nothing, no NATS connection visible). Two compounding bugs cause this:

### Bug 1 — `docker_entrypoint.sh` silences all output

```sh
# Before (broken):
exec /opt/fluxer_gateway/bin/fluxer_gateway foreground >/dev/null 2>&1

# After (fixed):
exec /opt/fluxer_gateway/bin/fluxer_gateway foreground
```

The `>/dev/null 2>&1` redirect discards both stdout and stderr at the OS level, so `docker logs` / `docker compose logs gateway` always returns empty output. Startup errors, NATS connection failures, and panics are silently swallowed.

### Bug 2 — `sys.config.template` disables the default logger handler

```erlang
% Before (broken):
{logger, [{handler, default, undefined}]}

% After (fixed):
{logger, [{handler, default, logger_std_h, #{}}]}
```

`{handler, default, undefined}` removes the OTP default logger handler (which writes to stdout). Even after fixing Bug 1, the Erlang runtime would emit no log lines because the handler is gone.

## Effect

Together these two bugs make the gateway a black box for self-hosters — no way to diagnose misconfiguration or startup failures. Fixes: `docker compose logs gateway` now shows gateway startup lines, NATS connection status, and any errors.

Fixes #1144.
