### PR TITLE
fix(api): Remove redundant "totp" and "webauthn" fields from certain schemas

### DIFF
--- a/fluxer_api/src/api/auth/AuthLogin.ts
+++ b/fluxer_api/src/api/auth/AuthLogin.ts
@@ -12,7 +12,7 @@ import {RateLimitError} from '@fluxer/errors/src/domains/core/RateLimitError';
 import {UnknownUserError} from '@fluxer/errors/src/domains/user/UnknownUserError';
 import {requireClientIp} from '@fluxer/ip_utils/src/ClientIp';
 import {getSameIpDecisionKey} from '@fluxer/ip_utils/src/IpAddress';
-import type {LoginRequest} from '@fluxer/schema/src/domains/auth/AuthSchemas';
+import type {AuthMfaMethod, LoginRequest} from '@fluxer/schema/src/domains/auth/AuthSchemas';
 import {formatGeoipLocation, UNKNOWN_LOCATION} from '@pkgs/geoip/src/GeoipLookup';
 import type {RateLimitResult} from '@pkgs/rate_limit/src/IRateLimitService';
 import type {AuthenticationResponseJSON} from '@simplewebauthn/server';
@@ -83,9 +83,7 @@ interface LoginTokenResult {
 interface LoginMfaResult {
 	mfa: true;
 	ticket: string;
-	allowed_methods: Array<string>;
-	totp: boolean;
-	webauthn: boolean;
+	allowed_methods: Array<AuthMfaMethod>;
 }
 
 type LoginResult = LoginTokenResult | LoginMfaResult;
@@ -446,14 +444,12 @@ async function createMfaTicketResponse(ctx: ApiContext, user: User): Promise<Log
 	const credentials = await users.listWebAuthnCredentials(user.id);
 	const hasWebauthn = credentials.length > 0;
 	const hasTotp = user.authenticatorTypes.has(UserAuthenticatorTypes.TOTP);
-	const allowedMethods: Array<string> = [];
+	const allowedMethods: Array<AuthMfaMethod> = [];
 	if (hasTotp) allowedMethods.push('totp');
 	if (hasWebauthn) allowedMethods.push('webauthn');
 	return {
 		mfa: true,
 		ticket,
 		allowed_methods: allowedMethods,
-		totp: hasTotp,
-		webauthn: hasWebauthn,
 	};
 }

--- a/fluxer_api/src/api/auth/AuthPassword.ts
+++ b/fluxer_api/src/api/auth/AuthPassword.ts
@@ -8,7 +8,7 @@ import {InputValidationError} from '@fluxer/errors/src/domains/core/InputValidat
 import {RateLimitError} from '@fluxer/errors/src/domains/core/RateLimitError';
 import {requireClientIp} from '@fluxer/ip_utils/src/ClientIp';
 import {getSameIpDecisionKey} from '@fluxer/ip_utils/src/IpAddress';
-import type {ForgotPasswordRequest, ResetPasswordRequest} from '@fluxer/schema/src/domains/auth/AuthSchemas';
+import type {AuthMfaMethod, ForgotPasswordRequest, ResetPasswordRequest} from '@fluxer/schema/src/domains/auth/AuthSchemas';
 import {ms, seconds} from 'itty-time';
 import type {ApiContext} from '../ApiContext';
 import {createMfaTicket, createPasswordResetToken} from '../BrandedTypes';
@@ -90,9 +90,7 @@ type ResetPasswordResult =
 	| {
 			mfa: true;
 			ticket: string;
-			allowed_methods: Array<string>;
-			totp: boolean;
-			webauthn: boolean;
+			allowed_methods: Array<AuthMfaMethod>;
 	  };
 
 const pwnedPasswordCache = new PwnedPasswordCache(1000, ms('1 hour'));
