### PR TITLE
Add scheduled events with RSVP support

### DIFF
--- a/fluxer_api/src/api/BrandedTypes.ts
+++ b/fluxer_api/src/api/BrandedTypes.ts
@@ -29,6 +29,7 @@ export type ReportID = Brand<bigint, 'ReportID'>;
 export type MemeID = Brand<bigint, 'MemeID'>;
 export type ApplicationID = Brand<bigint, 'ApplicationID'>;
 export type EntranceSoundID = Brand<bigint, 'EntranceSoundID'>;
+export type ScheduledEventID = Brand<bigint, 'ScheduledEventID'>;
 export type InviteCode = Brand<string, 'InviteCode'>;
 export type VanityURLCode = Brand<string, 'VanityURLCode'>;
 export type EmailVerificationToken = Brand<string, 'EmailVerificationToken'>;
@@ -91,6 +92,10 @@ export function createApplicationID<T extends bigint>(id: T extends BrandedValue
 
 export function createEntranceSoundID<T extends bigint>(id: T extends BrandedValue ? never : T): EntranceSoundID {
 	return brand<T, 'EntranceSoundID'>(id);
+}
+
+export function createScheduledEventID<T extends bigint>(id: T extends BrandedValue ? never : T): ScheduledEventID {
+	return brand<T, 'ScheduledEventID'>(id);
 }
 
 export function createInviteCode<T extends string>(code: T extends BrandedValue ? never : T): InviteCode {

--- a/fluxer_api/src/api/Tables.ts
+++ b/fluxer_api/src/api/Tables.ts
@@ -173,6 +173,8 @@ import {
 	GUILD_ROLE_COLUMNS,
 	GUILD_STICKER_BY_STICKER_ID_COLUMNS,
 	GUILD_STICKER_COLUMNS,
+	GUILD_SCHEDULED_EVENT_COLUMNS,
+	GUILD_SCHEDULED_EVENT_RSVP_COLUMNS,
 	type GuildAuditLogRow,
 	type GuildBanByEmailRow,
 	type GuildBanByUserIdRow,
@@ -183,6 +185,8 @@ import {
 	type GuildMembershipMetadataRow,
 	type GuildRoleRow,
 	type GuildRow,
+	type GuildScheduledEventRow,
+	type GuildScheduledEventRsvpRow,
 	type GuildStickerRow,
 } from './database/types/GuildTypes';
 import {INSTANCE_CONFIGURATION_COLUMNS, type InstanceConfigurationRow} from './database/types/InstanceConfigTypes';
@@ -1484,4 +1488,14 @@ export const BillingActionIntents = defineTable<BillingActionIntentRow, 'intent_
 	name: 'billing_action_intents',
 	columns: BILLING_ACTION_INTENT_COLUMNS,
 	primaryKey: ['intent_id'],
+});
+export const GuildScheduledEvents = defineTable<GuildScheduledEventRow, 'guild_id' | 'scheduled_event_id'>({
+	name: 'guild_scheduled_events',
+	columns: GUILD_SCHEDULED_EVENT_COLUMNS,
+	primaryKey: ['guild_id', 'scheduled_event_id'],
+});
+export const GuildScheduledEventRsvps = defineTable<GuildScheduledEventRsvpRow, 'guild_id' | 'scheduled_event_id' | 'user_id'>({
+	name: 'guild_scheduled_event_rsvps',
+	columns: GUILD_SCHEDULED_EVENT_RSVP_COLUMNS,
+	primaryKey: ['guild_id', 'scheduled_event_id', 'user_id'],
 });

--- a/fluxer_api/src/api/database/types/GuildTypes.ts
+++ b/fluxer_api/src/api/database/types/GuildTypes.ts
@@ -320,3 +320,53 @@ export interface GuildMemberByUserIdRow {
 export const GUILD_MEMBER_BY_USER_ID_COLUMNS = ['user_id', 'guild_id'] as const satisfies ReadonlyArray<
 	keyof GuildMemberByUserIdRow
 >;
+
+export interface GuildScheduledEventRow {
+	guild_id: GuildID;
+	scheduled_event_id: ScheduledEventID;
+	channel_id: ChannelID | null;
+	creator_id: UserID;
+	name: string;
+	description: string | null;
+	scheduled_start_time: string;
+	scheduled_end_time: string | null;
+	privacy_level: number;
+	status: number;
+	entity_type: number | null;
+	entity_id: string | null;
+	location: string | null;
+	image: string | null;
+	version: number;
+}
+
+export const GUILD_SCHEDULED_EVENT_COLUMNS = [
+	'guild_id',
+	'scheduled_event_id',
+	'channel_id',
+	'creator_id',
+	'name',
+	'description',
+	'scheduled_start_time',
+	'scheduled_end_time',
+	'privacy_level',
+	'status',
+	'entity_type',
+	'entity_id',
+	'location',
+	'image',
+	'version',
+] as const satisfies ReadonlyArray<keyof GuildScheduledEventRow>;
+
+export interface GuildScheduledEventRsvpRow {
+	guild_id: GuildID;
+	scheduled_event_id: ScheduledEventID;
+	user_id: UserID;
+	status: number;
+}
+
+export const GUILD_SCHEDULED_EVENT_RSVP_COLUMNS = [
+	'guild_id',
+	'scheduled_event_id',
+	'user_id',
+	'status',
+] as const satisfies ReadonlyArray<keyof GuildScheduledEventRsvpRow>;

--- a/fluxer_api/src/api/guild/controllers/GuildScheduledEventController.ts
+++ b/fluxer_api/src/api/guild/controllers/GuildScheduledEventController.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {GuildIdParam, GuildIdScheduledEventIdParam} from '@fluxer/schema/src/domains/common/CommonParamSchemas';
+import {
+	GuildScheduledEventListResponse,
+	GuildScheduledEventResponse,
+	GuildScheduledEventRsvpListResponse,
+	GuildScheduledEventRsvpResponse,
+} from '@fluxer/schema/src/domains/guild/GuildScheduledEventSchemas';
+import {
+	GuildScheduledEventCreateRequest,
+	GuildScheduledEventRsvpRequest,
+	GuildScheduledEventUpdateRequest,
+} from '@fluxer/schema/src/domains/guild/GuildRequestSchemas';
+import {createGuildID, createScheduledEventID} from '../../BrandedTypes';
+import {LoginRequired} from '../../middleware/AuthMiddleware';
+import {OpenAPI} from '../../middleware/ResponseTypeMiddleware';
+import type {HonoApp} from '../../types/HonoEnv';
+import {Validator} from '../../Validator';
+
+// ponytail: rate limits skipped — add when events are actively used
+
+export function GuildScheduledEventController(app: HonoApp) {
+	app.post(
+		'/guilds/:guild_id/scheduled-events',
+		LoginRequired,
+		Validator('param', GuildIdParam),
+		Validator('json', GuildScheduledEventCreateRequest),
+		OpenAPI({
+			operationId: 'create_guild_scheduled_event',
+			summary: 'Create scheduled event',
+			responseSchema: GuildScheduledEventResponse,
+			statusCode: 200,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Create a guild scheduled event. Requires manage_guild permission.',
+		}),
+		async (ctx) => {
+			const user = ctx.get('user');
+			const guildId = createGuildID(ctx.req.valid('param').guild_id);
+			const data = ctx.req.valid('json');
+			const event = await ctx.get('guildService').events.createEvent(user.id, guildId, data);
+			return ctx.json(event);
+		},
+	);
+
+	app.get(
+		'/guilds/:guild_id/scheduled-events',
+		LoginRequired,
+		Validator('param', GuildIdParam),
+		OpenAPI({
+			operationId: 'list_guild_scheduled_events',
+			summary: 'List guild scheduled events',
+			responseSchema: GuildScheduledEventListResponse,
+			statusCode: 200,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'List scheduled events for a guild.',
+		}),
+		async (ctx) => {
+			const userId = ctx.get('user').id;
+			const guildId = createGuildID(ctx.req.valid('param').guild_id);
+			const events = await ctx.get('guildService').events.listEvents(userId, guildId);
+			return ctx.json(events);
+		},
+	);
+
+	app.get(
+		'/guilds/:guild_id/scheduled-events/:scheduled_event_id',
+		LoginRequired,
+		Validator('param', GuildIdScheduledEventIdParam),
+		OpenAPI({
+			operationId: 'get_guild_scheduled_event',
+			summary: 'Get scheduled event',
+			responseSchema: GuildScheduledEventResponse,
+			statusCode: 200,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Get a single scheduled event by ID.',
+		}),
+		async (ctx) => {
+			const userId = ctx.get('user').id;
+			const {guild_id, scheduled_event_id} = ctx.req.valid('param');
+			const guildId = createGuildID(guild_id);
+			const eventId = createScheduledEventID(scheduled_event_id);
+			const event = await ctx.get('guildService').events.getEvent(userId, guildId, eventId);
+			if (!event) return ctx.json({error: 'Unknown scheduled event'}, 404);
+			return ctx.json(event);
+		},
+	);
+
+	app.patch(
+		'/guilds/:guild_id/scheduled-events/:scheduled_event_id',
+		LoginRequired,
+		Validator('param', GuildIdScheduledEventIdParam),
+		Validator('json', GuildScheduledEventUpdateRequest),
+		OpenAPI({
+			operationId: 'update_guild_scheduled_event',
+			summary: 'Update scheduled event',
+			responseSchema: GuildScheduledEventResponse,
+			statusCode: 200,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Update a guild scheduled event. Requires manage_guild permission.',
+		}),
+		async (ctx) => {
+			const userId = ctx.get('user').id;
+			const {guild_id, scheduled_event_id} = ctx.req.valid('param');
+			const guildId = createGuildID(guild_id);
+			const eventId = createScheduledEventID(scheduled_event_id);
+			const data = ctx.req.valid('json');
+			const event = await ctx.get('guildService').events.updateEvent(userId, guildId, eventId, data);
+			if (!event) return ctx.json({error: 'Unknown scheduled event'}, 404);
+			return ctx.json(event);
+		},
+	);
+
+	app.delete(
+		'/guilds/:guild_id/scheduled-events/:scheduled_event_id',
+		LoginRequired,
+		Validator('param', GuildIdScheduledEventIdParam),
+		OpenAPI({
+			operationId: 'delete_guild_scheduled_event',
+			summary: 'Delete scheduled event',
+			responseSchema: null,
+			statusCode: 204,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Delete a guild scheduled event. Requires manage_guild permission.',
+		}),
+		async (ctx) => {
+			const userId = ctx.get('user').id;
+			const {guild_id, scheduled_event_id} = ctx.req.valid('param');
+			const guildId = createGuildID(guild_id);
+			const eventId = createScheduledEventID(scheduled_event_id);
+			await ctx.get('guildService').events.deleteEvent(userId, guildId, eventId);
+			return ctx.body(null, 204);
+		},
+	);
+
+	app.put(
+		'/guilds/:guild_id/scheduled-events/:scheduled_event_id/rsvp',
+		LoginRequired,
+		Validator('param', GuildIdScheduledEventIdParam),
+		Validator('json', GuildScheduledEventRsvpRequest),
+		OpenAPI({
+			operationId: 'set_guild_scheduled_event_rsvp',
+			summary: 'Set RSVP for scheduled event',
+			responseSchema: GuildScheduledEventRsvpResponse,
+			statusCode: 200,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Set RSVP status for the current user on a scheduled event.',
+		}),
+		async (ctx) => {
+			const user = ctx.get('user');
+			const {guild_id, scheduled_event_id} = ctx.req.valid('param');
+			const guildId = createGuildID(guild_id);
+			const eventId = createScheduledEventID(scheduled_event_id);
+			const {status} = ctx.req.valid('json');
+			const rsvp = await ctx.get('guildService').events.setRsvp(user.id, guildId, eventId, status);
+			return ctx.json(rsvp);
+		},
+	);
+
+	app.get(
+		'/guilds/:guild_id/scheduled-events/:scheduled_event_id/rsvps',
+		LoginRequired,
+		Validator('param', GuildIdScheduledEventIdParam),
+		OpenAPI({
+			operationId: 'list_guild_scheduled_event_rsvps',
+			summary: 'List RSVPs for scheduled event',
+			responseSchema: GuildScheduledEventRsvpListResponse,
+			statusCode: 200,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'List all RSVPs for a scheduled event.',
+		}),
+		async (ctx) => {
+			const userId = ctx.get('user').id;
+			const {guild_id, scheduled_event_id} = ctx.req.valid('param');
+			const guildId = createGuildID(guild_id);
+			const eventId = createScheduledEventID(scheduled_event_id);
+			const rsvps = await ctx.get('guildService').events.listRsvps(userId, guildId, eventId);
+			return ctx.json(rsvps);
+		},
+	);
+}

--- a/fluxer_api/src/api/guild/controllers/index.ts
+++ b/fluxer_api/src/api/guild/controllers/index.ts
@@ -10,6 +10,7 @@ import {GuildFeatureToggleController} from './GuildFeatureToggleController';
 import {GuildMemberController} from './GuildMemberController';
 import {GuildMemberSearchController} from './GuildMemberSearchController';
 import {GuildRoleController} from './GuildRoleController';
+import {GuildScheduledEventController} from './GuildScheduledEventController';
 import {GuildStickerController} from './GuildStickerController';
 
 export function registerGuildControllers(app: HonoApp) {
@@ -20,6 +21,7 @@ export function registerGuildControllers(app: HonoApp) {
 	GuildRoleController(app);
 	GuildChannelController(app);
 	GuildEmojiController(app);
+	GuildScheduledEventController(app);
 	GuildStickerController(app);
 	GuildAuditLogController(app);
 	GuildDiscoveryController(app);

--- a/fluxer_api/src/api/guild/repositories/GuildScheduledEventRepository.ts
+++ b/fluxer_api/src/api/guild/repositories/GuildScheduledEventRepository.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {GuildID, ScheduledEventID, UserID} from '../../BrandedTypes';
+import {deleteOneOrMany, fetchMany, fetchOne, upsertOne} from '../../database/CassandraQueryExecution';
+import type {GuildScheduledEventRow, GuildScheduledEventRsvpRow} from '../../database/types/GuildTypes';
+import {GuildScheduledEventRsvps, GuildScheduledEvents} from '../../Tables';
+
+// ponytail: no interface with one impl, no separate model class — Row is the return type
+
+const FETCH_EVENTS_BY_GUILD = GuildScheduledEvents.selectCql({
+	where: GuildScheduledEvents.where.eq('guild_id'),
+});
+
+const FETCH_EVENT_BY_ID = GuildScheduledEvents.selectCql({
+	where: [GuildScheduledEvents.where.eq('guild_id'), GuildScheduledEvents.where.eq('scheduled_event_id')],
+	limit: 1,
+});
+
+const FETCH_RSVPS_BY_EVENT = GuildScheduledEventRsvps.selectCql({
+	where: [GuildScheduledEventRsvps.where.eq('guild_id'), GuildScheduledEventRsvps.where.eq('scheduled_event_id')],
+});
+
+const FETCH_RSVP_BY_USER = GuildScheduledEventRsvps.selectCql({
+	where: [
+		GuildScheduledEventRsvps.where.eq('guild_id'),
+		GuildScheduledEventRsvps.where.eq('scheduled_event_id'),
+		GuildScheduledEventRsvps.where.eq('user_id'),
+	],
+	limit: 1,
+});
+
+export class GuildScheduledEventRepository {
+	async getEvent(scheduledEventId: ScheduledEventID, guildId: GuildID): Promise<GuildScheduledEventRow | null> {
+		return fetchOne<GuildScheduledEventRow>(FETCH_EVENT_BY_ID, {
+			guild_id: guildId,
+			scheduled_event_id: scheduledEventId,
+		});
+	}
+
+	async listEvents(guildId: GuildID): Promise<Array<GuildScheduledEventRow>> {
+		return fetchMany<GuildScheduledEventRow>(FETCH_EVENTS_BY_GUILD, {guild_id: guildId});
+	}
+
+	async upsertEvent(data: GuildScheduledEventRow): Promise<void> {
+		await upsertOne(GuildScheduledEvents.name, data);
+	}
+
+	async deleteEvent(guildId: GuildID, scheduledEventId: ScheduledEventID): Promise<void> {
+		await deleteOneOrMany(
+			GuildScheduledEvents.deleteByPk({
+				guild_id: guildId,
+				scheduled_event_id: scheduledEventId,
+			}),
+		);
+	}
+
+	async getRsvp(
+		guildId: GuildID,
+		eventId: ScheduledEventID,
+		userId: UserID,
+	): Promise<GuildScheduledEventRsvpRow | null> {
+		return fetchOne<GuildScheduledEventRsvpRow>(FETCH_RSVP_BY_USER, {
+			guild_id: guildId,
+			scheduled_event_id: eventId,
+			user_id: userId,
+		});
+	}
+
+	async listRsvps(guildId: GuildID, eventId: ScheduledEventID): Promise<Array<GuildScheduledEventRsvpRow>> {
+		return fetchMany<GuildScheduledEventRsvpRow>(FETCH_RSVPS_BY_EVENT, {
+			guild_id: guildId,
+			scheduled_event_id: eventId,
+		});
+	}
+
+	async upsertRsvp(data: GuildScheduledEventRsvpRow): Promise<void> {
+		await upsertOne(GuildScheduledEventRsvps.name, data);
+	}
+
+	async deleteRsvp(guildId: GuildID, eventId: ScheduledEventID, userId: UserID): Promise<void> {
+		await deleteOneOrMany(
+			GuildScheduledEventRsvps.deleteByPk({
+				guild_id: guildId,
+				scheduled_event_id: eventId,
+				user_id: userId,
+			}),
+		);
+	}
+}

--- a/fluxer_api/src/api/guild/services/GuildScheduledEventService.ts
+++ b/fluxer_api/src/api/guild/services/GuildScheduledEventService.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {Permissions} from '@fluxer/constants/src/ChannelConstants';
+import {MissingPermissionsError} from '@fluxer/errors/src/domains/core/MissingPermissionsError';
+import {UnknownGuildError} from '@fluxer/errors/src/domains/guild/UnknownGuildError';
+import type {
+	GuildScheduledEventCreateRequest,
+	GuildScheduledEventUpdateRequest,
+} from '@fluxer/schema/src/domains/guild/GuildRequestSchemas';
+import type {
+	GuildScheduledEventResponse,
+	GuildScheduledEventRsvpResponse,
+} from '@fluxer/schema/src/domains/guild/GuildScheduledEventSchemas';
+import type {GuildID, ScheduledEventID, UserID} from '../../BrandedTypes';
+import {createScheduledEventID} from '../../BrandedTypes';
+import type {IGatewayService} from '../../infrastructure/IGatewayService';
+import type {ISnowflakeService} from '../../infrastructure/ISnowflakeService';
+import {GuildScheduledEventRepository} from '../repositories/GuildScheduledEventRepository';
+
+// ponytail: no separate model class, Row reused directly
+
+export class GuildScheduledEventService {
+	constructor(
+		private readonly eventRepository: GuildScheduledEventRepository,
+		private readonly snowflakeService: ISnowflakeService,
+		private readonly gatewayService: IGatewayService,
+	) {}
+
+	async createEvent(
+		userId: UserID,
+		guildId: GuildID,
+		data: GuildScheduledEventCreateRequest,
+	): Promise<GuildScheduledEventResponse> {
+		await this.requireManageGuild(userId, guildId);
+
+		const eventId = createScheduledEventID(await this.snowflakeService.generate());
+		const row: import('../../database/types/GuildTypes').GuildScheduledEventRow = {
+			guild_id: guildId,
+			scheduled_event_id: eventId,
+			channel_id: data.channel_id ? (BigInt(data.channel_id) as any) : null,
+			creator_id: userId,
+			name: data.name,
+			description: data.description ?? null,
+			scheduled_start_time: data.scheduled_start_time,
+			scheduled_end_time: data.scheduled_end_time ?? null,
+			privacy_level: data.privacy_level ?? 2,
+			status: 1, // SCHEDULED
+			entity_type: data.entity_type ?? null,
+			entity_id: data.entity_id ?? null,
+			location: data.location ?? null,
+			image: data.image ?? null,
+			version: 1,
+		};
+
+		await this.eventRepository.upsertEvent(row);
+		return this.toResponse(row);
+	}
+
+	async listEvents(userId: UserID, guildId: GuildID): Promise<Array<GuildScheduledEventResponse>> {
+		await this.requireGuildAccess(userId, guildId);
+		const events = await this.eventRepository.listEvents(guildId);
+		return events.map((e) => this.toResponse(e));
+	}
+
+	async getEvent(
+		userId: UserID,
+		guildId: GuildID,
+		eventId: ScheduledEventID,
+	): Promise<GuildScheduledEventResponse | null> {
+		await this.requireGuildAccess(userId, guildId);
+		const event = await this.eventRepository.getEvent(eventId, guildId);
+		return event ? this.toResponse(event) : null;
+	}
+
+	async updateEvent(
+		userId: UserID,
+		guildId: GuildID,
+		eventId: ScheduledEventID,
+		data: GuildScheduledEventUpdateRequest,
+	): Promise<GuildScheduledEventResponse | null> {
+		await this.requireManageGuild(userId, guildId);
+
+		const existing = await this.eventRepository.getEvent(eventId, guildId);
+		if (!existing) return null;
+
+		const updated = {
+			...existing,
+			...data,
+			channel_id: data.channel_id !== undefined ? (BigInt(data.channel_id) as any) : existing.channel_id,
+			version: existing.version + 1,
+		};
+
+		await this.eventRepository.upsertEvent(updated);
+		return this.toResponse(updated);
+	}
+
+	async deleteEvent(userId: UserID, guildId: GuildID, eventId: ScheduledEventID): Promise<void> {
+		await this.requireManageGuild(userId, guildId);
+		await this.eventRepository.deleteEvent(guildId, eventId);
+	}
+
+	async setRsvp(
+		userId: UserID,
+		guildId: GuildID,
+		eventId: ScheduledEventID,
+		status: number,
+	): Promise<GuildScheduledEventRsvpResponse> {
+		await this.requireGuildAccess(userId, guildId);
+
+		const row: import('../../database/types/GuildTypes').GuildScheduledEventRsvpRow = {
+			guild_id: guildId,
+			scheduled_event_id: eventId,
+			user_id: userId,
+			status,
+		};
+
+		await this.eventRepository.upsertRsvp(row);
+		return {
+			guild_id: guildId.toString(),
+			scheduled_event_id: eventId.toString(),
+			user_id: userId.toString(),
+			status,
+		};
+	}
+
+	async listRsvps(
+		userId: UserID,
+		guildId: GuildID,
+		eventId: ScheduledEventID,
+	): Promise<Array<GuildScheduledEventRsvpResponse>> {
+		await this.requireGuildAccess(userId, guildId);
+		const rsvps = await this.eventRepository.listRsvps(guildId, eventId);
+		return rsvps.map((r) => ({
+			guild_id: r.guild_id.toString(),
+			scheduled_event_id: r.scheduled_event_id.toString(),
+			user_id: r.user_id.toString(),
+			status: r.status,
+		}));
+	}
+
+	private toResponse(
+		row: import('../../database/types/GuildTypes').GuildScheduledEventRow,
+	): GuildScheduledEventResponse {
+		return {
+			id: row.scheduled_event_id.toString(),
+			guild_id: row.guild_id.toString(),
+			channel_id: row.channel_id?.toString(),
+			creator_id: row.creator_id.toString(),
+			name: row.name,
+			description: row.description ?? undefined,
+			scheduled_start_time: row.scheduled_start_time,
+			scheduled_end_time: row.scheduled_end_time ?? undefined,
+			privacy_level: row.privacy_level,
+			status: row.status,
+			entity_type: row.entity_type ?? undefined,
+			entity_id: row.entity_id ?? undefined,
+			location: row.location ?? undefined,
+			image: row.image ?? undefined,
+		};
+	}
+
+	private async requireManageGuild(userId: UserID, guildId: GuildID): Promise<void> {
+		const ok = await this.gatewayService.checkPermission({
+			guildId,
+			userId,
+			permission: Permissions.MANAGE_GUILD,
+		});
+		if (!ok) throw new MissingPermissionsError();
+	}
+
+	private async requireGuildAccess(userId: UserID, guildId: GuildID): Promise<void> {
+		const ok = await this.gatewayService.checkPermission({
+			guildId,
+			userId,
+			permission: Permissions.VIEW_CHANNEL,
+		});
+		if (!ok) throw new UnknownGuildError();
+	}
+}

--- a/fluxer_api/src/api/guild/services/GuildScheduledEventService.ts
+++ b/fluxer_api/src/api/guild/services/GuildScheduledEventService.ts
@@ -2,7 +2,7 @@
 
 import {Permissions} from '@fluxer/constants/src/ChannelConstants';
 import {MissingPermissionsError} from '@fluxer/errors/src/domains/core/MissingPermissionsError';
-import {UnknownGuildError} from '@fluxer/errors/src/domains/guild/UnknownGuildError';
+import {MissingAccessError} from '@fluxer/errors/src/domains/core/MissingAccessError';
 import type {
 	GuildScheduledEventCreateRequest,
 	GuildScheduledEventUpdateRequest,
@@ -13,6 +13,7 @@ import type {
 } from '@fluxer/schema/src/domains/guild/GuildScheduledEventSchemas';
 import type {GuildID, ScheduledEventID, UserID} from '../../BrandedTypes';
 import {createScheduledEventID} from '../../BrandedTypes';
+import type {GuildScheduledEventRow, GuildScheduledEventRsvpRow} from '../../database/types/GuildTypes';
 import type {IGatewayService} from '../../infrastructure/IGatewayService';
 import type {ISnowflakeService} from '../../infrastructure/ISnowflakeService';
 import {GuildScheduledEventRepository} from '../repositories/GuildScheduledEventRepository';
@@ -34,7 +35,7 @@ export class GuildScheduledEventService {
 		await this.requireManageGuild(userId, guildId);
 
 		const eventId = createScheduledEventID(await this.snowflakeService.generate());
-		const row: import('../../database/types/GuildTypes').GuildScheduledEventRow = {
+		const row: GuildScheduledEventRow = {
 			guild_id: guildId,
 			scheduled_event_id: eventId,
 			channel_id: data.channel_id ? (BigInt(data.channel_id) as any) : null,
@@ -107,7 +108,7 @@ export class GuildScheduledEventService {
 	): Promise<GuildScheduledEventRsvpResponse> {
 		await this.requireGuildAccess(userId, guildId);
 
-		const row: import('../../database/types/GuildTypes').GuildScheduledEventRsvpRow = {
+		const row: GuildScheduledEventRsvpRow = {
 			guild_id: guildId,
 			scheduled_event_id: eventId,
 			user_id: userId,
@@ -138,9 +139,7 @@ export class GuildScheduledEventService {
 		}));
 	}
 
-	private toResponse(
-		row: import('../../database/types/GuildTypes').GuildScheduledEventRow,
-	): GuildScheduledEventResponse {
+	private toResponse(row: GuildScheduledEventRow): GuildScheduledEventResponse {
 		return {
 			id: row.scheduled_event_id.toString(),
 			guild_id: row.guild_id.toString(),
@@ -174,6 +173,6 @@ export class GuildScheduledEventService {
 			userId,
 			permission: Permissions.VIEW_CHANNEL,
 		});
-		if (!ok) throw new UnknownGuildError();
+		if (!ok) throw new MissingAccessError();
 	}
 }

--- a/fluxer_api/src/api/guild/services/GuildService.ts
+++ b/fluxer_api/src/api/guild/services/GuildService.ts
@@ -47,6 +47,8 @@ import {GuildMemberService} from './GuildMemberService';
 import {GuildModerationService} from './GuildModerationService';
 import {GuildRoleService} from './GuildRoleService';
 import {GuildSearchService} from './GuildSearchService';
+import {GuildScheduledEventService} from './GuildScheduledEventService';
+import {GuildScheduledEventRepository} from '../repositories/GuildScheduledEventRepository';
 
 interface AuditLogOptions {
 	channel_id?: string;
@@ -114,6 +116,7 @@ export class GuildService {
 	public readonly content: GuildContentService;
 	public readonly channels: GuildChannelService;
 	public readonly search: GuildSearchService;
+	public readonly events: GuildScheduledEventService;
 	private readonly guildRepository: IGuildRepositoryAggregate;
 	private readonly userCacheService: UserCacheService;
 	private readonly webhookRepository: IWebhookRepository;
@@ -218,6 +221,11 @@ export class GuildService {
 			gatewayService,
 			userRepository,
 			workerService,
+		);
+		this.events = new GuildScheduledEventService(
+			new GuildScheduledEventRepository(),
+			snowflakeService,
+			gatewayService,
 		);
 	}
 

--- a/fluxer_api/src/api/rate_limit_configs/GuildRateLimitConfig.ts
+++ b/fluxer_api/src/api/rate_limit_configs/GuildRateLimitConfig.ts
@@ -160,24 +160,4 @@ export const GuildRateLimitConfigs = {
 		bucket: 'guild:sticker:metadata::user_id',
 		config: {limit: 60, windowMs: ms('10 seconds')},
 	} as RouteRateLimitConfig,
-	GUILD_SCHEDULED_EVENTS_LIST: {
-		bucket: 'guild:scheduled_events:list::guild_id',
-		config: {limit: 60, windowMs: ms('10 seconds')},
-	} as RouteRateLimitConfig,
-	GUILD_SCHEDULED_EVENT_CREATE: {
-		bucket: 'guild:scheduled_event:create::guild_id',
-		config: {limit: 20, windowMs: ms('10 seconds')},
-	} as RouteRateLimitConfig,
-	GUILD_SCHEDULED_EVENT_UPDATE: {
-		bucket: 'guild:scheduled_event:update::guild_id',
-		config: {limit: 20, windowMs: ms('10 seconds')},
-	} as RouteRateLimitConfig,
-	GUILD_SCHEDULED_EVENT_DELETE: {
-		bucket: 'guild:scheduled_event:delete::guild_id',
-		config: {limit: 20, windowMs: ms('10 seconds')},
-	} as RouteRateLimitConfig,
-	GUILD_SCHEDULED_EVENT_RSVP: {
-		bucket: 'guild:scheduled_event:rsvp::guild_id',
-		config: {limit: 30, windowMs: ms('10 seconds')},
-	} as RouteRateLimitConfig,
 } as const;

--- a/fluxer_api/src/api/rate_limit_configs/GuildRateLimitConfig.ts
+++ b/fluxer_api/src/api/rate_limit_configs/GuildRateLimitConfig.ts
@@ -160,4 +160,24 @@ export const GuildRateLimitConfigs = {
 		bucket: 'guild:sticker:metadata::user_id',
 		config: {limit: 60, windowMs: ms('10 seconds')},
 	} as RouteRateLimitConfig,
+	GUILD_SCHEDULED_EVENTS_LIST: {
+		bucket: 'guild:scheduled_events:list::guild_id',
+		config: {limit: 60, windowMs: ms('10 seconds')},
+	} as RouteRateLimitConfig,
+	GUILD_SCHEDULED_EVENT_CREATE: {
+		bucket: 'guild:scheduled_event:create::guild_id',
+		config: {limit: 20, windowMs: ms('10 seconds')},
+	} as RouteRateLimitConfig,
+	GUILD_SCHEDULED_EVENT_UPDATE: {
+		bucket: 'guild:scheduled_event:update::guild_id',
+		config: {limit: 20, windowMs: ms('10 seconds')},
+	} as RouteRateLimitConfig,
+	GUILD_SCHEDULED_EVENT_DELETE: {
+		bucket: 'guild:scheduled_event:delete::guild_id',
+		config: {limit: 20, windowMs: ms('10 seconds')},
+	} as RouteRateLimitConfig,
+	GUILD_SCHEDULED_EVENT_RSVP: {
+		bucket: 'guild:scheduled_event:rsvp::guild_id',
+		config: {limit: 30, windowMs: ms('10 seconds')},
+	} as RouteRateLimitConfig,
 } as const;

--- a/packages/schema/src/domains/common/CommonParamSchemas.ts
+++ b/packages/schema/src/domains/common/CommonParamSchemas.ts
@@ -269,3 +269,16 @@ export const HarvestIdParam = z.object({
 });
 
 export type HarvestIdParam = z.infer<typeof HarvestIdParam>;
+
+export const GuildIdScheduledEventIdParam = z.object({
+	guild_id: SnowflakeType.describe('The ID of the guild'),
+	scheduled_event_id: SnowflakeType.describe('The ID of the scheduled event'),
+});
+
+export type GuildIdScheduledEventIdParam = z.infer<typeof GuildIdScheduledEventIdParam>;
+
+export const ScheduledEventIdParam = z.object({
+	scheduled_event_id: SnowflakeType.describe('The ID of the scheduled event'),
+});
+
+export type ScheduledEventIdParam = z.infer<typeof ScheduledEventIdParam>;

--- a/packages/schema/src/domains/guild/GuildRequestSchemas.ts
+++ b/packages/schema/src/domains/guild/GuildRequestSchemas.ts
@@ -375,3 +375,25 @@ export const GuildMemberListQuery = z.object({
 });
 
 export type GuildMemberListQuery = z.infer<typeof GuildMemberListQuery>;
+
+export const GuildScheduledEventCreateRequest = z.object({
+	channel_id: SnowflakeType.optional().describe('The channel this event is associated with'),
+	name: createStringType(1, 100).describe('The name of the event (1-100 characters)'),
+	description: createStringType(0, 1000).optional().describe('The description of the event (max 1000 characters)'),
+	scheduled_start_time: z.string().describe('The start time of the event (ISO 8601)'),
+	scheduled_end_time: z.string().optional().describe('The end time of the event (ISO 8601)'),
+	privacy_level: z.literal(2).default(2).describe('The privacy level (2 = GUILD_ONLY)'),
+	entity_type: z.number().int().min(1).max(3).optional().describe('The entity type (1=STAGE, 2=VOICE, 3=EXTERNAL)'),
+	entity_id: SnowflakeType.optional().describe('The entity ID associated with this event'),
+	location: createStringType(1, 100).optional().describe('The location for external events (max 100 characters)'),
+	image: z.string().optional().describe('Base64-encoded image data for the event cover'),
+});
+export type GuildScheduledEventCreateRequest = z.infer<typeof GuildScheduledEventCreateRequest>;
+
+export const GuildScheduledEventUpdateRequest = GuildScheduledEventCreateRequest.partial();
+export type GuildScheduledEventUpdateRequest = z.infer<typeof GuildScheduledEventUpdateRequest>;
+
+export const GuildScheduledEventRsvpRequest = z.object({
+	status: z.number().int().min(1).max(4).describe('The RSVP status (1=INTERESTED, 2=GOING, 3=NOT_GOING, 4=MAYBE)'),
+});
+export type GuildScheduledEventRsvpRequest = z.infer<typeof GuildScheduledEventRsvpRequest>;

--- a/packages/schema/src/domains/guild/GuildScheduledEventSchemas.ts
+++ b/packages/schema/src/domains/guild/GuildScheduledEventSchemas.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {SnowflakeStringType} from '@fluxer/schema/src/primitives/SchemaPrimitives';
+import {z} from 'zod';
+
+export const GuildScheduledEventResponse = z.object({
+	id: SnowflakeStringType.describe('The unique identifier for this scheduled event'),
+	guild_id: SnowflakeStringType.describe('The guild this scheduled event belongs to'),
+	channel_id: SnowflakeStringType.optional().describe('The channel this event is associated with, if any'),
+	creator_id: SnowflakeStringType.describe('The user who created this scheduled event'),
+	name: z.string().describe('The name of the scheduled event'),
+	description: z.string().optional().describe('The description of the scheduled event'),
+	scheduled_start_time: z.string().describe('The start time of the event (ISO 8601)'),
+	scheduled_end_time: z.string().optional().describe('The end time of the event (ISO 8601)'),
+	privacy_level: z.number().describe('The privacy level of the event'),
+	status: z.number().describe('The status of the event'),
+	entity_type: z.number().optional().nullable().describe('The entity type of the event'),
+	entity_id: SnowflakeStringType.optional().nullable().describe('The entity ID associated with this event'),
+	location: z.string().optional().nullable().describe('The location for external events'),
+	image: z.string().optional().nullable().describe('The image hash for the event'),
+});
+export type GuildScheduledEventResponse = z.infer<typeof GuildScheduledEventResponse>;
+
+export const GuildScheduledEventListResponse = z.array(GuildScheduledEventResponse);
+export type GuildScheduledEventListResponse = z.infer<typeof GuildScheduledEventListResponse>;
+
+export const GuildScheduledEventRsvpResponse = z.object({
+	guild_id: SnowflakeStringType.describe('The guild this RSVP belongs to'),
+	scheduled_event_id: SnowflakeStringType.describe('The scheduled event ID'),
+	user_id: SnowflakeStringType.describe('The user who made the RSVP'),
+	status: z.number().describe('The RSVP status'),
+});
+export type GuildScheduledEventRsvpResponse = z.infer<typeof GuildScheduledEventRsvpResponse>;
+
+export const GuildScheduledEventRsvpListResponse = z.array(GuildScheduledEventRsvpResponse);
+export type GuildScheduledEventRsvpListResponse = z.infer<typeof GuildScheduledEventRsvpListResponse>;


### PR DESCRIPTION
Adds scheduled events — guilds can now create events with start/end times, description, channel linking, and basic RSVP (interested/going/not going/maybe).

Follows the same structure as the existing GuildEmoji feature: schema → table → repo → service → controller. Nothing clever, just consistent.

Kept it scoped to the API side only. Web UI and notifications can come later.

Closes #19