### PR TITLE
feat(tools): add Dart SDK validation workflow

### DIFF
--- a/.github/workflows/dart-sdk-validation.yml
+++ b/.github/workflows/dart-sdk-validation.yml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+name: Dart SDK Validation
+
+on:
+  pull_request:
+    paths:
+      - 'fluxer_api/src/api/openapi/openapi.json'
+      - 'tools/dart_sdk_validation/**'
+      - 'scripts/validate_dart_sdk.sh'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dart-sdk-validation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dart-sdk-validation:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+        with:
+          sdk: stable
+
+      - name: Validate Dart SDK generation
+        run: |
+          chmod +x scripts/validate_dart_sdk.sh
+          ./scripts/validate_dart_sdk.sh

--- a/scripts/validate_dart_sdk.sh
+++ b/scripts/validate_dart_sdk.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Validates that the repo OpenAPI spec can generate a compatible Dart SDK.
+# Usage: ./scripts/validate_dart_sdk.sh [path/to/openapi.json]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATION_DIR="$REPO_ROOT/tools/dart_sdk_validation"
+DEFAULT_SPEC="$REPO_ROOT/fluxer_api/src/api/openapi/openapi.json"
+SPEC_PATH="${1:-$DEFAULT_SPEC}"
+
+if [[ ! -f "$SPEC_PATH" ]]; then
+  echo "ERROR: OpenAPI spec not found: $SPEC_PATH"
+  exit 1
+fi
+
+echo "=== Step 1/5: Checking prerequisites ==="
+command -v dart >/dev/null 2>&1 || { echo "ERROR: dart not found"; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 not found"; exit 1; }
+
+echo "=== Step 2/5: Copying and patching OpenAPI spec ==="
+cp "$SPEC_PATH" "$VALIDATION_DIR/openapi.json"
+python3 "$VALIDATION_DIR/scripts/patch_openapi_spec.py" "$VALIDATION_DIR/openapi.json"
+
+echo "=== Step 3/5: Generating SDK ==="
+cd "$VALIDATION_DIR"
+find lib/ -mindepth 1 ! -name '.*' ! -name '.gitkeep' -exec rm -rf {} + 2>/dev/null || true
+dart pub get
+dart run openapi_sdk_gen --file openapi_generator.yaml
+
+echo "=== Step 4/5: Running build_runner ==="
+dart run build_runner build --delete-conflicting-outputs
+
+echo "=== Step 5/5: Running dart analyze ==="
+dart analyze --no-fatal-warnings
+
+echo "=== Validation successful ==="
+echo "OpenAPI spec is compatible with Dart SDK generation"

--- a/tools/dart_sdk_validation/build.yaml
+++ b/tools/dart_sdk_validation/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          checked: true

--- a/tools/dart_sdk_validation/openapi_generator.yaml
+++ b/tools/dart_sdk_validation/openapi_generator.yaml
@@ -1,0 +1,17 @@
+openapi_generator:
+  schema_path: openapi.json
+  output_directory: lib
+  json_serializer: json_serializable
+  root_client: true
+  root_client_name: FluxerClient
+  client_postfix: Api
+  export_file: true
+  put_in_folder: true
+  put_clients_in_folder: false
+  enums_to_json: true
+  unknown_enum_value: true
+  enums_parent_prefix: true
+  mark_files_as_generated: true
+  original_http_response: false
+  include_if_null: true
+  path_method_name: false

--- a/tools/dart_sdk_validation/pubspec.yaml
+++ b/tools/dart_sdk_validation/pubspec.yaml
@@ -1,0 +1,19 @@
+name: dart_sdk_validation
+publish_to: none
+description: Throwaway package for validating OpenAPI spec against Dart SDK generation.
+
+environment:
+  sdk: ">=3.10.0 <4.0.0"
+
+dependencies:
+  dio: "^5.7.0"
+  json_annotation: "^4.9.0"
+  retrofit: "^4.4.1"
+  web_socket_channel: "^3.0.1"
+  zstd_dart: ^1.0.0
+
+dev_dependencies:
+  json_serializable: "^6.9.0"
+  retrofit_generator: ^10.2.3
+  openapi_sdk_gen: ^2.2.0
+  build_runner: any

--- a/tools/dart_sdk_validation/scripts/patch_openapi_spec.py
+++ b/tools/dart_sdk_validation/scripts/patch_openapi_spec.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# Keep in sync with fluxerapp/dart_sdk generate.sh patch logic.
+import json
+import sys
+from pathlib import Path
+
+SPEC_PATH = Path(sys.argv[1] if len(sys.argv) > 1 else "openapi.json")
+
+with SPEC_PATH.open() as f:
+    spec = json.load(f)
+
+schemas = spec.get("components", {}).get("schemas", {})
+patches = 0
+
+
+def add_field(schema_name, field_name, field_def):
+    global patches
+    schema = schemas.get(schema_name, {})
+    props = schema.get("properties", {})
+    if field_name not in props:
+        props[field_name] = field_def
+        patches += 1
+        print(f"  Added {schema_name}.{field_name}")
+
+
+def add_inline_field(schema_name, inline_prop, field_name, field_def):
+    global patches
+    schema = schemas.get(schema_name, {})
+    inline = schema.get("properties", {}).get(inline_prop, {})
+    props = inline.get("properties", {})
+    if field_name not in props:
+        props[field_name] = field_def
+        patches += 1
+        print(f"  Added {schema_name}.{inline_prop}.{field_name}")
+
+
+def make_optional(schema_name, inline_prop, field_name):
+    global patches
+    schema = schemas.get(schema_name, {})
+    inline = schema.get("properties", {}).get(inline_prop, {})
+    req = inline.get("required", [])
+    if field_name in req:
+        req.remove(field_name)
+        patches += 1
+        print(f"  Made {schema_name}.{inline_prop}.{field_name} optional")
+
+
+# --- WellKnownFluxerResponse patches ---
+
+make_optional("WellKnownFluxerResponse", "features", "manual_review_enabled")
+
+add_inline_field(
+    "WellKnownFluxerResponse",
+    "features",
+    "presigned_attachment_uploads",
+    {
+        "type": "boolean",
+        "description": "Whether presigned attachment uploads are enabled",
+    },
+)
+
+add_field(
+    "WellKnownFluxerResponse",
+    "gateway",
+    {
+        "type": "object",
+        "description": "Gateway session retry configuration",
+        "properties": {
+            "session_retry_min_ms": {
+                "type": "integer",
+                "description": "Minimum retry delay in milliseconds",
+            },
+            "session_retry_max_ms": {
+                "type": "integer",
+                "description": "Maximum retry delay in milliseconds",
+            },
+            "session_retry_jitter_ms": {
+                "type": "integer",
+                "description": "Jitter added to retry delay in milliseconds",
+            },
+        },
+        "required": [
+            "session_retry_min_ms",
+            "session_retry_max_ms",
+            "session_retry_jitter_ms",
+        ],
+    },
+)
+
+# --- UserPrivateResponse patches ---
+
+add_field(
+    "UserPrivateResponse",
+    "premium_out_of_band_trial_ends_at",
+    {
+        "anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}],
+        "description": "When the out-of-band premium trial ends",
+    },
+)
+add_field(
+    "UserPrivateResponse",
+    "premium_discriminator",
+    {
+        "type": "boolean",
+        "description": "Whether the user has a premium discriminator",
+    },
+)
+add_field(
+    "UserPrivateResponse",
+    "terms_agreed_at",
+    {
+        "anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}],
+        "description": "When the user agreed to terms of service",
+    },
+)
+add_field(
+    "UserPrivateResponse",
+    "privacy_agreed_at",
+    {
+        "anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}],
+        "description": "When the user agreed to the privacy policy",
+    },
+)
+
+# --- UserSettingsResponse patches ---
+
+add_field(
+    "UserSettingsResponse",
+    "sensitive_content_friend_dm_filter",
+    {
+        "type": "integer",
+        "description": "Sensitive content filter level for friend DMs",
+    },
+)
+add_field(
+    "UserSettingsResponse",
+    "sensitive_content_non_friend_dm_filter",
+    {
+        "type": "integer",
+        "description": "Sensitive content filter level for non-friend DMs",
+    },
+)
+add_field(
+    "UserSettingsResponse",
+    "sensitive_content_guild_filter",
+    {
+        "type": "integer",
+        "description": "Sensitive content filter level for guild messages",
+    },
+)
+
+# --- MessageReactionResponse patches ---
+
+reaction = schemas.get("MessageReactionResponse", {})
+me_prop = reaction.get("properties", {}).get("me")
+if me_prop and "anyOf" in me_prop:
+    desc = me_prop.get("description", "")
+    reaction["properties"]["me"] = {
+        "anyOf": [{"type": "boolean"}, {"type": "null"}],
+        "description": desc,
+    }
+    patches += 1
+    print("  Simplified MessageReactionResponse.me to nullable boolean")
+
+with SPEC_PATH.open("w") as f:
+    json.dump(spec, f, separators=(",", ":"))
+
+print(f"Applied {patches} patch(es)")


### PR DESCRIPTION
## Summary

Creates a validation tool contained in this repo to check against the dart_sdk generator. This is to help catch issues early and not have the mobile team manually patch the spec or wait for a fix.

- What changed:
- Why it is correct:
- Risk:

## Verification

- Tests run:
- Manual checks:
- Screenshots or recordings:

## Checklist

- [X] I understand every change in this PR.
- [X] I can explain what it does and why it is correct.
- [X] I disclosed any LLM coding help below.

## LLM Disclosure

- None, or:
