### PR TITLE
feat: apply media attachment decay settings retroactively

### DIFF
--- a/fluxer_api/src/api/admin/controllers/InstanceConfigAdminController.ts
+++ b/fluxer_api/src/api/admin/controllers/InstanceConfigAdminController.ts
@@ -26,9 +26,11 @@ import {
 	REGISTRATION_REJECTED_TRAIT,
 } from '../../instance/InstanceConfigRepository';
 import {deriveSsoRedirectUri, normalizeAndValidateSsoConfig} from '../../instance/SsoConfigValidation';
+import {Logger} from '../../Logger';
 import {requireAdminACL} from '../../middleware/AdminMiddleware';
 import {RateLimitMiddleware} from '../../middleware/RateLimitMiddleware';
 import {OpenAPI} from '../../middleware/ResponseTypeMiddleware';
+import {getWorkerService} from '../../middleware/ServiceRegistry';
 import {getGatewayRolloutConfigPublisher, getInstanceConfigRepository} from '../../middleware/ServiceSingletons';
 import {RateLimitConfigs} from '../../RateLimitConfig';
 import type {HonoApp, HonoEnv} from '../../types/HonoEnv';
@@ -359,6 +361,13 @@ export function InstanceConfigAdminController(app: HonoApp) {
 							})
 						: undefined,
 				});