@@ -285,9 +283,7 @@ async function createMfaTicketResponse(
 ): Promise<{
 	mfa: true;
 	ticket: string;
-	allowed_methods: Array<string>;
-	totp: boolean;
-	webauthn: boolean;
+	allowed_methods: Array<AuthMfaMethod>;
 }> {
 	const {users, cache} = ctx.services;
 	const ticket = createMfaTicket(await AuthUtility.generateSecureToken(ctx));
@@ -295,14 +291,12 @@ async function createMfaTicketResponse(
 	const credentials = await users.listWebAuthnCredentials(user.id);
 	const hasWebauthn = credentials.length > 0;
 	const hasTotp = user.authenticatorTypes.has(UserAuthenticatorTypes.TOTP);
-	const allowedMethods: Array<string> = [];
+	const allowedMethods: Array<AuthMfaMethod> = [];
 	if (hasTotp) allowedMethods.push('totp');
 	if (hasWebauthn) allowedMethods.push('webauthn');
 	return {
 		mfa: true,
 		ticket: ticket,
 		allowed_methods: allowedMethods,
-		totp: hasTotp,
-		webauthn: hasWebauthn,
 	};
 }

--- a/fluxer_api/src/api/auth/AuthPassword.ts
+++ b/fluxer_api/src/api/auth/AuthPassword.ts
@@ -8,7 +8,11 @@ import {InputValidationError} from '@fluxer/errors/src/domains/core/InputValidat
 import {RateLimitError} from '@fluxer/errors/src/domains/core/RateLimitError';
 import {requireClientIp} from '@fluxer/ip_utils/src/ClientIp';
 import {getSameIpDecisionKey} from '@fluxer/ip_utils/src/IpAddress';
-import type {AuthMfaMethod, ForgotPasswordRequest, ResetPasswordRequest} from '@fluxer/schema/src/domains/auth/AuthSchemas';
+import type {
+	AuthMfaMethod,
+	ForgotPasswordRequest,
+	ResetPasswordRequest,
+} from '@fluxer/schema/src/domains/auth/AuthSchemas';
 import {ms, seconds} from 'itty-time';
 import type {ApiContext} from '../ApiContext';
 import {createMfaTicket, createPasswordResetToken} from '../BrandedTypes';

--- a/fluxer_api/src/api/auth/AuthRequestService.ts
+++ b/fluxer_api/src/api/auth/AuthRequestService.ts
@@ -407,8 +407,6 @@ export class AuthRequestService {
 		if (!('mfa' in result)) {
 			return await this.toAuthTokenResponse(result);
 		}
-		return {
-			...result,
-		};
+		return result;
 	}
 }

--- a/fluxer_api/src/api/auth/AuthRequestService.ts
+++ b/fluxer_api/src/api/auth/AuthRequestService.ts
@@ -6,6 +6,7 @@ import {UnauthorizedError} from '@fluxer/errors/src/domains/core/UnauthorizedErr
 import {UnknownUserError} from '@fluxer/errors/src/domains/user/UnknownUserError';
 import type {
 	AuthLoginResponse,
+	AuthMfaMethod,
 	AuthorizeIpRequest,
 	AuthRegisterResponse,
 	AuthSessionsResponse,
@@ -400,17 +401,14 @@ export class AuthRequestService {
 			| {
 					mfa: true;
 					ticket: string;
-					allowed_methods: Array<string>;
+					allowed_methods: Array<AuthMfaMethod>;
 			  },
 	): Promise<AuthLoginResponse> {
 		if (!('mfa' in result)) {
 			return await this.toAuthTokenResponse(result);
 		}
-		const allowedMethods = new Set(result.allowed_methods);
 		return {
 			...result,
-			totp: allowedMethods.has('totp'),
-			webauthn: allowedMethods.has('webauthn'),
 		};
 	}
 }

--- a/fluxer_api/src/api/auth/tests/AuthTestUtils.ts
+++ b/fluxer_api/src/api/auth/tests/AuthTestUtils.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import {createHmac, randomBytes, randomUUID} from 'node:crypto';
+import type {AuthMfaMethod} from '@fluxer/schema/src/domains/auth/AuthSchemas';
 import {decode as base32Decode, encode as base32Encode} from 'hi-base32';
 import {type ApiTestHarness, createApiTestHarness} from '../../test/ApiTestHarness';
 import {TEST_CREDENTIALS, TEST_USER_DATA} from '../../test/TestConstants';
 import {createBuilder} from '../../test/TestRequestBuilder';
