### PR TITLE
fix(EntityAssetService): include format during asset upload

### DIFF
--- a/fluxer_api/src/api/infrastructure/EntityAssetService.ts
+++ b/fluxer_api/src/api/infrastructure/EntityAssetService.ts
@@ -139,7 +139,7 @@ export class EntityAssetService {
 		const newHash = animated ? `a_${imageHashShort}` : imageHashShort;
 		const isAnimated = animated;
 		const newS3Key = `${s3KeyBase}/${imageHashShort}`;
-		const newCdnUrl = `${cdnUrlBase}/${newHash}`;
+		const newCdnUrl = `${cdnUrlBase}/${newHash}.${format}`;
 		if (newHash === previousHash) {
 			return {
 				newHash,


### PR DESCRIPTION
## Summary

- What changed: Added file extension to the newCdnUrl returned when uploading an asset
- Why it is correct: Without the file extension, branding images uploaded during the self-hosted setup do not resolve (resolves #1065)
- Risk:

## Verification

- Tests run: All tests. Same number of tests are failing before and after changing this
- Manual checks: Went through self-hosted asset setup and verified that branded assets resolve correctly after change. Changed user avatar to verify that setting avatar wasn't broken
- Screenshots or recordings:

Before the change:
<img width="1944" height="806" alt="image" src="https://github.com/user-attachments/assets/2825d3cb-442a-4fe9-94ad-8ea4211c3fe2" />

After the change:
<img width="1925" height="825" alt="image" src="https://github.com/user-attachments/assets/79f5a162-b019-45c7-9572-5a2e9c5fc293" />


## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- No LLM usage