+				if (data.media.attachment_decay) {
+					try {
+						await getWorkerService().addJob('recalculateAttachmentDecay', {});
+					} catch (workerErr) {
+						Logger.error({err: workerErr}, 'Failed to enqueue recalculateAttachmentDecay worker task');
+					}
+				}
 			}
 			if (data.policy) {
 				await applyInstancePolicyUpdate(ctx, data.policy);

--- a/fluxer_api/src/api/attachment/AttachmentDecayService.ts
+++ b/fluxer_api/src/api/attachment/AttachmentDecayService.ts
@@ -51,7 +51,6 @@ export class AttachmentDecayService {
 
 	async upsertMany(payloads: Array<AttachmentDecayPayload>): Promise<void> {
 		const config = await this.resolveConfig();
-		if (!config.enabled) return;
 		const rules = buildDecayRules(config);
 		for (const payload of payloads) {
 			const decay = computeDecay({sizeBytes: payload.sizeBytes, uploadedAt: payload.uploadedAt, rules});
@@ -80,7 +79,6 @@ export class AttachmentDecayService {
 	async extendForAttachments(attachments: Array<AttachmentDecayPayload>): Promise<void> {
 		if (attachments.length === 0) return;
 		const config = await this.resolveConfig();
-		if (!config.enabled) return;
 		const rules = buildDecayRules(config);
 		const attachmentIds = attachments.map((a) => a.attachmentId);
 		const existingRecords = await this.repo.fetchByIds(attachmentIds);

--- a/fluxer_api/src/api/channel/services/message/MessageResponseDataService.ts
+++ b/fluxer_api/src/api/channel/services/message/MessageResponseDataService.ts
@@ -298,9 +298,15 @@ export class MessageResponseDataService {
 				await this.connectionManager.connect();
 			}
 			const connection = this.connectionManager.getConnection();
+			const {getInstanceConfigRepository} = await import('../../../middleware/ServiceSingletons');
+			const attachmentDecayEnabled = await getInstanceConfigRepository().isAttachmentDecayEnabled();
+			const fullPayload = {
+				...payload,
+				attachment_decay_enabled: attachmentDecayEnabled,
+			};
 			const response = await connection.request(
 				MESSAGE_RESPONSE_SERVICE_SUBJECT,
-				this.codec.encode(JSON.stringify(payload)),
+				this.codec.encode(JSON.stringify(fullPayload)),
 				{timeout: MESSAGE_RESPONSE_SERVICE_TIMEOUT_MS},
 			);
 			const parsed = parseJsonWithGuard(this.codec.decode(response.data), isMessageServiceResponse);

--- a/fluxer_api/src/api/channel/tests/AttachmentDecayRetroactive.test.ts
+++ b/fluxer_api/src/api/channel/tests/AttachmentDecayRetroactive.test.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {AttachmentDecayRepository} from '../../attachment/AttachmentDecayRepository';
+import {createTestAccount} from '../../auth/tests/AuthTestUtils';
+import {createAttachmentID} from '../../BrandedTypes';
+import {getInstanceConfigRepository} from '../../middleware/ServiceSingletons';
+import {type ApiTestHarness, createApiTestHarness} from '../../test/ApiTestHarness';
+import {HTTP_STATUS} from '../../test/TestConstants';
+import {createBuilder} from '../../test/TestRequestBuilder';
+import {recalculateAttachmentDecay} from '../../worker/tasks/RecalculateAttachmentDecay';
+import {createChannel, createGuild, loadFixture, sendMessageWithAttachments} from './AttachmentTestUtils';
+
+describe('Attachment Decay Retroactive Expiry Bug Reproduction & Fix Verification', () => {
+	let harness: ApiTestHarness;
+
+	beforeEach(async () => {
+		harness = await createApiTestHarness();
+	});
+
+	afterEach(async () => {
+		await harness?.shutdown();
+	});
+
+	test('Scenario 1: If media expiry is enabled, then disabled, old attachments should retroactively NOT have expiry applied', async () => {
+		// 1. Ensure media expiry is enabled
+		await getInstanceConfigRepository().setInstanceMediaConfig({
+			attachment_decay: {
+				enabled: true,
+				min_size_mb: 0,
+				max_size_mb: 10,
+				min_lifetime_days: 1,
+				max_lifetime_days: 30,
+			},
+		});
+
+		const account = await createTestAccount(harness);
+		const guild = await createGuild(harness, account.token, 'Scenario 1 Guild');
+		const channel = await createChannel(harness, account.token, guild.id, 's1-channel');
+		const channelId = guild.system_channel_id ?? channel.id;
+		const fileData = loadFixture('yeah.png');
+
+		// 2. Upload an attachment
+		const {response, json} = await sendMessageWithAttachments(
+			harness,
+			account.token,
+			channelId,
+			{
+				content: 'Attachment with expiry initially enabled',
+				attachments: [{id: 0, filename: 's1.png'}],
+			},
+			[{index: 0, filename: 's1.png', data: fileData}],
+		);
+		expect(response.status).toBe(HTTP_STATUS.OK);
+		const attachmentId = json.attachments![0].id;
+
+		// Verify it currently has expires_at in response
+		let messageResponse = await createBuilder<{
+			id: string;
+			attachments: Array<{
+				id: string;
+				expires_at?: string | null;
+			}>;
+		}>(harness, account.token)
+			.get(`/channels/${channelId}/messages/${json.id}`)
+			.execute();
+		expect(messageResponse.attachments![0].expires_at).toBeTruthy();
+
+		// 3. Disable attachment expiry
+		await getInstanceConfigRepository().setInstanceMediaConfig({
+			attachment_decay: {
+				enabled: false,
+			},
+		});
+
+		// 4. Run the recalculation task
+		await recalculateAttachmentDecay();
+
+		// Verify the database record has null expires_at
+		const repo = new AttachmentDecayRepository();
+		const dbRecord = await repo.fetchById(createAttachmentID(BigInt(attachmentId)));
+		expect(dbRecord?.expires_at).toBeNull();
+
+		// Retrieve the message again. It should NOT have an expiry date applied.
+		messageResponse = await createBuilder<{
+			id: string;
+			attachments: Array<{
+				id: string;
+				expires_at?: string | null;
+			}>;
+		}>(harness, account.token)
+			.get(`/channels/${channelId}/messages/${json.id}`)
+			.execute();
+
+		expect(messageResponse.attachments![0].expires_at).toBeNull();
+	});
+
+	test('Scenario 2: If media expiry is disabled, then enabled, old attachments should retroactively have expiry applied', async () => {
+		// 1. Ensure media expiry is disabled
+		await getInstanceConfigRepository().setInstanceMediaConfig({
+			attachment_decay: {
+				enabled: false,
+			},
+		});
+
+		const account = await createTestAccount(harness);
+		const guild = await createGuild(harness, account.token, 'Scenario 2 Guild');
+		const channel = await createChannel(harness, account.token, guild.id, 's2-channel');
+		const channelId = guild.system_channel_id ?? channel.id;
+		const fileData = loadFixture('yeah.png');
+
+		// 2. Upload an attachment
+		const {response, json} = await sendMessageWithAttachments(
+			harness,
+			account.token,
+			channelId,
+			{
+				content: 'Attachment with expiry initially disabled',
+				attachments: [{id: 0, filename: 's2.png'}],
+			},
+			[{index: 0, filename: 's2.png', data: fileData}],
+		);
+		expect(response.status).toBe(HTTP_STATUS.OK);
+		const attachmentId = json.attachments![0].id;
+
+		// Verify it currently does NOT have expires_at in response (since disabled)
+		let messageResponse = await createBuilder<{
+			id: string;
+			attachments: Array<{
+				id: string;
+				expires_at?: string | null;
+			}>;
+		}>(harness, account.token)
+			.get(`/channels/${channelId}/messages/${json.id}`)
+			.execute();
+		expect(messageResponse.attachments![0].expires_at).toBeFalsy();
+
+		// 3. Enable attachment expiry with new rules
+		await getInstanceConfigRepository().setInstanceMediaConfig({
+			attachment_decay: {
+				enabled: true,
+				min_size_mb: 0,
+				max_size_mb: 10,
+				min_lifetime_days: 1,
+				max_lifetime_days: 30,
+			},
+		});
+
+		// 4. Run the recalculation task to apply new rules retroactively
+		await recalculateAttachmentDecay();
+
+		// Fetch the database record and check computed expiry (should be 30 days, not the default 3 years)
+		const repo = new AttachmentDecayRepository();
+		let dbRecord = await repo.fetchById(createAttachmentID(BigInt(attachmentId)));
+		expect(dbRecord?.expires_at).not.toBeNull();
+
+		const uploadedAt = new Date(dbRecord!.uploaded_at);
+		const expiresAt = new Date(dbRecord!.expires_at);
+		const diffDays = Math.round((expiresAt.getTime() - uploadedAt.getTime()) / (1000 * 60 * 60 * 24));
+		expect(diffDays).toBe(30);
+
+		// Retrieve the message again. It should have the new 30-day expiry date applied retroactively.
+		messageResponse = await createBuilder<{
+			id: string;
+			attachments: Array<{
+				id: string;
+				expires_at?: string | null;
+			}>;
+		}>(harness, account.token)
+			.get(`/channels/${channelId}/messages/${json.id}`)
+			.execute();
+
+		expect(messageResponse.attachments![0].expires_at).toBeTruthy();
+
+		// Fetch the database record again to check that they match now (since GET request might have updated/renewed it)
+		dbRecord = await repo.fetchById(createAttachmentID(BigInt(attachmentId)));
+		expect(messageResponse.attachments![0].expires_at).toBe(dbRecord!.expires_at.toISOString());
+	});
+});

--- a/fluxer_api/src/api/test/mocks/RepositoryBackedMessageResponseDataService.ts
+++ b/fluxer_api/src/api/test/mocks/RepositoryBackedMessageResponseDataService.ts
@@ -29,7 +29,7 @@ import {
 	MessageResponseDataService,
 	messageResponseAccessForChannel,
 } from '../../channel/services/message/MessageResponseDataService';
-import {getChannelRepository, getUserRepository} from '../../middleware/ServiceSingletons';
+import {getChannelRepository, getInstanceConfigRepository, getUserRepository} from '../../middleware/ServiceSingletons';
 import type {Attachment} from '../../models/Attachment';
 import type {CallInfo} from '../../models/CallInfo';
 import type {Embed} from '../../models/Embed';
@@ -352,19 +352,22 @@ export class RepositoryBackedMessageResponseDataService extends MessageResponseD
 		message: Message,
 	): Promise<Array<MessageAttachmentResponse> | null> {
 		if (attachments.length === 0) return null;
-		await this.attachmentDecayService.extendForAttachments(
-			attachments.map((attachment) => ({
-				attachmentId: attachment.id,
-				channelId: message.channelId,
-				messageId: message.id,
-				filename: attachment.filename,
-				sizeBytes: attachment.size,
-				uploadedAt: snowflakeToDate(message.id),
-			})),
-		);
+		const attachmentDecayEnabled = await getInstanceConfigRepository().isAttachmentDecayEnabled();
+		if (attachmentDecayEnabled) {
+			await this.attachmentDecayService.extendForAttachments(
+				attachments.map((attachment) => ({
+					attachmentId: attachment.id,
+					channelId: message.channelId,
+					messageId: message.id,
+					filename: attachment.filename,
+					sizeBytes: attachment.size,
+					uploadedAt: snowflakeToDate(message.id),
+				})),
+			);
+		}
 		return Promise.all(
 			attachments.map(async (attachment) => {
-				const decay = await this.attachmentDecayRepository.fetchById(attachment.id);
+				const decay = attachmentDecayEnabled ? await this.attachmentDecayRepository.fetchById(attachment.id) : null;
 				const url = this.mapAttachmentUrl(message, attachment);
 				return {
 					id: attachment.id.toString(),

--- a/fluxer_api/src/api/worker/WorkerLaneConfig.ts
+++ b/fluxer_api/src/api/worker/WorkerLaneConfig.ts
@@ -65,6 +65,7 @@ const LANE_CONFIG = {
 		tasks: [
 			'enqueueGifFeaturedCategoriesRefresh',
 			'expireAttachments',
+			'recalculateAttachmentDecay',
 			'indexChannelMessages',
 			'indexGuildMembers',
 			'processAssetDeletionQueue',

--- a/fluxer_api/src/api/worker/WorkerTaskRegistry.ts
+++ b/fluxer_api/src/api/worker/WorkerTaskRegistry.ts
@@ -33,6 +33,7 @@ import processPendingBulkMessageDeletions from './tasks/ProcessPendingBulkMessag
 import processPremiumStateReconciliationQueue from './tasks/ProcessPremiumStateReconciliationQueue';
 import processStripeWebhook from './tasks/ProcessStripeWebhook';
 import prunePostgresKvTtl from './tasks/PrunePostgresKvTtl';
+import recalculateAttachmentDecay from './tasks/RecalculateAttachmentDecay';
 import reconcileUserPayments from './tasks/ReconcileUserPayments';
 import refreshGifFeaturedCategories from './tasks/RefreshGifFeaturedCategories';
 import refreshSearchIndex from './tasks/RefreshSearchIndex';
@@ -62,6 +63,7 @@ export const workerTasks: Record<WorkerTaskName, WorkerTaskHandler> = {
 	deleteUserMessagesInGuildByTime,
 	enqueueGifFeaturedCategoriesRefresh,
 	expireAttachments,
+	recalculateAttachmentDecay,
 	extractEmbeds,
 	finalizeNcmecAttachmentReport,
 	handleMentions,

--- a/fluxer_api/src/api/worker/tasks/RecalculateAttachmentDecay.ts
+++ b/fluxer_api/src/api/worker/tasks/RecalculateAttachmentDecay.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {WorkerTaskHandler} from '@pkgs/worker/src/contracts/WorkerTask';
+import {ms} from 'itty-time';
+import {BatchBuilder, fetchPage, type PagedQueryResult} from '../../database/CassandraQueryExecution';
+import type {InstanceAttachmentDecayEffectiveConfig} from '../../instance/InstanceConfigRepository';
+import {Logger} from '../../Logger';
+import {AttachmentDecayByExpiry, AttachmentDecayById} from '../../Tables';
+import type {AttachmentDecayRow} from '../../types/AttachmentDecayTypes';
+import type {AttachmentDecayRules} from '../../utils/AttachmentDecay';
+import {computeDecay, getExpiryBucket, maybeRenewExpiry} from '../../utils/AttachmentDecay';
+
+function buildDecayRulesFromConfig(config: InstanceAttachmentDecayEffectiveConfig): AttachmentDecayRules {
+	return {
+		minMb: config.min_size_mb,
+		maxMb: config.max_size_mb,
+		maxEligibleMb: config.max_eligible_size_mb,
+		minDays: config.min_lifetime_days,
+		maxDays: config.max_lifetime_days,
+		curve: config.curve,
+	};
+}
+
+export async function recalculateAttachmentDecay(): Promise<void> {
+	const {getInstanceConfigRepository} = await import('../../middleware/ServiceSingletons');
+	const instanceConfigRepository = getInstanceConfigRepository();
+	const config = await instanceConfigRepository.getEffectiveAttachmentDecayConfig();
+	let pageState: string | null = null;
+	let totalUpdated = 0;
+	let totalProcessed = 0;
+
+	const rules = buildDecayRulesFromConfig(config);
+
+	do {
+		const result: PagedQueryResult<AttachmentDecayRow> = await fetchPage<AttachmentDecayRow>(
+			AttachmentDecayById.selectCql(),
+			{},
+			{pageSize: 100, pageState},
+		);
+		pageState = result.pageState;
+
+		for (const row of result.rows) {
+			totalProcessed++;
+
+			let expiresAt: Date | null = null;
+			let cost = 0;
+			let lifetimeDays = 0;
+
+			if (config.enabled) {
+				const decay = computeDecay({
+					sizeBytes: row.size_bytes,
+					uploadedAt: row.uploaded_at,
+					rules,
+				});
+				if (decay) {
+					expiresAt = decay.expiresAt;
+					cost = decay.cost;
+					lifetimeDays = decay.days;
+
+					if (row.last_accessed_at && row.last_accessed_at.getTime() > row.uploaded_at.getTime()) {
+						const renewed = maybeRenewExpiry({
+							currentExpiry: expiresAt,
+							now: row.last_accessed_at,
+							thresholdDays: config.renew_threshold_days,
+							windowDays: config.renew_window_days,
+						});
+						if (renewed) {
+							expiresAt = renewed;
+							lifetimeDays = Math.round((expiresAt.getTime() - row.uploaded_at.getTime()) / ms('1 day'));
+							const sizeTB = Number(row.size_bytes) / 1024 / 1024 / 1024 / 1024;
+							const lifetimeMonths = lifetimeDays / 30;
+							cost = sizeTB * (rules.pricePerTBPerMonth ?? 0.0081103 * 1000) * lifetimeMonths;
+						}
+					}
+				}
+			}
+
+			const oldExpiresAt = row.expires_at ? new Date(row.expires_at) : null;
+			const expiresAtTime = expiresAt?.getTime() ?? null;
+			const oldExpiresAtTime = oldExpiresAt?.getTime() ?? null;
+
+			if (expiresAtTime !== oldExpiresAtTime) {
+				totalUpdated++;
+
+				const batch = new BatchBuilder();
+
+				if (oldExpiresAt) {
+					batch.addPrepared(
+						AttachmentDecayByExpiry.deleteByPk({
+							expiry_bucket: getExpiryBucket(oldExpiresAt),
+							expires_at: oldExpiresAt,
+							attachment_id: row.attachment_id,
+						}),
+					);
+				}
+
+				if (expiresAt) {
+					const expiryBucket = getExpiryBucket(expiresAt);
+					batch.addPrepared(
+						AttachmentDecayById.upsertAll({
+							...row,
+							expires_at: expiresAt,
+							cost,
+							lifetime_days: lifetimeDays,
+						}),
+					);
+					batch.addPrepared(
+						AttachmentDecayByExpiry.upsertAll({
+							expiry_bucket: expiryBucket,
+							expires_at: expiresAt,
+							attachment_id: row.attachment_id,
+							channel_id: row.channel_id,
+							message_id: row.message_id,
+						}),
+					);
+				} else {
+					batch.addPrepared(
+						AttachmentDecayById.upsertAll({
+							...row,
+							expires_at: null as any,
+							cost: 0,
+							lifetime_days: 0,
+						}),
+					);
+				}
+
+				await batch.execute();
+			}
+		}
+	} while (pageState);
+
+	Logger.info(
+		{totalProcessed, totalUpdated},
+		'Finished recalculating attachment decay expiries based on updated configuration',
+	);
+}
+
+const recalculateAttachmentDecayTask: WorkerTaskHandler = async () => {
+	await recalculateAttachmentDecay();
+};
+
+export default recalculateAttachmentDecayTask;

--- a/fluxer_messages/src/shard_impl.rs
+++ b/fluxer_messages/src/shard_impl.rs
@@ -242,6 +242,7 @@ struct ResponseBuildOptions {
     include_reactions: bool,
     nonce: Option<String>,
     tts: bool,
+    attachment_decay_enabled: bool,
 }
 
 #[derive(Debug, Default)]
@@ -752,7 +753,13 @@ impl MessagesShard {
         let channel_ids = collect_channel_mention_ids(&all_messages, &mention_context);
         let user_ids = collect_user_ids(&all_messages, &mention_context);
         let reactions_future = self.fetch_reactions_for_messages(messages, options);
-        let attachment_decay_future = self.fetch_attachment_decay(attachment_ids);
+        let attachment_decay_future = async {
+            if options.attachment_decay_enabled {
+                self.fetch_attachment_decay(attachment_ids).await
+            } else {
+                Ok(HashMap::new())
+            }
+        };
         let channel_mentions_future = self.resolve_channel_mentions(channel_ids, options);
         let (reactions, attachment_decay, channel_mentions) = tokio::join!(
             reactions_future,
@@ -2140,6 +2147,7 @@ impl ShardService for MessagesShard {
                 include_reactions,
                 nonce,
                 tts,
+                attachment_decay_enabled,
             } => {
                 let channel_id = parse_i64(&channel_id, "channel_id")?;
                 let message_id = parse_i64(&message_id, "message_id")?;
@@ -2162,6 +2170,7 @@ impl ShardService for MessagesShard {
                             include_reactions: include_reactions.unwrap_or(true),
                             nonce,
                             tts: tts.unwrap_or(false),
+                            attachment_decay_enabled: attachment_decay_enabled.unwrap_or(true),
                         },
                     )
                     .await?;
@@ -2181,6 +2190,7 @@ impl ShardService for MessagesShard {
                 include_reactions,
                 nonce,
                 tts,
+                attachment_decay_enabled,
             } => {
                 let viewer_user_id = parse_i64(&viewer_user_id, "viewer_user_id")?;
                 let source_guild_id = source_guild_id
@@ -2200,6 +2210,7 @@ impl ShardService for MessagesShard {
                             include_reactions: include_reactions.unwrap_or(true),
                             nonce,
                             tts: tts.unwrap_or(false),
+                            attachment_decay_enabled: attachment_decay_enabled.unwrap_or(true),
                         },
                     )
                     .await?;
@@ -2217,6 +2228,7 @@ impl ShardService for MessagesShard {
                 media_endpoint,
                 media_proxy_secret_key,
                 include_reactions,
+                attachment_decay_enabled,
             } => {
                 let viewer_user_id = parse_i64(&viewer_user_id, "viewer_user_id")?;
                 let source_guild_id = source_guild_id
@@ -2236,6 +2248,7 @@ impl ShardService for MessagesShard {
                             include_reactions: include_reactions.unwrap_or(true),
                             nonce: None,
                             tts: false,
+                            attachment_decay_enabled: attachment_decay_enabled.unwrap_or(true),
                         },
                     )
                     .await?;
@@ -2254,6 +2267,7 @@ impl ShardService for MessagesShard {
                 media_endpoint,
                 media_proxy_secret_key,
                 include_reactions,
+                attachment_decay_enabled,
             } => {
                 let channel_id = parse_i64(&channel_id, "channel_id")?;
                 let viewer_user_id = parse_i64(&viewer_user_id, "viewer_user_id")?;
@@ -2290,6 +2304,7 @@ impl ShardService for MessagesShard {
                             include_reactions: include_reactions.unwrap_or(true),
                             nonce: None,
                             tts: false,
+                            attachment_decay_enabled: attachment_decay_enabled.unwrap_or(true),
                         },
                     )
                     .await?;

--- a/fluxer_messages/src/types.rs
+++ b/fluxer_messages/src/types.rs
@@ -86,6 +86,7 @@ pub enum MessageRequest {
         include_reactions: Option<bool>,
         nonce: Option<String>,
         tts: Option<bool>,
+        attachment_decay_enabled: Option<bool>,
     },
     BuildResponse {
         message: Message,
@@ -98,6 +99,7 @@ pub enum MessageRequest {
         include_reactions: Option<bool>,
         nonce: Option<String>,
         tts: Option<bool>,
+        attachment_decay_enabled: Option<bool>,
     },
     BuildResponses {
         messages: Vec<Message>,
@@ -108,6 +110,7 @@ pub enum MessageRequest {
         media_endpoint: String,
         media_proxy_secret_key: String,
         include_reactions: Option<bool>,
+        attachment_decay_enabled: Option<bool>,
     },
     ListResponses {
         channel_id: String,
@@ -122,6 +125,7 @@ pub enum MessageRequest {
         media_endpoint: String,
         media_proxy_secret_key: String,
         include_reactions: Option<bool>,
+        attachment_decay_enabled: Option<bool>,
     },
     ExtractMentions {
         contents: Vec<String>,


### PR DESCRIPTION
## Summary

- **What changed:**
  - Added a new background task `recalculateAttachmentDecay` that scans all attachment decay entries in ScyllaDB/Cassandra and retroactively applies the latest instance retention rules (or clears expiries if disabled).
  - Integrated the background task to run asynchronously whenever the media configuration is updated in `InstanceConfigAdminController`.
  - Updated the NATS/Rust microservice message mapping (`fluxer_messages`) to respect whether attachment decay is currently enabled when constructing message responses.

- **Why it is correct:**
  - Previously, media expiry was calculated statically only at the time of upload, meaning admin panel changes did not affect pre-existing attachments. The new background task ensures that settings are retroactively applied to all historical attachments.

- **Risk:**
  - Low. The background task queries ScyllaDB/Cassandra using pagination (100 records per page) to prevent query load issues.

## Verification

- **Tests run:**
  - Created a new integration test suite `AttachmentDecayRetroactive.test.ts` verifying:
    - **Scenario 1**: Disabling decay retroactively clears expiries.
    - **Scenario 2**: Enabling decay retroactively applies the lifetime rules to pre-existing files.
  - Ran the test suite via Vitest:
    ```bash
    npx vitest run src/api/channel/tests/AttachmentDecayRetroactive.test.ts
    ```
    (Result: Both scenarios passed successfully).
  
- **Manual checks:**
  - Ran `pnpm --filter fluxer_api typecheck` and Biome format/lint checks successfully.

- **Screenshots or recordings:**
  - None.

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- Only tests were generated with AI.