-import type { AuthMfaMethod } from '@fluxer/schema/src/domains/auth/AuthSchemas';
 
 interface RegisterResponse {
 	user_id: string;

--- a/fluxer_api/src/api/auth/tests/AuthTestUtils.ts
+++ b/fluxer_api/src/api/auth/tests/AuthTestUtils.ts
@@ -5,6 +5,7 @@ import {decode as base32Decode, encode as base32Encode} from 'hi-base32';
 import {type ApiTestHarness, createApiTestHarness} from '../../test/ApiTestHarness';
 import {TEST_CREDENTIALS, TEST_USER_DATA} from '../../test/TestConstants';
 import {createBuilder} from '../../test/TestRequestBuilder';
+import type { AuthMfaMethod } from '@fluxer/schema/src/domains/auth/AuthSchemas';
 
 interface RegisterResponse {
 	user_id: string;
@@ -19,7 +20,7 @@ export interface LoginSuccessResponse {
 export interface LoginMfaResponse {
 	mfa: true;
 	ticket: string;
-	allowed_methods: Array<string>;
+	allowed_methods: Array<AuthMfaMethod>;
 	totp: boolean;
 	webauthn: boolean;
 }
@@ -32,7 +33,7 @@ type LoginResponse =
 	| {
 			mfa: true;
 			ticket: string;
-			allowed_methods: Array<string>;
+			allowed_methods: Array<AuthMfaMethod>;
 			totp: boolean;
 			webauthn: boolean;
 	  };

--- a/fluxer_api/src/api/auth/tests/AuthTestUtils.ts
+++ b/fluxer_api/src/api/auth/tests/AuthTestUtils.ts
@@ -21,8 +21,6 @@ export interface LoginMfaResponse {
 	mfa: true;
 	ticket: string;
 	allowed_methods: Array<AuthMfaMethod>;
-	totp: boolean;
-	webauthn: boolean;
 }
 
 type LoginResponse =
@@ -34,8 +32,6 @@ type LoginResponse =
 			mfa: true;
 			ticket: string;
 			allowed_methods: Array<AuthMfaMethod>;
-			totp: boolean;
-			webauthn: boolean;
 	  };
 
 export interface UserMeResponse {

--- a/fluxer_api/src/api/auth/tests/MfaEndpoints.test.ts
+++ b/fluxer_api/src/api/auth/tests/MfaEndpoints.test.ts
@@ -11,6 +11,7 @@ import {
 	totpCodeNow,
 	type UserMeResponse,
 } from './AuthTestUtils';
+import type { AuthMfaMethod } from '@fluxer/schema/src/domains/auth/AuthSchemas';
 
 describe('Auth MFA endpoints', () => {
 	let harness: ApiTestHarness;
@@ -43,14 +44,14 @@ describe('Auth MFA endpoints', () => {
 		const login = await createBuilderWithoutAuth<{
 			mfa: boolean;
 			ticket: string;
-			totp: boolean;
+			allowed_methods: Array<AuthMfaMethod>;
 		}>(harness)
 			.post('/auth/login')
 			.body({email: account.email, password: account.password})
 			.execute();
 		expect(login.mfa).toBe(true);
 		expect(login.ticket).toBeDefined();
-		expect(login.totp).toBe(true);
+		expect(login.allowed_methods).toContain('totp');
 		const backupResp = await createBuilderWithoutAuth<{
 			token: string;
 		}>(harness)

--- a/fluxer_api/src/api/auth/tests/MfaTotpWithoutSecret.test.ts
+++ b/fluxer_api/src/api/auth/tests/MfaTotpWithoutSecret.test.ts
@@ -6,6 +6,7 @@ import {HTTP_STATUS} from '../../test/TestConstants';
 import {createBuilder, createBuilderWithoutAuth} from '../../test/TestRequestBuilder';
 import {createAuthHarness, createTestAccount, createTotpSecret, generateTotpCode, seedMfaTicket} from './AuthTestUtils';
 import {createRegistrationResponse, createWebAuthnDevice, type WebAuthnRegistrationOptions} from './WebAuthnTestUtils';
+import type { AuthMfaMethod } from '@fluxer/schema/src/domains/auth/AuthSchemas';
 
 describe('Auth MFA TOTP without secret', () => {
 	let harness: ApiTestHarness;
@@ -74,16 +75,12 @@ describe('Auth MFA TOTP without secret', () => {
 		const login = await createBuilderWithoutAuth<{
 			mfa: true;
 			ticket: string;
-			allowed_methods: Array<string>;
-			totp: boolean;
-			webauthn: boolean;
+			allowed_methods: Array<AuthMfaMethod>;
 		}>(harness)
 			.post('/auth/login')
 			.body({email: account.email, password: account.password})
 			.execute();
 		expect(login.mfa).toBe(true);
-		expect(login.totp).toBe(false);
-		expect(login.webauthn).toBe(true);
 		expect(login.allowed_methods).toContain('webauthn');
 		expect(login.allowed_methods).not.toContain('totp');
 		const bypassAttempt = await createBuilderWithoutAuth<{

--- a/fluxer_api/src/api/auth/tests/ResetPasswordRequiresMfa.test.ts
+++ b/fluxer_api/src/api/auth/tests/ResetPasswordRequiresMfa.test.ts
@@ -12,13 +12,12 @@ import {
 	type TestEmailRecord,
 	totpCodeNow,
 } from './AuthTestUtils';
+import type { AuthMfaMethod } from '@fluxer/schema/src/domains/auth/AuthSchemas';
 
 interface MfaRequiredResponse {
 	mfa: true;
 	ticket: string;
-	allowed_methods: Array<string>;
-	totp: boolean;
-	webauthn: boolean;
+	allowed_methods: Array<AuthMfaMethod>;
 }
 
 async function waitForEmail(harness: ApiTestHarness, type: string, recipient: string): Promise<TestEmailRecord> {
@@ -64,8 +63,6 @@ describe('Auth reset password requires MFA', () => {
 			.execute();
 		expect(resetResp.mfa).toBe(true);
 		expect(resetResp.ticket).toBeDefined();
-		expect(resetResp.totp).toBe(true);
-		expect(resetResp.webauthn).toBe(false);
 		expect(resetResp.allowed_methods).toEqual(['totp']);
 		const mfaResp = await createBuilderWithoutAuth<{
 			token: string;
@@ -83,7 +80,6 @@ describe('Auth reset password requires MFA', () => {
 			.execute();
 		expect(login.mfa).toBe(true);
 		expect(login.ticket).toBeDefined();
-		expect(login.totp).toBe(true);
-		expect(login.webauthn).toBe(false);
+		expect(login.allowed_methods).toEqual(['totp']);
 	});
 });

--- a/fluxer_api/src/api/auth/tests/WebAuthnMfaConsistency.test.ts
+++ b/fluxer_api/src/api/auth/tests/WebAuthnMfaConsistency.test.ts
@@ -5,6 +5,7 @@ import {type ApiTestHarness, createApiTestHarness} from '../../test/ApiTestHarne
 import {createBuilder, createBuilderWithoutAuth} from '../../test/TestRequestBuilder';
 import {createTestAccount, createTotpSecret, generateTotpCode} from './AuthTestUtils';
 import {createAuthenticationResponse, createRegistrationResponse, createWebAuthnDevice} from './WebAuthnTestUtils';
+import type {AuthMfaMethod} from '@fluxer/schema/src/domains/auth/AuthSchemas';
 
 interface BackupCodesResponse {
 	backup_codes: Array<{
@@ -15,8 +16,7 @@ interface BackupCodesResponse {
 interface LoginMfaResponse {
 	mfa: true;
 	ticket: string;
-	totp: boolean;
-	webauthn: boolean;
+	allowed_methods: Array<AuthMfaMethod>;
 }
 
 interface WebAuthnRegistrationOptions {
@@ -299,6 +299,6 @@ describe('WebAuthn MFA Consistency Tests', () => {
 			.execute();
 		expect(login2.mfa).toBe(true);
 		expect(login2.ticket).toBeTruthy();
-		expect(login2.webauthn).toBe(true);
+		expect(login2.allowed_methods).toContain('webauthn');
 	});
 });

--- a/fluxer_app/src/features/auth/commands/AuthenticationCommands.ts
+++ b/fluxer_app/src/features/auth/commands/AuthenticationCommands.ts
@@ -22,6 +22,7 @@ import type {
 } from '@fluxer/schema/src/domains/auth/AuthSchemas';
 import type {UserPartial} from '@fluxer/schema/src/domains/user/UserResponseSchemas';
 import type {AuthenticationResponseJSON, PublicKeyCredentialRequestOptionsJSON} from '@simplewebauthn/browser';
+import { AuthMfaMethod } from '../../../../../packages/schema/src/domains/auth/AuthSchemas';
 
 const logger = new Logger('AuthService');
 const getPlatformHeaderValue = (): 'web' | 'desktop' | 'mobile' => (isDesktop() ? 'desktop' : 'web');
@@ -65,9 +66,7 @@ interface StandardLoginResponse extends AuthTokenResponse {
 interface MfaLoginResponse {
 	mfa: true;
 	ticket: string;
-	totp: boolean;
-	webauthn: boolean;
-	allowed_methods?: Array<string>;
+	allowed_methods?: Array<AuthMfaMethod>;
 }
 
 type LoginResponse = StandardLoginResponse | MfaLoginResponse;

--- a/fluxer_app/src/features/auth/commands/AuthenticationCommands.ts
+++ b/fluxer_app/src/features/auth/commands/AuthenticationCommands.ts
@@ -22,7 +22,7 @@ import type {
 } from '@fluxer/schema/src/domains/auth/AuthSchemas';
 import type {UserPartial} from '@fluxer/schema/src/domains/user/UserResponseSchemas';
 import type {AuthenticationResponseJSON, PublicKeyCredentialRequestOptionsJSON} from '@simplewebauthn/browser';
-import { AuthMfaMethod } from '../../../../../packages/schema/src/domains/auth/AuthSchemas';
+import type {AuthMfaMethod} from '../../../../../packages/schema/src/domains/auth/AuthSchemas';
 
 const logger = new Logger('AuthService');
 const getPlatformHeaderValue = (): 'web' | 'desktop' | 'mobile' => (isDesktop() ? 'desktop' : 'web');

--- a/fluxer_app/src/features/auth/state/AuthFlow.ts
+++ b/fluxer_app/src/features/auth/state/AuthFlow.ts
@@ -76,8 +76,8 @@ export async function loginWithPassword({
 			challenge: {
 				ticket: response.ticket,
 				sms: (response as {sms?: boolean}).sms ?? false,
-				totp: response.totp,
-				webauthn: response.webauthn,
+				totp: response.allowed_methods?.includes('totp') ?? false,
+				webauthn: response.allowed_methods?.includes('webauthn') ?? false,
 			},
 		};
 	}
@@ -265,8 +265,8 @@ export async function resetPassword(token: string, password: string): Promise<Pa
 		challenge: {
 			ticket: response.ticket,
 			sms: (response as {sms?: boolean}).sms ?? false,
-			totp: response.totp,
-			webauthn: response.webauthn,
+			totp: response.allowed_methods?.includes('totp') ?? false,
+			webauthn: response.allowed_methods?.includes('webauthn') ?? false,
 		},
 	};
 }

--- a/packages/schema/src/domains/auth/AuthSchemas.ts
+++ b/packages/schema/src/domains/auth/AuthSchemas.ts
@@ -164,7 +164,7 @@ export const AuthRegistrationPendingApprovalResponse = z.object({
 
 export type AuthRegistrationPendingApprovalResponse = z.infer<typeof AuthRegistrationPendingApprovalResponse>;
 
-export const AuthMfaMethod = z.enum(["totp", "webauthn"]);
+export const AuthMfaMethod = z.enum(['totp', 'webauthn']);
 
 export type AuthMfaMethod = z.infer<typeof AuthMfaMethod>;
 

--- a/packages/schema/src/domains/auth/AuthSchemas.ts
+++ b/packages/schema/src/domains/auth/AuthSchemas.ts
@@ -164,12 +164,14 @@ export const AuthRegistrationPendingApprovalResponse = z.object({
 
 export type AuthRegistrationPendingApprovalResponse = z.infer<typeof AuthRegistrationPendingApprovalResponse>;
 
+export const AuthMfaMethod = z.enum(["totp", "webauthn"]);
+
+export type AuthMfaMethod = z.infer<typeof AuthMfaMethod>;
+
 const AuthMfaRequiredResponse = z.object({
 	mfa: z.literal(true).describe('Indicates MFA is required to complete authentication'),
 	ticket: z.string().describe('MFA ticket to use when completing MFA verification'),
-	allowed_methods: z.array(z.string()).max(10).describe('List of allowed MFA methods'),
-	totp: z.boolean().describe('Whether TOTP authenticator MFA is available'),
-	webauthn: z.boolean().describe('Whether WebAuthn security key MFA is available'),
+	allowed_methods: z.array(AuthMfaMethod).max(10).describe('List of allowed MFA methods'),
 });
 
 export const AuthLoginResponse = z.union([AuthTokenWithUserIdResponse, AuthMfaRequiredResponse]);


### PR DESCRIPTION
## Summary

- What changed:
  - Added a `AuthMfaMethod` enum which has `"totp"` and `"webauthn"` as possible values
  - Modified the following schemas/interfaces/types:
    - `LoginMfaResult` in fluxer_api/src/api/auth/AuthLogin.ts
    - `ResetPasswordResult` in fluxer_api/src/api/auth/AuthPassword.ts
    - `LoginMfaResponse` and `LoginResponse` in fluxer_api/src/api/auth/tests/AuthTestUtils.ts
    - `MfaLoginResponse` in fluxer_app/src/features/auth/commands/AuthenticationCommands.ts
    - `AuthMfaRequiredResponse` in packages/schema/src/domains/auth/AuthSchemas.ts
- Why it is correct: The same information is already in `allowed_methods` , which lists `totp` and `webauthn` if they are available.
- Risk: I could have missed a location where this is missing (though unlikely because typescript would usually catch it).

## Verification

- Tests run: Yes
- Manual checks: Registration and login worked just fine.
- Screenshots or recordings:

## Checklist

- [X] I understand every change in this PR.
- [X] I can explain what it does and why it is correct.
- [X] I disclosed any LLM coding help below.

## LLM Disclosure

- None