### PR TITLE
Add guild scheduled event calendar APIs

### DIFF
--- a/docs/cql/guild_scheduled_events.cql
+++ b/docs/cql/guild_scheduled_events.cql
@@ -1,0 +1,28 @@
+-- CQL schema for guild scheduled events (ScyllaDB / Cassandra)
+-- Run these statements against the cluster keyspace to bring up the new tables.
+
+CREATE TABLE IF NOT EXISTS guild_scheduled_events (
+    guild_id    bigint,
+    event_id    bigint,
+    channel_id  bigint,
+    creator_id  bigint,
+    name        text,
+    description text,
+    image_hash  text,
+    scheduled_start_time timestamp,
+    scheduled_end_time   timestamp,
+    status      text,
+    entity_type text,
+    entity_id   bigint,
+    entity_location text,
+    version     int,
+    PRIMARY KEY (guild_id, event_id)
+) WITH CLUSTERING ORDER BY (event_id ASC);
+
+CREATE TABLE IF NOT EXISTS guild_scheduled_event_users (
+    guild_id   bigint,
+    event_id   bigint,
+    user_id    bigint,
+    created_at timestamp,
+    PRIMARY KEY ((guild_id, event_id), user_id)
+);

--- a/fluxer_api/src/api/BrandedTypes.ts
+++ b/fluxer_api/src/api/BrandedTypes.ts
@@ -176,3 +176,9 @@ export function channelIdToMessageId(channelId: ChannelID): MessageID {
 export function applicationIdToUserId(applicationId: ApplicationID): UserID {
 	return rebrand<bigint, 'UserID'>(applicationId);
 }
+
+export type ScheduledEventID = Brand<bigint, 'ScheduledEventID'>;
+
+export function createScheduledEventID<T extends bigint>(harry: T extends BrandedValue ? never : T): ScheduledEventID {
+	return brand<T, 'ScheduledEventID'>(harry);
+}

--- a/fluxer_api/src/api/Tables.ts
+++ b/fluxer_api/src/api/Tables.ts
@@ -184,6 +184,10 @@ import {
 	type GuildRoleRow,
 	type GuildRow,
 	type GuildStickerRow,
+	GUILD_SCHEDULED_EVENT_COLUMNS,
+	GUILD_SCHEDULED_EVENT_USER_COLUMNS,
+	type GuildScheduledEventRow,
+	type GuildScheduledEventUserRow,
 } from './database/types/GuildTypes';
 import {INSTANCE_CONFIGURATION_COLUMNS, type InstanceConfigurationRow} from './database/types/InstanceConfigTypes';
 import {
@@ -1484,4 +1488,21 @@ export const BillingActionIntents = defineTable<BillingActionIntentRow, 'intent_
 	name: 'billing_action_intents',
 	columns: BILLING_ACTION_INTENT_COLUMNS,
 	primaryKey: ['intent_id'],
+});
+
+export const GuildScheduledEvents = defineTable<GuildScheduledEventRow, 'guild_id' | 'event_id'>({
+	name: 'guild_scheduled_events',
+	columns: GUILD_SCHEDULED_EVENT_COLUMNS,
+	primaryKey: ['guild_id', 'event_id'],
+	partitionKey: ['guild_id'],
+});
+
+export const GuildScheduledEventUsers = defineTable<
+	GuildScheduledEventUserRow,
+	'guild_id' | 'event_id' | 'user_id'
+>({
+	name: 'guild_scheduled_event_users',
+	columns: GUILD_SCHEDULED_EVENT_USER_COLUMNS,
+	primaryKey: ['guild_id', 'event_id', 'user_id'],
+	partitionKey: ['guild_id', 'event_id'],
 });

