### PR TITLE
fix(AdminSchemas): partial schema instead of optional

### DIFF
--- a/packages/schema/src/domains/admin/AdminSchemas.ts
+++ b/packages/schema/src/domains/admin/AdminSchemas.ts
@@ -1428,7 +1428,7 @@ export const LimitConfigGetResponse = z.object({
 	}),
 	limit_config_json: z.string(),
 	self_hosted: z.boolean(),
-	defaults: z.record(z.string(), z.record(LimitKeySchema, z.number().optional())),
+	defaults: z.record(z.string(), z.partialRecord(LimitKeySchema, z.number())),
 	metadata: z.record(LimitKeySchema, LimitKeyMetadataSchema),
 	categories: z.record(z.string(), z.string()),
 	limit_keys: z.array(z.string()),


### PR DESCRIPTION
## Summary

- What changed: Dropping optional to use a partial record
- Why it is correct: Intent. Optional means present and `undefined`, which is not possible here
- Risk: None

## Verification

- Tests run: None
- Manual checks: None
- Screenshots or recordings: N/A

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None
