### PR TITLE
feat: use client-provided SSO redirectUri

### DIFF
--- a/fluxer_api/src/api/auth/AuthRequestService.ts
+++ b/fluxer_api/src/api/auth/AuthRequestService.ts
@@ -151,7 +151,10 @@ export class AuthRequestService {
 	}
 
 	startSso(data: SsoStartRequest) {
-		return this.ssoService.startLogin(data.redirect_to ?? undefined);
+		return this.ssoService.startLogin({
+			redirectTo: data.redirect_to ?? undefined,
+			redirectUri: data.redirect_uri ?? undefined,
+		});
 	}
 
 	completeSso(data: SsoCompleteRequest, request: Request) {

--- a/fluxer_api/src/api/auth/services/SsoService.ts
+++ b/fluxer_api/src/api/auth/services/SsoService.ts
@@ -264,11 +264,11 @@ export class SsoService {
 		const codeVerifier = randomBase64UrlToken(CODE_VERIFIER_BYTE_LENGTH);
 		const codeChallenge = buildCodeChallenge(codeVerifier);
 		const nonce = randomBase64UrlToken(NONCE_BYTE_LENGTH);
-		let redirect_uri = sanitizeSsoRedirectTo(redirectTo) ?? config.redirectUri;
+		const redirectUri = sanitizeSsoRedirectTo(redirectTo) ?? config.redirectUri;
 		const statePayload: SsoStatePayload = {
 			codeVerifier,
 			nonce,
-			redirectTo: redirect_uri,
+			redirectTo: redirectUri,
 			createdAt: Date.now(),
 		};
 		const {cache} = this.apiContext.services;
@@ -276,7 +276,7 @@ export class SsoService {
 		const searchParams = new URLSearchParams({
 			response_type: 'code',
 			client_id: config.clientId ?? '',
-			redirect_uri: redirect_uri,
+			redirect_uri: redirectUri,
 			scope: config.scope,
 			state,
 			code_challenge: codeChallenge,
@@ -298,7 +298,7 @@ export class SsoService {
 				throw new FeatureTemporarilyDisabledError();
 			}
 		}
-		return {authorization_url: authorizationUrlString, state, redirect_uri: redirect_uri};
+		return {authorization_url: authorizationUrlString, state, redirect_uri: redirectUri};
 	}
 
 	async completeLogin({code, state, request}: {code: string; state: string; request: Request}): Promise<{

--- a/fluxer_api/src/api/auth/services/SsoService.ts
+++ b/fluxer_api/src/api/auth/services/SsoService.ts
@@ -52,7 +52,7 @@ import {parseTokenEndpointResponse, sanitizeSsoRedirectTo, tryDiscoverOidcProvid
 interface SsoStatePayload {
 	codeVerifier: string;
 	nonce: string;
-	redirectTo?: string;
+	redirectTo: string;
 	createdAt: number;
 }
 
@@ -264,10 +264,11 @@ export class SsoService {
 		const codeVerifier = randomBase64UrlToken(CODE_VERIFIER_BYTE_LENGTH);
 		const codeChallenge = buildCodeChallenge(codeVerifier);
 		const nonce = randomBase64UrlToken(NONCE_BYTE_LENGTH);
+		let redirect_uri = sanitizeSsoRedirectTo(redirectTo) ?? config.redirectUri;
 		const statePayload: SsoStatePayload = {
 			codeVerifier,
 			nonce,
-			redirectTo: sanitizeSsoRedirectTo(redirectTo),
+			redirectTo: redirect_uri,
 			createdAt: Date.now(),
 		};
 		const {cache} = this.apiContext.services;
@@ -275,7 +276,7 @@ export class SsoService {
 		const searchParams = new URLSearchParams({
 			response_type: 'code',
 			client_id: config.clientId ?? '',
-			redirect_uri: config.redirectUri,
+			redirect_uri: redirect_uri,
 			scope: config.scope,
 			state,
 			code_challenge: codeChallenge,
@@ -297,7 +298,7 @@ export class SsoService {
 				throw new FeatureTemporarilyDisabledError();
 			}
 		}
-		return {authorization_url: authorizationUrlString, state, redirect_uri: config.redirectUri};
+		return {authorization_url: authorizationUrlString, state, redirect_uri: redirect_uri};
 	}
 
 	async completeLogin({code, state, request}: {code: string; state: string; request: Request}): Promise<{
@@ -314,6 +315,7 @@ export class SsoService {
 		const tokenResponse = await this.exchangeCode({
 			code,
 			codeVerifier: statePayload.codeVerifier,
+			redirectUri: statePayload.redirectTo,
 			config,
 		});
 		const claims = await this.resolveClaims(tokenResponse, config, statePayload.nonce);
@@ -764,10 +766,12 @@ export class SsoService {
 	private async exchangeCode({
 		code,
 		codeVerifier,
+		redirectUri,
 		config,
 	}: {
 		code: string;
 		codeVerifier: string;
+		redirectUri: string;
 		config: ResolvedSsoConfig;
 	}): Promise<{
 		id_token?: string;
@@ -779,7 +783,7 @@ export class SsoService {
 		const body = new URLSearchParams({
 			grant_type: 'authorization_code',
 			code,
-			redirect_uri: config.redirectUri,
+			redirect_uri: redirectUri,
 			client_id: config.clientId ?? '',
 			code_verifier: codeVerifier,
 		});

--- a/fluxer_api/src/api/auth/services/SsoService.ts
+++ b/fluxer_api/src/api/auth/services/SsoService.ts
@@ -52,7 +52,8 @@ import {parseTokenEndpointResponse, sanitizeSsoRedirectTo, tryDiscoverOidcProvid
 interface SsoStatePayload {
 	codeVerifier: string;
 	nonce: string;
-	redirectTo: string;
+	redirectTo?: string;
+	redirectUri?: string;
 	createdAt: number;
 }
 
@@ -96,6 +97,7 @@ interface JwksCacheEntry {
 const CODE_VERIFIER_BYTE_LENGTH = 32;
 const STATE_BYTE_LENGTH = 16;
 const NONCE_BYTE_LENGTH = 16;
+const MOBILE_SSO_REDIRECT_URI = 'fluxer://auth/sso/callback';
 
 function randomBase64UrlToken(byteLength: number): string {
 	return randomBytes(byteLength).toString('base64url');
@@ -116,6 +118,14 @@ function buildStateCacheKey(state: string): string {
 function buildDiscoveryCacheKey(issuer: string): string {
 	const key = createHash('sha256').update(issuer).digest('hex').slice(0, 32);
 	return `sso:oidc-discovery:${key}`;
+}
+
+function resolveSsoRedirectUri(requestedRedirectUri: string | undefined, defaultRedirectUri: string): string {
+	if (!requestedRedirectUri) return defaultRedirectUri;
+	const trimmed = requestedRedirectUri.trim();
+	if (!trimmed) return defaultRedirectUri;
+	if (trimmed === defaultRedirectUri || trimmed === MOBILE_SSO_REDIRECT_URI) return trimmed;
+	throw InputValidationError.fromCode('redirect_uri', ValidationErrorCodes.INVALID_URL_FORMAT);
 }
 
 function coerceEmailVerified(value: unknown): boolean | undefined {
@@ -254,7 +264,7 @@ export class SsoService {
 		return config.enabled && config.ready && config.enforced;
 	}
 
-	async startLogin(redirectTo?: string): Promise<{
+	async startLogin({redirectTo, redirectUri}: {redirectTo?: string; redirectUri?: string} = {}): Promise<{
 		authorization_url: string;
 		state: string;
 		redirect_uri: string;
@@ -264,11 +274,12 @@ export class SsoService {
 		const codeVerifier = randomBase64UrlToken(CODE_VERIFIER_BYTE_LENGTH);
 		const codeChallenge = buildCodeChallenge(codeVerifier);
 		const nonce = randomBase64UrlToken(NONCE_BYTE_LENGTH);
-		const redirectUri = sanitizeSsoRedirectTo(redirectTo) ?? config.redirectUri;
+		const ssoRedirectUri = resolveSsoRedirectUri(redirectUri, config.redirectUri);
 		const statePayload: SsoStatePayload = {
 			codeVerifier,
 			nonce,
-			redirectTo: redirectUri,
+			redirectTo: sanitizeSsoRedirectTo(redirectTo),
+			redirectUri: ssoRedirectUri,
 			createdAt: Date.now(),
 		};
 		const {cache} = this.apiContext.services;
@@ -276,7 +287,7 @@ export class SsoService {
 		const searchParams = new URLSearchParams({
 			response_type: 'code',
 			client_id: config.clientId ?? '',
-			redirect_uri: redirectUri,
+			redirect_uri: ssoRedirectUri,
 			scope: config.scope,
 			state,
 			code_challenge: codeChallenge,
@@ -298,7 +309,7 @@ export class SsoService {
 				throw new FeatureTemporarilyDisabledError();
 			}
 		}
-		return {authorization_url: authorizationUrlString, state, redirect_uri: redirectUri};
+		return {authorization_url: authorizationUrlString, state, redirect_uri: ssoRedirectUri};
 	}
 
 	async completeLogin({code, state, request}: {code: string; state: string; request: Request}): Promise<{
@@ -315,7 +326,7 @@ export class SsoService {
 		const tokenResponse = await this.exchangeCode({
 			code,
 			codeVerifier: statePayload.codeVerifier,
-			redirectUri: statePayload.redirectTo,
+			redirectUri: statePayload.redirectUri ?? config.redirectUri,
 			config,
 		});
 		const claims = await this.resolveClaims(tokenResponse, config, statePayload.nonce);

--- a/fluxer_api/src/api/auth/tests/SsoFlow.test.ts
+++ b/fluxer_api/src/api/auth/tests/SsoFlow.test.ts
@@ -29,6 +29,13 @@ interface SsoStatusResponse {
 	enabled: boolean;
 	enforced: boolean;
 	display_name?: string;
+	redirect_uri: string;
+}
+
+function getAuthorizationUrlParam(authorizationUrlString: string, param: string): string | null {
+	const queryStart = authorizationUrlString.indexOf('?');
+	if (queryStart === -1) return null;
+	return new URLSearchParams(authorizationUrlString.slice(queryStart + 1)).get(param);
 }
 
 describe('Auth SSO flow', () => {
@@ -130,6 +137,7 @@ describe('Auth SSO flow', () => {
 			expect(authUrlString).toContain('code_challenge_method=S256');
 			expect(authUrlString).toContain('code_challenge=');
 			expect(authUrlString).toContain('nonce=');
+			expect(getAuthorizationUrlParam(authUrlString, 'redirect_uri')).toBe(startData.redirect_uri);
 			if (authUrlString.startsWith('http://') || authUrlString.startsWith('https://')) {
 				const authUrl = new URL(authUrlString);
 				const stateParam = authUrl.searchParams.get('state');
@@ -151,6 +159,7 @@ describe('Auth SSO flow', () => {
 				.execute();
 			expect(completeData.token).toBeTruthy();
 			expect(completeData.user_id).toBeTruthy();
+			expect(completeData.redirect_to).toBe('/me');
 			const meData = await createBuilder<{
 				email: string | null;
 			}>(harness, completeData.token)
@@ -169,6 +178,34 @@ describe('Auth SSO flow', () => {
 			expect(startData.redirect_uri).toContain('/auth/sso/callback');
 			expect(startData.redirect_uri).not.toContain('evil.example');
 			expect(startData.authorization_url).toContain(encodeURIComponent(startData.redirect_uri));
+		});
+		it('uses the requested mobile SSO redirect URI without changing the post-login redirect', async () => {
+			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness)
+				.post('/auth/sso/start')
+				.body({
+					redirect_to: '/me',
+					redirect_uri: 'fluxer://auth/sso/callback',
+				})
+				.execute();
+			expect(startData.redirect_uri).toBe('fluxer://auth/sso/callback');
+			expect(getAuthorizationUrlParam(startData.authorization_url, 'redirect_uri')).toBe('fluxer://auth/sso/callback');
+			const email = `sso-mobile-redirect-${Date.now()}@example.com`;
+			const completeData = await createBuilderWithoutAuth<SsoCompleteResponse>(harness)
+				.post('/auth/sso/complete')
+				.body({
+					code: email,
+					state: startData.state,
+				})
+				.execute();
+			expect(completeData.token).toBeTruthy();
+			expect(completeData.redirect_to).toBe('/me');
+		});
+		it('rejects unapproved SSO redirect URIs', async () => {
+			await createBuilderWithoutAuth(harness)
+				.post('/auth/sso/start')
+				.body({redirect_uri: 'https://evil.example/auth/sso/callback'})
+				.expect(400, 'INVALID_FORM_BODY')
+				.execute();
 		});
 	});
 	describe('redirect validation', () => {
@@ -198,7 +235,7 @@ describe('Auth SSO flow', () => {
 					state: startData.state,
 				})
 				.execute();
-			expect(completeData.redirect_to).toBe(startData.redirect_uri);
+			expect(completeData.redirect_to).toBe('');
 		});
 		it('rejects protocol-relative redirects', async () => {
 			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness)
@@ -213,7 +250,7 @@ describe('Auth SSO flow', () => {
 					state: startData.state,
 				})
 				.execute();
-			expect(completeData.redirect_to).toBe(startData.redirect_uri);
+			expect(completeData.redirect_to).toBe('');
 		});
 		it('rejects redirects with newlines', async () => {
 			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness)
@@ -228,7 +265,7 @@ describe('Auth SSO flow', () => {
 					state: startData.state,
 				})
 				.execute();
-			expect(completeData.redirect_to).toBe(startData.redirect_uri);
+			expect(completeData.redirect_to).toBe('');
 		});
 		it('rejects too long redirects', async () => {
 			const longRedirect = `/${'a'.repeat(2100)}`;
@@ -251,7 +288,7 @@ describe('Auth SSO flow', () => {
 					state: startData.state,
 				})
 				.execute();
-			expect(completeData.redirect_to.trim()).toBe(startData.redirect_uri);
+			expect(completeData.redirect_to.trim()).toBe('');
 		});
 		it('treats empty redirect as missing', async () => {
 			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness)
@@ -266,7 +303,7 @@ describe('Auth SSO flow', () => {
 					state: startData.state,
 				})
 				.execute();
-			expect(completeData.redirect_to.trim()).toBe(startData.redirect_uri);
+			expect(completeData.redirect_to.trim()).toBe('');
 		});
 	});
 	describe('state validation', () => {

--- a/fluxer_api/src/api/auth/tests/SsoFlow.test.ts
+++ b/fluxer_api/src/api/auth/tests/SsoFlow.test.ts
@@ -198,7 +198,7 @@ describe('Auth SSO flow', () => {
 					state: startData.state,
 				})
 				.execute();
-			expect(completeData.redirect_to).toBe('');
+			expect(completeData.redirect_to).toBe(startData.redirect_uri);
 		});
 		it('rejects protocol-relative redirects', async () => {
 			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness)
@@ -213,7 +213,7 @@ describe('Auth SSO flow', () => {
 					state: startData.state,
 				})
 				.execute();
-			expect(completeData.redirect_to).toBe('');
+			expect(completeData.redirect_to).toBe(startData.redirect_uri);
 		});
 		it('rejects redirects with newlines', async () => {
 			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness)
@@ -228,7 +228,7 @@ describe('Auth SSO flow', () => {
 					state: startData.state,
 				})
 				.execute();
-			expect(completeData.redirect_to).toBe('');
+			expect(completeData.redirect_to).toBe(startData.redirect_uri);
 		});
 		it('rejects too long redirects', async () => {
 			const longRedirect = `/${'a'.repeat(2100)}`;
@@ -251,7 +251,7 @@ describe('Auth SSO flow', () => {
 					state: startData.state,
 				})
 				.execute();
-			expect(completeData.redirect_to.trim()).toBe('');
+			expect(completeData.redirect_to.trim()).toBe(startData.redirect_uri);
 		});
 		it('treats empty redirect as missing', async () => {
 			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness)
@@ -266,7 +266,7 @@ describe('Auth SSO flow', () => {
 					state: startData.state,
 				})
 				.execute();
-			expect(completeData.redirect_to.trim()).toBe('');
+			expect(completeData.redirect_to.trim()).toBe(startData.redirect_uri);
 		});
 	});
 	describe('state validation', () => {

--- a/fluxer_api/src/api/openapi/openapi.json
+++ b/fluxer_api/src/api/openapi/openapi.json
@@ -26323,7 +26323,7 @@
 				"properties": {
 					"authorization_url": {"type": "string", "description": "URL to redirect user to for SSO authentication"},
 					"state": {"type": "string", "description": "State parameter for CSRF protection"},
-					"redirect_uri": {"type": "string", "description": "Redirect URI after SSO completion"}
+					"redirect_uri": {"type": "string", "description": "OAuth redirect URI used for the SSO provider callback"}
 				},
 				"required": ["authorization_url", "state", "redirect_uri"]
 			},
@@ -26333,6 +26333,10 @@
 					"redirect_to": {
 						"anyOf": [{"type": "string"}, {"type": "null"}],
 						"description": "URL to redirect to after SSO completion"
+					},
+					"redirect_uri": {
+						"anyOf": [{"type": "string"}, {"type": "null"}],
+						"description": "OAuth redirect URI to use for the SSO provider callback"
 					}
 				}
 			},

--- a/fluxer_app/src/features/auth/commands/AuthenticationCommands.ts
+++ b/fluxer_app/src/features/auth/commands/AuthenticationCommands.ts
@@ -16,6 +16,9 @@ import type {ValueOf} from '@fluxer/constants/src/ValueOf';
 import type {
 	AuthRegistrationPendingApprovalResponse,
 	RegisterRequest,
+	SsoCompleteResponse,
+	SsoStartRequest,
+	SsoStartResponse,
 } from '@fluxer/schema/src/domains/auth/AuthSchemas';
 import type {UserPartial} from '@fluxer/schema/src/domains/user/UserResponseSchemas';
 import type {AuthenticationResponseJSON, PublicKeyCredentialRequestOptionsJSON} from '@simplewebauthn/browser';
@@ -627,20 +630,26 @@ export async function completeLogin(
 	}
 }
 
-export async function startSso(redirectTo?: string): Promise<{
-	authorization_url: string;
-}> {
-	const response = await http.post<{
-		authorization_url: string;
-	}>(Endpoints.AUTH_SSO_START, {
-		body: {redirect_to: redirectTo},
+export async function startSso({
+	redirectTo,
+	redirectUri,
+}: {
+	redirectTo?: string;
+	redirectUri?: string;
+} = {}): Promise<SsoStartResponse> {
+	const body: SsoStartRequest = {
+		redirect_to: redirectTo,
+		redirect_uri: redirectUri,
+	};
+	const response = await http.post<SsoStartResponse>(Endpoints.AUTH_SSO_START, {
+		body,
 		headers: withPlatformHeader(),
 	});
 	return response.body;
 }
 
-export async function completeSso({code, state}: {code: string; state: string}): Promise<TokenResponse> {
-	const response = await http.post<TokenResponse>(Endpoints.AUTH_SSO_COMPLETE, {
+export async function completeSso({code, state}: {code: string; state: string}): Promise<SsoCompleteResponse> {
+	const response = await http.post<SsoCompleteResponse>(Endpoints.AUTH_SSO_COMPLETE, {
 		body: {code, state},
 		headers: withPlatformHeader(),
 	});

--- a/fluxer_app/src/features/auth/state/AuthFlow.ts
+++ b/fluxer_app/src/features/auth/state/AuthFlow.ts
@@ -168,13 +168,17 @@ export function getPendingSsoRedirectTo(): string | undefined {
 	}
 }
 
-export async function startSsoLogin({redirectTo}: {redirectTo?: string}): Promise<{
+export async function startSsoLogin({redirectTo, redirectUri}: {redirectTo?: string; redirectUri?: string}): Promise<{
 	authorizationUrl: string;
+	redirectUri: string;
 }> {
 	const safeRedirectTo = safeRedirectTarget(redirectTo);
-	const result = await AuthenticationCommands.startSso(safeRedirectTo ?? undefined);
+	const result = await AuthenticationCommands.startSso({
+		redirectTo: safeRedirectTo ?? undefined,
+		redirectUri,
+	});
 	storeSsoRedirectTo(safeRedirectTo ?? undefined);
-	return {authorizationUrl: result.authorization_url};
+	return {authorizationUrl: result.authorization_url, redirectUri: result.redirect_uri};
 }
 
 export async function completeSsoLogin({code, state}: {code: string; state: string}): Promise<LoginSuccessPayload> {

--- a/packages/schema/src/domains/auth/AuthSchemas.ts
+++ b/packages/schema/src/domains/auth/AuthSchemas.ts
@@ -135,7 +135,7 @@ export type SsoStatusResponse = z.infer<typeof SsoStatusResponse>;
 export const SsoStartResponse = z.object({
 	authorization_url: z.string().describe('URL to redirect user to for SSO authentication'),
 	state: z.string().describe('State parameter for CSRF protection'),
-	redirect_uri: z.string().describe('Redirect URI after SSO completion'),
+	redirect_uri: z.string().describe('OAuth redirect URI used for the SSO provider callback'),
 });
 
 export type SsoStartResponse = z.infer<typeof SsoStartResponse>;
@@ -254,6 +254,7 @@ export type HandoffStatusResponse = z.infer<typeof HandoffStatusResponse>;
 
 export const SsoStartRequest = z.object({
 	redirect_to: createStringType(0, 2048).nullish().describe('URL to redirect to after SSO completion'),
+	redirect_uri: createStringType(0, 2048).nullish().describe('OAuth redirect URI to use for the SSO provider callback'),
 });
 
 export type SsoStartRequest = z.infer<typeof SsoStartRequest>;


### PR DESCRIPTION
Use client-provided SSO redirectUri when available. Otherwise derive from instance config.

Resolves #1151.

## Summary

- What changed: Removed relevant fixed references to Config.webAppEndpoint for SsoRedirectUri and replaced them with the sanitized client provided RedirectUri with fallback to the config-derived RedirectUri
- Why it is correct: This allows for fluxer:// redirect URIs for mobile clients.
- Risk: None

## Verification

- Tests run: N/A
- Manual checks: Incoming
- Screenshots or recordings: Incoming

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None.
