### PR TITLE
fix(media-proxy): handle coalescer future cancellation with optimal drop guard

### DIFF
--- a/fluxer_media_proxy/src/coalescer.rs
+++ b/fluxer_media_proxy/src/coalescer.rs
@@ -71,10 +71,38 @@ impl ByteCoalescer {
             crate::metrics::GLOBAL
                 .coalescer_leader
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+            struct CleanupGuard<'a> {
+                in_flight: &'a Mutex<HashMap<String, Arc<Slot>>>,
+                key: &'a str,
+                slot: &'a Arc<Slot>,
+                completed: bool,
+            }
+
+            impl Drop for CleanupGuard<'_> {
+                fn drop(&mut self) {
+                    if !self.completed {
+                        self.in_flight.lock().remove(self.key);
+                        let mut state = self.slot.state.lock();
+                        *state = Some(Err(CoalescerError::WorkFailed));
+                        self.slot.notify.notify_waiters();
+                    }
+                }
+            }
+
+            let mut guard = CleanupGuard {
+                in_flight: &self.in_flight,
+                key: &key,
+                slot: &slot,
+                completed: false,
+            };
+
             let result = work().await.map(Bytes::from).map_err(coalesced_work_error);
             *slot.state.lock() = Some(result.clone());
+            guard.completed = true;
             slot.notify.notify_waiters();
             self.in_flight.lock().remove(&key);
+            
             result
         } else {
             crate::metrics::GLOBAL

--- a/fluxer_media_proxy/src/coalescer.rs
+++ b/fluxer_media_proxy/src/coalescer.rs
@@ -100,9 +100,10 @@ impl ByteCoalescer {
             let result = work().await.map(Bytes::from).map_err(coalesced_work_error);
             *slot.state.lock() = Some(result.clone());
             guard.completed = true;
+            drop(guard);
             slot.notify.notify_waiters();
             self.in_flight.lock().remove(&key);
-            
+
             result
         } else {
             crate::metrics::GLOBAL

--- a/fluxer_media_proxy/src/coalescer.rs
+++ b/fluxer_media_proxy/src/coalescer.rs
@@ -25,6 +25,24 @@ pub struct ByteCoalescer {
     in_flight: Mutex<HashMap<String, Arc<Slot>>>,
 }
 
+struct CleanupGuard<'a> {
+    in_flight: &'a Mutex<HashMap<String, Arc<Slot>>>,
+    key: &'a str,
+    slot: &'a Arc<Slot>,
+    completed: bool,
+}
+
+impl Drop for CleanupGuard<'_> {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.in_flight.lock().remove(self.key);
+            let mut state = self.slot.state.lock();
+            *state = Some(Err(CoalescerError::WorkFailed));
+            self.slot.notify.notify_waiters();
+        }
+    }
+}
+
 impl ByteCoalescer {
     pub fn new() -> Self {
         Self::default()
@@ -71,24 +89,6 @@ impl ByteCoalescer {
             crate::metrics::GLOBAL
                 .coalescer_leader
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-            struct CleanupGuard<'a> {
-                in_flight: &'a Mutex<HashMap<String, Arc<Slot>>>,
-                key: &'a str,
-                slot: &'a Arc<Slot>,
-                completed: bool,
-            }
-
-            impl Drop for CleanupGuard<'_> {
-                fn drop(&mut self) {
-                    if !self.completed {
-                        self.in_flight.lock().remove(self.key);
-                        let mut state = self.slot.state.lock();
-                        *state = Some(Err(CoalescerError::WorkFailed));
-                        self.slot.notify.notify_waiters();
-                    }
-                }
-            }
 
             let mut guard = CleanupGuard {
                 in_flight: &self.in_flight,

--- a/fluxer_media_proxy/src/coalescer.rs
+++ b/fluxer_media_proxy/src/coalescer.rs
@@ -92,7 +92,7 @@ impl ByteCoalescer {
 
             let mut guard = CleanupGuard {
                 in_flight: &self.in_flight,
-                key: &key,
+                key: key.as_str(),
                 slot: &slot,
                 completed: false,
             };


### PR DESCRIPTION
Refs #1146

This PR resolves the `coalescer_timeout_asset_image` issue where certain media (like emojis) would indefinitely timeout for specific sizes while succeeding for others.

## Summary

- **What changed:** Added a `CleanupGuard` (`Drop` guard) utilizing a `completed` flag to the `run_once_until` method in `fluxer_media_proxy/src/coalescer.rs`.
- **Why it is correct:** If the leader's tokio future is unexpectedly dropped or aborted, the guard ensures the `in_flight` map is cleaned up and waiters are notified with a `WorkFailed` error. By utilizing a `completed` flag, the drop guard's cleanup logic is safely bypassed on the happy path. This avoids redundant state locking and race conditions, making the coalescer fully cancellation-safe with zero overhead for successful requests.
- **Risk:** Low. The change is strictly isolated to the coalescer's internal state management.

## Verification

- **Tests run:** Existing unit tests for `ByteCoalescer` in `coalescer.rs` pass successfully (`cargo test -p fluxer_media_proxy`).
- **Manual checks:** Verified there are no redundant state locks when the leader completes successfully.
- **Screenshots or recordings:** N/A

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure
Used gemini to translate the summary, and fix grammar mistakes.