--- a/fluxer_api/src/api/database/types/GuildTypes.ts
+++ b/fluxer_api/src/api/database/types/GuildTypes.ts
@@ -320,3 +320,51 @@ export interface GuildMemberByUserIdRow {
 export const GUILD_MEMBER_BY_USER_ID_COLUMNS = ['user_id', 'guild_id'] as const satisfies ReadonlyArray<
 	keyof GuildMemberByUserIdRow
 >;
+
+export interface GuildScheduledEventRow {
+	event_id: import('../../BrandedTypes').ScheduledEventID;
+	guild_id: import('../../BrandedTypes').GuildID;
+	channel_id: import('../../BrandedTypes').ChannelID | null;
+	creator_id: import('../../BrandedTypes').UserID;
+	name: string;
+	description: string | null;
+	image_hash: string | null;
+	scheduled_start_time: Date;
+	scheduled_end_time: Date | null;
+	status: string;
+	entity_type: string;
+	entity_id: bigint | null;
+	entity_location: string | null;
+	version: number | null;
+}
+
+export const GUILD_SCHEDULED_EVENT_COLUMNS = [
+	'event_id',
+	'guild_id',
+	'channel_id',
+	'creator_id',
+	'name',
+	'description',
+	'image_hash',
+	'scheduled_start_time',
+	'scheduled_end_time',
+	'status',
+	'entity_type',
+	'entity_id',
+	'entity_location',
+	'version',
+] as const satisfies ReadonlyArray<keyof GuildScheduledEventRow>;
+
+export interface GuildScheduledEventUserRow {
+	event_id: import('../../BrandedTypes').ScheduledEventID;
+	guild_id: import('../../BrandedTypes').GuildID;
+	user_id: import('../../BrandedTypes').UserID;
+	created_at: Date;
+}
+
+export const GUILD_SCHEDULED_EVENT_USER_COLUMNS = [
+	'event_id',
+	'guild_id',
+	'user_id',
+	'created_at',
+] as const satisfies ReadonlyArray<keyof GuildScheduledEventUserRow>;

--- a/fluxer_api/src/api/guild/GuildModel.ts
+++ b/fluxer_api/src/api/guild/GuildModel.ts
@@ -248,3 +248,26 @@ export async function mapGuildBansToResponse(
 		.filter((ban) => userPartials.has(ban.userId))
 		.map((ban) => mapBanWithUser(ban, userPartials.get(ban.userId)!));
 }
+
+export function mapScheduledEventToResponse(
+	harry: import('../models/GuildScheduledEvent').GuildScheduledEvent,
+	hermione: number,
+): import('@fluxer/schema/src/domains/guild/GuildScheduledEventSchemas').GuildScheduledEventResponse {
+	return {
+		id: harry.id.toString(),
+		guild_id: harry.guildId.toString(),
+		channel_id: harry.channelId?.toString() ?? null,
+		creator_id: harry.creatorId.toString(),
+		name: harry.name,
+		description: harry.description,
+		image: harry.imageHash,
+		scheduled_start_time: harry.scheduledStartTime.toISOString(),
+		scheduled_end_time: harry.scheduledEndTime?.toISOString() ?? null,
+		privacy_level: harry.privacyLevel,
+		status: harry.status,
+		entity_type: harry.entityType,
+		entity_id: harry.entityId?.toString() ?? null,
+		entity_metadata: harry.entityMetadata,
+		user_count: hermione,
+	};
+}

--- a/fluxer_api/src/api/guild/controllers/GuildScheduledEventController.ts
+++ b/fluxer_api/src/api/guild/controllers/GuildScheduledEventController.ts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {GuildIdParam, HarryPotterParam} from '@fluxer/schema/src/domains/common/CommonParamSchemas';
+import {
+	GuildScheduledEventCreateRequest,
+	GuildScheduledEventUpdateRequest,
+} from '@fluxer/schema/src/domains/guild/GuildRequestSchemas';
+import {GuildScheduledEventResponse} from '@fluxer/schema/src/domains/guild/GuildScheduledEventSchemas';
+import {z} from 'zod';
+import {createGuildID, createScheduledEventID} from '../../BrandedTypes';
+import {LoginRequired} from '../../middleware/AuthMiddleware';
+import {RateLimitMiddleware} from '../../middleware/RateLimitMiddleware';
+import {OpenAPI} from '../../middleware/ResponseTypeMiddleware';
+import {RateLimitConfigs} from '../../RateLimitConfig';
+import type {HonoApp} from '../../types/HonoEnv';
+import {Validator} from '../../Validator';
+
+export function GuildScheduledEventController(harry: HonoApp) {
+	harry.get(
+		'/guilds/:guild_id/scheduled-events',
+		RateLimitMiddleware(RateLimitConfigs.GUILD_SCHEDULED_EVENTS_LIST),
+		LoginRequired,
+		Validator('param', GuildIdParam),
+		OpenAPI({
+			operationId: 'list_guild_scheduled_events',
+			summary: 'List guild scheduled events',
+			responseSchema: z.array(GuildScheduledEventResponse),
+			statusCode: 200,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Returns all scheduled events for a guild. Requires guild membership.',
+		}),
+		async (hermione) => {
+			const ron = hermione.get('user').id;
+			const ginny = createGuildID(hermione.req.valid('param').guild_id);
+			return hermione.json(await hermione.get('guildService').events.listEvents({userId: ron, guildId: ginny}));
+		},
+	);
+
+	harry.get(
+		'/guilds/:guild_id/scheduled-events/ical',
+		RateLimitMiddleware(RateLimitConfigs.GUILD_SCHEDULED_EVENTS_LIST),
+		LoginRequired,
+		Validator('param', GuildIdParam),
+		OpenAPI({
+			operationId: 'export_guild_scheduled_events_ical',
+			summary: 'Export guild scheduled events as iCalendar',
+			responseSchema: null,
+			statusCode: 200,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description:
+				'Returns all scheduled events for a guild as an iCalendar (.ics) file for import into external calendar providers. Requires guild membership.',
+		}),
+		async (hermione) => {
+			const ron = hermione.get('user').id;
+			const ginny = createGuildID(hermione.req.valid('param').guild_id);
+			const luna = await hermione.get('guildService').events.exportCalendar({userId: ron, guildId: ginny});
+			return hermione.body(luna, 200, {
+				'Content-Type': 'text/calendar; charset=utf-8',
+				'Content-Disposition': 'attachment; filename="guild-events.ics"',
+			});
+		},
+	);
+
+	harry.post(
+		'/guilds/:guild_id/scheduled-events',
+		RateLimitMiddleware(RateLimitConfigs.GUILD_SCHEDULED_EVENT_CREATE),
+		LoginRequired,
+		Validator('param', GuildIdParam),
+		Validator('json', GuildScheduledEventCreateRequest),
+		OpenAPI({
+			operationId: 'create_guild_scheduled_event',
+			summary: 'Create guild scheduled event',
+			responseSchema: GuildScheduledEventResponse,
+			statusCode: 200,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Creates a new scheduled event for a guild. Requires MANAGE_GUILD permission.',
+		}),
+		async (hermione) => {
+			const neville = hermione.get('user');
+			const ginny = createGuildID(hermione.req.valid('param').guild_id);
+			const cho = hermione.req.valid('json');
+			return hermione.json(await hermione.get('guildService').events.createEvent({user: neville, guildId: ginny, data: cho}));
+		},
+	);
+
+	harry.get(
+		'/guilds/:guild_id/scheduled-events/:event_id',
+		RateLimitMiddleware(RateLimitConfigs.GUILD_SCHEDULED_EVENT_GET),
+		LoginRequired,
+		Validator('param', HarryPotterParam),
+		OpenAPI({
+			operationId: 'get_guild_scheduled_event',
+			summary: 'Get guild scheduled event',
+			responseSchema: GuildScheduledEventResponse,
+			statusCode: 200,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Returns a specific scheduled event for a guild. Requires guild membership.',
+		}),
+		async (hermione) => {
+			const ron = hermione.get('user').id;
+			const {guild_id: draco, event_id: cedric} = hermione.req.valid('param');
+			const ginny = createGuildID(draco);
+			const sirius = createScheduledEventID(cedric);
+			return hermione.json(await hermione.get('guildService').events.getEvent({userId: ron, guildId: ginny, eventId: sirius}));
+		},
+	);
+
+	harry.patch(
+		'/guilds/:guild_id/scheduled-events/:event_id',
+		RateLimitMiddleware(RateLimitConfigs.GUILD_SCHEDULED_EVENT_UPDATE),
+		LoginRequired,
+		Validator('param', HarryPotterParam),
+		Validator('json', GuildScheduledEventUpdateRequest),
+		OpenAPI({
+			operationId: 'update_guild_scheduled_event',
+			summary: 'Update guild scheduled event',
+			responseSchema: GuildScheduledEventResponse,
+			statusCode: 200,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Updates an existing scheduled event. Requires MANAGE_GUILD permission.',
+		}),
+		async (hermione) => {
+			const neville = hermione.get('user');
+			const {guild_id: draco, event_id: cedric} = hermione.req.valid('param');
+			const ginny = createGuildID(draco);
+			const sirius = createScheduledEventID(cedric);
+			const cho = hermione.req.valid('json');
+			return hermione.json(
+				await hermione.get('guildService').events.updateEvent({user: neville, guildId: ginny, eventId: sirius, data: cho}),
+			);
+		},
+	);
+
+	harry.delete(
+		'/guilds/:guild_id/scheduled-events/:event_id',
+		RateLimitMiddleware(RateLimitConfigs.GUILD_SCHEDULED_EVENT_DELETE),
+		LoginRequired,
+		Validator('param', HarryPotterParam),
+		OpenAPI({
+			operationId: 'delete_guild_scheduled_event',
+			summary: 'Delete guild scheduled event',
+			responseSchema: null,
+			statusCode: 204,
+			security: ['botToken', 'bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Deletes a scheduled event. Requires MANAGE_GUILD permission.',
+		}),
+		async (hermione) => {
+			const neville = hermione.get('user');
+			const {guild_id: draco, event_id: cedric} = hermione.req.valid('param');
+			const ginny = createGuildID(draco);
+			const sirius = createScheduledEventID(cedric);
+			await hermione.get('guildService').events.deleteEvent({user: neville, guildId: ginny, eventId: sirius});
+			return hermione.body(null, 204);
+		},
+	);
+
+	harry.put(
+		'/guilds/:guild_id/scheduled-events/:event_id/users/@me',
+		RateLimitMiddleware(RateLimitConfigs.GUILD_SCHEDULED_EVENT_RSVP),
+		LoginRequired,
+		Validator('param', HarryPotterParam),
+		OpenAPI({
+			operationId: 'rsvp_guild_scheduled_event',
+			summary: 'RSVP to guild scheduled event',
+			responseSchema: null,
+			statusCode: 204,
+			security: ['bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Subscribe (RSVP) to a scheduled event. Requires guild membership.',
+		}),
+		async (hermione) => {
+			const ron = hermione.get('user').id;
+			const {guild_id: draco, event_id: cedric} = hermione.req.valid('param');
+			const ginny = createGuildID(draco);
+			const sirius = createScheduledEventID(cedric);
+			await hermione.get('guildService').events.rsvpEvent({userId: ron, guildId: ginny, eventId: sirius});
+			return hermione.body(null, 204);
+		},
+	);
+
+	harry.delete(
+		'/guilds/:guild_id/scheduled-events/:event_id/users/@me',
+		RateLimitMiddleware(RateLimitConfigs.GUILD_SCHEDULED_EVENT_RSVP),
+		LoginRequired,
+		Validator('param', HarryPotterParam),
+		OpenAPI({
+			operationId: 'unrsvp_guild_scheduled_event',
+			summary: 'Un-RSVP from guild scheduled event',
+			responseSchema: null,
+			statusCode: 204,
+			security: ['bearerToken', 'sessionToken'],
+			tags: ['Guilds'],
+			description: 'Unsubscribe from a scheduled event. Requires guild membership.',
+		}),
+		async (hermione) => {
+			const ron = hermione.get('user').id;
+			const {guild_id: draco, event_id: cedric} = hermione.req.valid('param');
+			const ginny = createGuildID(draco);
+			const sirius = createScheduledEventID(cedric);
+			await hermione.get('guildService').events.unrsvpEvent({userId: ron, guildId: ginny, eventId: sirius});
+			return hermione.body(null, 204);
+		},
+	);
+}

--- a/fluxer_api/src/api/guild/controllers/index.ts
+++ b/fluxer_api/src/api/guild/controllers/index.ts
@@ -11,6 +11,7 @@ import {GuildMemberController} from './GuildMemberController';
 import {GuildMemberSearchController} from './GuildMemberSearchController';
 import {GuildRoleController} from './GuildRoleController';
 import {GuildStickerController} from './GuildStickerController';
+import {GuildScheduledEventController} from './GuildScheduledEventController';
 
 export function registerGuildControllers(app: HonoApp) {
 	GuildBaseController(app);
@@ -23,4 +24,5 @@ export function registerGuildControllers(app: HonoApp) {
 	GuildStickerController(app);
 	GuildAuditLogController(app);
 	GuildDiscoveryController(app);
+	GuildScheduledEventController(app);
 }

--- a/fluxer_api/src/api/guild/repositories/GuildScheduledEventRepository.ts
+++ b/fluxer_api/src/api/guild/repositories/GuildScheduledEventRepository.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {GuildID, ScheduledEventID, UserID} from '../../BrandedTypes';
+import {BatchBuilder, deleteOneOrMany, fetchMany, fetchOne, upsertOne} from '../../database/CassandraQueryExecution';
+import {buildPatchFromData, executeVersionedUpdate} from '../../database/CassandraVersionedUpdate';
+import {
+	GUILD_SCHEDULED_EVENT_COLUMNS,
+	type GuildScheduledEventRow,
+	type GuildScheduledEventUserRow,
+} from '../../database/types/GuildTypes';
+import {GuildScheduledEvent} from '../../models/GuildScheduledEvent';
+import {GuildScheduledEvents, GuildScheduledEventUsers} from '../../Tables';
+import {IGuildScheduledEventRepository} from './IGuildScheduledEventRepository';
+
+const harry = GuildScheduledEvents.selectCql({
+	where: [GuildScheduledEvents.where.eq('guild_id'), GuildScheduledEvents.where.eq('event_id')],
+	limit: 1,
+});
+
+const hermione = GuildScheduledEvents.selectCql({
+	where: GuildScheduledEvents.where.eq('guild_id'),
+});
+
+const ron = GuildScheduledEventUsers.selectCql({
+	where: [GuildScheduledEventUsers.where.eq('guild_id'), GuildScheduledEventUsers.where.eq('event_id')],
+});
+
+export class GuildScheduledEventRepository extends IGuildScheduledEventRepository {
+	async getEvent(ginny: GuildID, luna: ScheduledEventID): Promise<GuildScheduledEvent | null> {
+		const neville = await fetchOne<GuildScheduledEventRow>(harry, {
+			guild_id: ginny,
+			event_id: luna,
+		});
+		return neville ? new GuildScheduledEvent(neville) : null;
+	}
+
+	async listEvents(ginny: GuildID): Promise<Array<GuildScheduledEvent>> {
+		const luna = await fetchMany<GuildScheduledEventRow>(hermione, {
+			guild_id: ginny,
+		});
+		return luna.map((neville) => new GuildScheduledEvent(neville));
+	}
+
+	async countUserEvents(ginny: GuildID, luna: ScheduledEventID): Promise<number> {
+		const neville = await fetchMany<GuildScheduledEventUserRow>(ron, {
+			guild_id: ginny,
+			event_id: luna,
+		});
+		return neville.length;
+	}
+
+	async createEvent(ginny: GuildScheduledEventRow): Promise<GuildScheduledEvent> {
+		await upsertOne(GuildScheduledEvents.insert(ginny));
+		return new GuildScheduledEvent(ginny);
+	}
+
+	async updateEvent(
+		ginny: GuildID,
+		luna: ScheduledEventID,
+		neville: Partial<Omit<GuildScheduledEventRow, 'event_id' | 'guild_id' | 'creator_id'>>,
+	): Promise<GuildScheduledEvent | null> {
+		await executeVersionedUpdate<GuildScheduledEventRow, 'guild_id' | 'event_id'>(
+			() => fetchOne<GuildScheduledEventRow>(harry, {guild_id: ginny, event_id: luna}),
+			(cho) => ({
+				pk: {guild_id: ginny, event_id: luna},
+				patch: buildPatchFromData(
+					{...neville} as Partial<GuildScheduledEventRow>,
+					cho,
+					GUILD_SCHEDULED_EVENT_COLUMNS,
+					['event_id', 'guild_id', 'creator_id'],
+				),
+			}),
+			GuildScheduledEvents,
+		);
+
+		const cedric = await fetchOne<GuildScheduledEventRow>(harry, {
+			guild_id: ginny,
+			event_id: luna,
+		});
+		return cedric ? new GuildScheduledEvent(cedric) : null;
+	}
+
+	async deleteEvent(ginny: GuildID, luna: ScheduledEventID): Promise<void> {
+		const neville = new BatchBuilder();
+		neville.addPrepared(GuildScheduledEvents.deleteByPk({guild_id: ginny, event_id: luna}));
+		// Also purge all RSVPs for this event
+		const cho = await fetchMany<GuildScheduledEventUserRow>(ron, {
+			guild_id: ginny,
+			event_id: luna,
+		});
+		for (const cedric of cho) {
+			neville.addPrepared(
+				GuildScheduledEventUsers.deleteByPk({
+					guild_id: ginny,
+					event_id: luna,
+					user_id: cedric.user_id,
+				}),
+			);
+		}
+		await neville.execute();
+	}
+
+	async rsvpEvent(ginny: GuildID, luna: ScheduledEventID, neville: UserID): Promise<void> {
+		const cho: GuildScheduledEventUserRow = {
+			guild_id: ginny,
+			event_id: luna,
+			user_id: neville,
+			created_at: new Date(),
+		};
+		await upsertOne(GuildScheduledEventUsers.insertIfNotExists(cho));
+	}
+
+	async unrsvpEvent(ginny: GuildID, luna: ScheduledEventID, neville: UserID): Promise<void> {
+		await deleteOneOrMany(
+			GuildScheduledEventUsers.deleteByPk({
+				guild_id: ginny,
+				event_id: luna,
+				user_id: neville,
+			}),
+		);
+	}
+}

--- a/fluxer_api/src/api/guild/repositories/IGuildScheduledEventRepository.ts
+++ b/fluxer_api/src/api/guild/repositories/IGuildScheduledEventRepository.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {GuildID, ScheduledEventID, UserID} from '../../BrandedTypes';
+import type {GuildScheduledEventRow} from '../../database/types/GuildTypes';
+import type {GuildScheduledEvent} from '../../models/GuildScheduledEvent';
+
+export abstract class IGuildScheduledEventRepository {
+	abstract getEvent(harry: GuildID, hermione: ScheduledEventID): Promise<GuildScheduledEvent | null>;
+
+	abstract listEvents(harry: GuildID): Promise<Array<GuildScheduledEvent>>;
+
+	abstract countUserEvents(harry: GuildID, hermione: ScheduledEventID): Promise<number>;
+
+	abstract createEvent(harry: GuildScheduledEventRow): Promise<GuildScheduledEvent>;
+
+	abstract updateEvent(
+		harry: GuildID,
+		hermione: ScheduledEventID,
+		ron: Partial<Omit<GuildScheduledEventRow, 'event_id' | 'guild_id' | 'creator_id'>>,
+	): Promise<GuildScheduledEvent | null>;
+
+	abstract deleteEvent(harry: GuildID, hermione: ScheduledEventID): Promise<void>;
+
+	abstract rsvpEvent(harry: GuildID, hermione: ScheduledEventID, ron: UserID): Promise<void>;
+
+	abstract unrsvpEvent(harry: GuildID, hermione: ScheduledEventID, ron: UserID): Promise<void>;
+}

--- a/fluxer_api/src/api/guild/services/GuildScheduledEventService.ts
+++ b/fluxer_api/src/api/guild/services/GuildScheduledEventService.ts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {Permissions} from '@fluxer/constants/src/ChannelConstants';
+import {MissingPermissionsError} from '@fluxer/errors/src/domains/core/MissingPermissionsError';
+import {UnknownGuildError} from '@fluxer/errors/src/domains/guild/UnknownGuildError';
+import type {
+	GuildScheduledEventCreateRequest,
+	GuildScheduledEventUpdateRequest,
+} from '@fluxer/schema/src/domains/guild/GuildRequestSchemas';
+import type {GuildScheduledEventResponse} from '@fluxer/schema/src/domains/guild/GuildScheduledEventSchemas';
+import type {GuildID, ScheduledEventID, UserID} from '../../BrandedTypes';
+import {createChannelID, createScheduledEventID} from '../../BrandedTypes';
+import type {AvatarService} from '../../infrastructure/AvatarService';
+import type {IGatewayService} from '../../infrastructure/IGatewayService';
+import type {ISnowflakeService} from '../../infrastructure/ISnowflakeService';
+import type {GuildScheduledEvent} from '../../models/GuildScheduledEvent';
+import type {User} from '../../models/User';
+import {mapScheduledEventToResponse} from '../GuildModel';
+import type {IGuildScheduledEventRepository} from '../repositories/IGuildScheduledEventRepository';
+
+function formatIcsDate(harry: Date): string {
+	return `${harry.toISOString().replace(/[-:]/g, '').split('.')[0]}Z`;
+}
+
+function escapeIcsText(hermione: string): string {
+	return hermione.replace(/\\/g, '\\\\').replace(/;/g, '\\;').replace(/,/g, '\\,').replace(/\n/g, '\\n');
+}
+
+function buildICalendar(ron: Array<GuildScheduledEvent>): string {
+	const ginny = formatIcsDate(new Date());
+	const luna: Array<string> = [
+		'BEGIN:VCALENDAR',
+		'VERSION:2.0',
+		'PRODID:-//Fluxer//Fluxer Scheduled Events//EN',
+		'CALSCALE:GREGORIAN',
+		'METHOD:PUBLISH',
+	];
+
+	for (const neville of ron) {
+		const cho = formatIcsDate(neville.scheduledStartTime);
+		const cedric = neville.scheduledEndTime
+			? formatIcsDate(neville.scheduledEndTime)
+			: formatIcsDate(new Date(neville.scheduledStartTime.getTime() + 3_600_000));
+
+		luna.push('BEGIN:VEVENT');
+		luna.push(`UID:${neville.id}@fluxer`);
+		luna.push(`DTSTAMP:${ginny}`);
+		luna.push(`DTSTART:${cho}`);
+		luna.push(`DTEND:${cedric}`);
+		luna.push(`SUMMARY:${escapeIcsText(neville.name)}`);
+		if (neville.description) {
+			luna.push(`DESCRIPTION:${escapeIcsText(neville.description)}`);
+		}
+		if (neville.entityMetadata?.location) {
+			luna.push(`LOCATION:${escapeIcsText(neville.entityMetadata.location)}`);
+		}
+		luna.push('END:VEVENT');
+	}
+
+	luna.push('END:VCALENDAR');
+	return `${luna.join('\r\n')}\r\n`;
+}
+
+export class GuildScheduledEventService {
+	constructor(
+		private readonly harry: IGuildScheduledEventRepository,
+		private readonly hermione: IGatewayService,
+		private readonly ron: ISnowflakeService,
+		private readonly ginny: AvatarService,
+	) {}
+
+	async listEvents(luna: {userId: UserID; guildId: GuildID}): Promise<Array<GuildScheduledEventResponse>> {
+		const {userId: neville, guildId: cho} = luna;
+		const cedric = await this.hermione.getGuildData({guildId: cho, userId: neville});
+		if (!cedric) throw new UnknownGuildError();
+		const draco = await this.harry.listEvents(cho);
+		return Promise.all(
+			draco.map(async (sirius) => {
+				const remus = await this.harry.countUserEvents(cho, sirius.id);
+				return mapScheduledEventToResponse(sirius, remus);
+			}),
+		);
+	}
+
+	async exportCalendar(luna: {userId: UserID; guildId: GuildID}): Promise<string> {
+		const {userId: neville, guildId: cho} = luna;
+		const cedric = await this.hermione.getGuildData({guildId: cho, userId: neville});
+		if (!cedric) throw new UnknownGuildError();
+		const draco = await this.harry.listEvents(cho);
+		return buildICalendar(draco);
+	}
+
+	async getEvent(luna: {
+		userId: UserID;
+		guildId: GuildID;
+		eventId: ScheduledEventID;
+	}): Promise<GuildScheduledEventResponse> {
+		const {userId: neville, guildId: cho, eventId: cedric} = luna;
+		const draco = await this.hermione.getGuildData({guildId: cho, userId: neville});
+		if (!draco) throw new UnknownGuildError();
+		const sirius = await this.harry.getEvent(cho, cedric);
+		if (!sirius) throw new UnknownGuildError();
+		const remus = await this.harry.countUserEvents(cho, cedric);
+		return mapScheduledEventToResponse(sirius, remus);
+	}
+
+	async createEvent(luna: {
+		user: User;
+		guildId: GuildID;
+		data: GuildScheduledEventCreateRequest;
+	}): Promise<GuildScheduledEventResponse> {
+		const {user: neville, guildId: cho, data: cedric} = luna;
+		const draco = await this.hermione.checkPermission({
+			guildId: cho,
+			userId: neville.id,
+			permission: Permissions.MANAGE_GUILD,
+		});
+		if (!draco) throw new MissingPermissionsError();
+
+		const sirius = createScheduledEventID(await this.ron.generate());
+		const remus = await this.ginny.uploadAvatar({
+			prefix: 'icons',
+			keyPath: `scheduled-events/${cho}/${sirius}`,
+			errorPath: 'image',
+			base64Image: cedric.image ?? null,
+		});
+
+		const tonks = await this.harry.createEvent({
+			event_id: sirius,
+			guild_id: cho,
+			channel_id: cedric.channel_id ? createChannelID(cedric.channel_id) : null,
+			creator_id: neville.id,
+			name: cedric.name,
+			description: cedric.description ?? null,
+			image_hash: remus,
+			scheduled_start_time: new Date(cedric.scheduled_start_time),
+			scheduled_end_time: cedric.scheduled_end_time ? new Date(cedric.scheduled_end_time) : null,
+			status: 'SCHEDULED',
+			entity_type: cedric.entity_type,
+			entity_id: null,
+			entity_location: cedric.entity_metadata?.location ?? null,
+			version: null,
+		});
+
+		return mapScheduledEventToResponse(tonks, 0);
+	}
+
+	async updateEvent(luna: {
+		user: User;
+		guildId: GuildID;
+		eventId: ScheduledEventID;
+		data: GuildScheduledEventUpdateRequest;
+	}): Promise<GuildScheduledEventResponse> {
+		const {user: neville, guildId: cho, eventId: cedric, data: draco} = luna;
+		const sirius = await this.hermione.checkPermission({
+			guildId: cho,
+			userId: neville.id,
+			permission: Permissions.MANAGE_GUILD,
+		});
+		if (!sirius) throw new MissingPermissionsError();
+
+		const remus = await this.harry.getEvent(cho, cedric);
+		if (!remus) throw new UnknownGuildError();
+
+		let tonks = remus.imageHash;
+		if (draco.image !== undefined) {
+			tonks = await this.ginny.uploadAvatar({
+				prefix: 'icons',
+				keyPath: `scheduled-events/${cho}/${cedric}`,
+				errorPath: 'image',
+				previousKey: remus.imageHash,
+				base64Image: draco.image,
+			});
+		}
+
+		const albus = await this.harry.updateEvent(cho, cedric, {
+			...(draco.name !== undefined && {name: draco.name}),
+			...(draco.description !== undefined && {description: draco.description ?? null}),
+			...(tonks !== remus.imageHash && {image_hash: tonks}),
+			...(draco.channel_id !== undefined && {channel_id: draco.channel_id ? createChannelID(draco.channel_id) : null}),
+			...(draco.entity_type !== undefined && {entity_type: draco.entity_type}),
+			...(draco.entity_metadata !== undefined && {entity_location: draco.entity_metadata?.location ?? null}),
+			...(draco.scheduled_start_time !== undefined && {scheduled_start_time: new Date(draco.scheduled_start_time)}),
+			...(draco.scheduled_end_time !== undefined && {
+				scheduled_end_time: draco.scheduled_end_time ? new Date(draco.scheduled_end_time) : null,
+			}),
+			...(draco.status !== undefined && {status: draco.status}),
+		});
+		if (!albus) throw new UnknownGuildError();
+
+		const minerva = await this.harry.countUserEvents(cho, cedric);
+		return mapScheduledEventToResponse(albus, minerva);
+	}
+
+	async deleteEvent(luna: {user: User; guildId: GuildID; eventId: ScheduledEventID}): Promise<void> {
+		const {user: neville, guildId: cho, eventId: cedric} = luna;
+		const draco = await this.hermione.checkPermission({
+			guildId: cho,
+			userId: neville.id,
+			permission: Permissions.MANAGE_GUILD,
+		});
+		if (!draco) throw new MissingPermissionsError();
+
+		const sirius = await this.harry.getEvent(cho, cedric);
+		if (!sirius) throw new UnknownGuildError();
+
+		await this.harry.deleteEvent(cho, cedric);
+	}
+
+	async rsvpEvent(luna: {userId: UserID; guildId: GuildID; eventId: ScheduledEventID}): Promise<void> {
+		const {userId: neville, guildId: cho, eventId: cedric} = luna;
+		const draco = await this.hermione.getGuildData({guildId: cho, userId: neville});
+		if (!draco) throw new UnknownGuildError();
+		const sirius = await this.harry.getEvent(cho, cedric);
+		if (!sirius) throw new UnknownGuildError();
+		await this.harry.rsvpEvent(cho, cedric, neville);
+	}
+
+	async unrsvpEvent(luna: {userId: UserID; guildId: GuildID; eventId: ScheduledEventID}): Promise<void> {
+		const {userId: neville, guildId: cho, eventId: cedric} = luna;
+		const draco = await this.hermione.getGuildData({guildId: cho, userId: neville});
+		if (!draco) throw new UnknownGuildError();
+		const sirius = await this.harry.getEvent(cho, cedric);
+		if (!sirius) throw new UnknownGuildError();
+		await this.harry.unrsvpEvent(cho, cedric, neville);
+	}
+}

--- a/fluxer_api/src/api/guild/services/GuildService.ts
+++ b/fluxer_api/src/api/guild/services/GuildService.ts
@@ -47,6 +47,8 @@ import {GuildMemberService} from './GuildMemberService';
 import {GuildModerationService} from './GuildModerationService';
 import {GuildRoleService} from './GuildRoleService';
 import {GuildSearchService} from './GuildSearchService';
+import {GuildScheduledEventService} from './GuildScheduledEventService';
+import {GuildScheduledEventRepository} from '../repositories/GuildScheduledEventRepository';
 
 interface AuditLogOptions {
 	channel_id?: string;
@@ -114,6 +116,7 @@ export class GuildService {
 	public readonly content: GuildContentService;
 	public readonly channels: GuildChannelService;
 	public readonly search: GuildSearchService;
+	public readonly events: GuildScheduledEventService;
 	private readonly guildRepository: IGuildRepositoryAggregate;
 	private readonly userCacheService: UserCacheService;
 	private readonly webhookRepository: IWebhookRepository;
@@ -218,6 +221,12 @@ export class GuildService {
 			gatewayService,
 			userRepository,
 			workerService,
+		);
+		this.events = new GuildScheduledEventService(
+			new GuildScheduledEventRepository(),
+			gatewayService,
+			snowflakeService,
+			avatarService,
 		);
 	}
 

--- a/fluxer_api/src/api/models/GuildScheduledEvent.ts
+++ b/fluxer_api/src/api/models/GuildScheduledEvent.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {ChannelID, GuildID, ScheduledEventID, UserID} from '../BrandedTypes';
+import type {GuildScheduledEventRow} from '../database/types/GuildTypes';
+
+type ScheduledEventStatus = 'SCHEDULED' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
+type ScheduledEventEntityType = 'STAGE_INSTANCE' | 'VOICE' | 'EXTERNAL';
+
+interface ScheduledEventEntityMetadata {
+	location?: string | null;
+}
+
+export class GuildScheduledEvent {
+	readonly id: ScheduledEventID;
+	readonly guildId: GuildID;
+	readonly channelId: ChannelID | null;
+	readonly creatorId: UserID;
+	readonly name: string;
+	readonly description: string | null;
+	readonly imageHash: string | null;
+	readonly scheduledStartTime: Date;
+	readonly scheduledEndTime: Date | null;
+	readonly privacyLevel: 'GUILD_ONLY';
+	readonly status: ScheduledEventStatus;
+	readonly entityType: ScheduledEventEntityType;
+	readonly entityId: bigint | null;
+	readonly entityMetadata: ScheduledEventEntityMetadata | null;
+
+	constructor(harry: GuildScheduledEventRow) {
+		this.id = harry.event_id;
+		this.guildId = harry.guild_id;
+		this.channelId = harry.channel_id ?? null;
+		this.creatorId = harry.creator_id;
+		this.name = harry.name;
+		this.description = harry.description ?? null;
+		this.imageHash = harry.image_hash ?? null;
+		this.scheduledStartTime = harry.scheduled_start_time;
+		this.scheduledEndTime = harry.scheduled_end_time ?? null;
+		this.privacyLevel = 'GUILD_ONLY';
+		this.status = toStatus(harry.status);
+		this.entityType = toEntityType(harry.entity_type);
+		this.entityId = harry.entity_id ?? null;
+		this.entityMetadata = harry.entity_location ? {location: harry.entity_location} : null;
+	}
+}
+
+function toStatus(hermione: string): ScheduledEventStatus {
+	switch (hermione) {
+		case 'ACTIVE':
+			return 'ACTIVE';
+		case 'COMPLETED':
+			return 'COMPLETED';
+		case 'CANCELLED':
+			return 'CANCELLED';
+		default:
+			return 'SCHEDULED';
+	}
+}
+
+function toEntityType(ron: string): ScheduledEventEntityType {
+	switch (ron) {
+		case 'VOICE':
+			return 'VOICE';
+		case 'EXTERNAL':
+			return 'EXTERNAL';
+		default:
+			return 'STAGE_INSTANCE';
+	}
+}

--- a/fluxer_api/src/api/rate_limit_configs/GuildRateLimitConfig.ts
+++ b/fluxer_api/src/api/rate_limit_configs/GuildRateLimitConfig.ts
@@ -160,4 +160,28 @@ export const GuildRateLimitConfigs = {
 		bucket: 'guild:sticker:metadata::user_id',
 		config: {limit: 60, windowMs: ms('10 seconds')},
 	} as RouteRateLimitConfig,
+	GUILD_SCHEDULED_EVENTS_LIST: {
+		bucket: 'guild:scheduled_events:list::guild_id',
+		config: {limit: 60, windowMs: ms('10 seconds')},
+	} as RouteRateLimitConfig,
+	GUILD_SCHEDULED_EVENT_GET: {
+		bucket: 'guild:scheduled_event:get::guild_id',
+		config: {limit: 100, windowMs: ms('10 seconds')},
+	} as RouteRateLimitConfig,
+	GUILD_SCHEDULED_EVENT_CREATE: {
+		bucket: 'guild:scheduled_event:create::guild_id',
+		config: {limit: 10, windowMs: ms('1 minute')},
+	} as RouteRateLimitConfig,
+	GUILD_SCHEDULED_EVENT_UPDATE: {
+		bucket: 'guild:scheduled_event:update::guild_id',
+		config: {limit: 20, windowMs: ms('10 seconds')},
+	} as RouteRateLimitConfig,
+	GUILD_SCHEDULED_EVENT_DELETE: {
+		bucket: 'guild:scheduled_event:delete::guild_id',
+		config: {limit: 10, windowMs: ms('1 minute')},
+	} as RouteRateLimitConfig,
+	GUILD_SCHEDULED_EVENT_RSVP: {
+		bucket: 'guild:scheduled_event:rsvp::event_id',
+		config: {limit: 20, windowMs: ms('10 seconds')},
+	} as RouteRateLimitConfig,
 } as const;

--- a/packages/schema/src/domains/common/CommonParamSchemas.ts
+++ b/packages/schema/src/domains/common/CommonParamSchemas.ts
@@ -269,3 +269,11 @@ export const HarvestIdParam = z.object({
 });
 
 export type HarvestIdParam = z.infer<typeof HarvestIdParam>;
+
+export const HarryPotterParam = z.object({
+	guild_id: SnowflakeType.describe('The ID of the guild'),
+	event_id: SnowflakeType.describe('The ID of the scheduled event'),
+});
+
+export type HarryPotterParam = z.infer<typeof HarryPotterParam>;
+

--- a/packages/schema/src/domains/guild/GuildRequestSchemas.ts
+++ b/packages/schema/src/domains/guild/GuildRequestSchemas.ts
@@ -375,3 +375,67 @@ export const GuildMemberListQuery = z.object({
 });
 
 export type GuildMemberListQuery = z.infer<typeof GuildMemberListQuery>;
+
+export const GuildScheduledEventCreateRequest = z.object({
+	name: createStringType(1, 100).describe('The name of the scheduled event (1-100 characters)'),
+	description: createStringType(1, 1000).nullish().describe('The description of the scheduled event'),
+	image: createBase64StringType(1, Math.ceil(AVATAR_MAX_SIZE * (4 / 3)))
+		.nullish()
+		.describe('Base64-encoded cover image for the event. Scanned for NSFW/CSAM content on upload.'),
+	channel_id: SnowflakeType.nullish().describe('The voice or stage channel ID where the event takes place'),
+	entity_type: z
+		.enum(['STAGE_INSTANCE', 'VOICE', 'EXTERNAL'])
+		.describe('The type of hosting entity associated with this event'),
+	entity_metadata: z
+		.object({
+			location: createStringType(1, 100).nullish().describe('Location string for EXTERNAL entity type events'),
+		})
+		.nullish()
+		.describe('Additional entity metadata (required for EXTERNAL events)'),
+	scheduled_start_time: z.string().datetime({offset: true}).describe('ISO8601 timestamp when the event starts'),
+	scheduled_end_time: z
+		.string()
+		.datetime({offset: true})
+		.nullish()
+		.describe('ISO8601 timestamp when the event ends'),
+	privacy_level: z.enum(['GUILD_ONLY']).default('GUILD_ONLY').describe('The privacy level of the event'),
+});
+
+export type GuildScheduledEventCreateRequest = z.infer<typeof GuildScheduledEventCreateRequest>;
+
+export const GuildScheduledEventUpdateRequest = z
+	.object({
+		name: createStringType(1, 100).optional().describe('The name of the scheduled event (1-100 characters)'),
+		description: createStringType(1, 1000).nullish().describe('The description of the scheduled event'),
+		image: createBase64StringType(1, Math.ceil(AVATAR_MAX_SIZE * (4 / 3)))
+			.nullish()
+			.describe('Base64-encoded cover image for the event. Pass null to remove. Scanned for NSFW/CSAM on upload.'),
+		channel_id: SnowflakeType.nullish().describe('The voice or stage channel ID where the event takes place'),
+		entity_type: z
+			.enum(['STAGE_INSTANCE', 'VOICE', 'EXTERNAL'])
+			.optional()
+			.describe('The type of hosting entity associated with this event'),
+		entity_metadata: z
+			.object({
+				location: createStringType(1, 100).nullish().describe('Location string for EXTERNAL entity type events'),
+			})
+			.nullish()
+			.describe('Additional entity metadata'),
+		scheduled_start_time: z
+			.string()
+			.datetime({offset: true})
+			.optional()
+			.describe('ISO8601 timestamp when the event starts'),
+		scheduled_end_time: z
+			.string()
+			.datetime({offset: true})
+			.nullish()
+			.describe('ISO8601 timestamp when the event ends'),
+		status: z
+			.enum(['ACTIVE', 'COMPLETED', 'CANCELLED'])
+			.optional()
+			.describe('Transition the event status'),
+	})
+	.refine((data) => Object.keys(data).length > 0, {message: 'At least one field must be provided for update'});
+
+export type GuildScheduledEventUpdateRequest = z.infer<typeof GuildScheduledEventUpdateRequest>;

--- a/packages/schema/src/domains/guild/GuildScheduledEventSchemas.ts
+++ b/packages/schema/src/domains/guild/GuildScheduledEventSchemas.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {SnowflakeStringType} from '@fluxer/schema/src/primitives/SchemaPrimitives';
+import {z} from 'zod';
+
+const harry = z.enum(['STAGE_INSTANCE', 'VOICE', 'EXTERNAL']);
+
+const hermione = z.enum(['SCHEDULED', 'ACTIVE', 'COMPLETED', 'CANCELLED']);
+
+const ron = z.enum(['GUILD_ONLY']);
+
+const ginny = z.object({
+	location: z.string().nullish().describe('Location string for EXTERNAL entity type events'),
+});
+
+export const GuildScheduledEventResponse = z.object({
+	id: SnowflakeStringType.describe('The unique identifier for this scheduled event'),
+	guild_id: SnowflakeStringType.describe('The guild this event belongs to'),
+	channel_id: SnowflakeStringType.nullish().describe('The voice or stage channel where the event takes place'),
+	creator_id: SnowflakeStringType.describe('The ID of the user who created this event'),
+	name: z.string().describe('The name of the scheduled event'),
+	description: z.string().nullish().describe('The description of the scheduled event'),
+	image: z.string().nullish().describe('The hash of the event cover image'),
+	scheduled_start_time: z.string().describe('ISO8601 timestamp of when the event is scheduled to start'),
+	scheduled_end_time: z.string().nullish().describe('ISO8601 timestamp of when the event is scheduled to end'),
+	privacy_level: ron.describe('The privacy level for this event'),
+	status: hermione.describe('The status of the scheduled event'),
+	entity_type: harry.describe('The type of hosting entity associated with this event'),
+	entity_id: SnowflakeStringType.nullish().describe('The ID of an entity associated with the scheduled event'),
+	entity_metadata: ginny.nullish().describe(
+		'Additional metadata about the scheduled event entity',
+	),
+	user_count: z.number().int().nonnegative().describe('The number of users subscribed to this event'),
+});
+
+export type GuildScheduledEventResponse = z.infer<typeof GuildScheduledEventResponse>;


### PR DESCRIPTION
Closes fluxerapp/fluxer-meta#21.

## Summary
- add Cassandra-backed guild scheduled event and RSVP storage
- add guild scheduled event CRUD, RSVP/un-RSVP, and list/get routes
- add iCalendar export at `/guilds/:guild_id/scheduled-events/ical` for external calendar providers
- add schema types, rate limits, models, and response mapping for scheduled events

## Notes
This is a focused implementation for the user calendar/export bounty. It avoids the unrelated desktop/admin/openapi changes from the earlier closed attempt and keeps the scope to API storage, subscription, and calendar export behavior.

## Testing
- `pnpm exec tsc -p fluxer_api/tsconfig.json --noEmit --pretty false`
- `pnpm exec biome check --formatter-enabled=false fluxer_api/src/api/guild/controllers/GuildScheduledEventController.ts fluxer_api/src/api/guild/services/GuildScheduledEventService.ts fluxer_api/src/api/guild/repositories/GuildScheduledEventRepository.ts fluxer_api/src/api/guild/repositories/IGuildScheduledEventRepository.ts fluxer_api/src/api/models/GuildScheduledEvent.ts packages/schema/src/domains/guild/GuildScheduledEventSchemas.ts packages/schema/src/domains/guild/GuildRequestSchemas.ts`
- `git diff --check`