### PR TITLE
feat(api): enable SSO auto provision when general registration is disabled

### DIFF
--- a/fluxer_api/src/api/auth/services/SsoService.ts
+++ b/fluxer_api/src/api/auth/services/SsoService.ts
@@ -3,7 +3,6 @@
 import {createHash, randomBytes} from 'node:crypto';
 import {ProfileFieldPrivacyFlags} from '@fluxer/constants/src/UserConstants';
 import {ValidationErrorCodes} from '@fluxer/constants/src/ValidationErrorCodes';
-import {RegistrationClosedError} from '@fluxer/errors/src/domains/auth/RegistrationClosedError';
 import {RegistrationPendingApprovalError} from '@fluxer/errors/src/domains/auth/RegistrationPendingApprovalError';
 import {SsoRequiredError} from '@fluxer/errors/src/domains/auth/SsoRequiredError';
 import {ContentBlockedError} from '@fluxer/errors/src/domains/content/ContentBlockedError';
@@ -362,9 +361,6 @@ export class SsoService {
 			throw new SsoRequiredError();
 		}
 		const registrationConfig = await this.instanceConfigRepository.getRegistrationConfig();
-		if (registrationConfig.mode === 'closed') {
-			throw new RegistrationClosedError();
-		}
 		const pendingApproval = registrationConfig.mode === 'approval';
 		const user = await this.provisionUserFromClaims(claims, config, {pendingApproval});
 		if (pendingApproval) {

--- a/fluxer_api/src/api/auth/tests/SsoFlow.test.ts
+++ b/fluxer_api/src/api/auth/tests/SsoFlow.test.ts
@@ -3,6 +3,7 @@
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from 'vitest';
 import type {ApiTestHarness} from '../../test/ApiTestHarness';
 import {createBuilder, createBuilderWithoutAuth} from '../../test/TestRequestBuilder';
+import {getInstanceConfigRepository} from '../../middleware/ServiceSingletons';
 import {
 	createAuthHarness,
 	createTestAccount,
@@ -523,10 +524,11 @@ describe('Auth SSO flow', () => {
 		afterEach(async () => {
 			await disableSso(harness, admin.token);
 		});
-		it('respects auto_provision flag', async () => {
+		it('respects auto_provision flag with registration closed', async () => {
 			await enableSso(harness, admin.token, {
 				auto_provision: false,
 			});
+			await getInstanceConfigRepository().setRegistrationConfig({mode: 'closed'});
 			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness)
 				.post('/auth/sso/start')
 				.body({redirect_to: '/me'})
@@ -539,6 +541,25 @@ describe('Auth SSO flow', () => {
 					state: startData.state,
 				})
 				.expect(403)
+				.execute();
+		});
+		it('allows SSO auto provisioning when registration is closed', async () => {
+			await enableSso(harness, admin.token, {
+				auto_provision: true,
+			});
+			await getInstanceConfigRepository().setRegistrationConfig({mode: 'closed'});
+			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness)
+				.post('/auth/sso/start')
+				.body({redirect_to: '/me'})
+				.execute();
+			const email = `sso-noprovision-${Date.now()}@example.com`;
+			await createBuilderWithoutAuth(harness)
+				.post('/auth/sso/complete')
+				.body({
+					code: email,
+					state: startData.state,
+				})
+				.expect(200)
 				.execute();
 		});
 	});


### PR DESCRIPTION
## Summary
- Recreation of #1114 
- What changed: SSO auto provisiong works even when general registration is disabled
- Why it is correct: This is expected behaviour in SSO context.
- Risk: None

## Verification

- Tests run: Default test suite including new and adapted tests for this scenario.
- Manual checks: 
  - Registration disabled/SSO Auto Provisioning enabled/SSO Required enabled: Login with new SSO user. 
  - Registration disabled/SSO Auto Provisioning enabled/SSO Required disabled: Registration with none-SSO users not possible
  - Registration requires approval/SSO Auto Provisioning enabled/SSO Required enabled: Login with new SSO user - > Requires approval -> login after approval works.

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## Screen Recording
[Screencast_20260621_204921.webm](https://github.com/user-attachments/assets/670c9a3c-49c0-4055-8016-ce2fed7a2e2d)

## LLM Disclosure

- None. Code search and changes done organically by me.

Closes #1112 
