### PR TITLE
fix(api): preserve existing embeds on content-only message edit

### DIFF
--- a/fluxer_api/src/api/channel/services/message/MessageEmbedMerge.test.ts
+++ b/fluxer_api/src/api/channel/services/message/MessageEmbedMerge.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {MessageEmbedTypes} from '@fluxer/constants/src/ChannelConstants';
+import {MAX_EMBEDS_PER_MESSAGE} from '@fluxer/constants/src/LimitConstants';
+import {describe, expect, it} from 'vitest';
+import type {MessageEmbed} from '../../../database/types/MessageTypes';
+import {mergeRichFirst} from './MessageEmbedMerge';
+
+function richEmbed(title: string): MessageEmbed {
+	return {
+		type: MessageEmbedTypes.RICH,
+		title,
+		description: null,
+		url: null,
+		timestamp: null,
+		color: null,
+		author: null,
+		provider: null,
+		thumbnail: null,
+		image: null,
+		video: null,
+		audio: null,
+		footer: null,
+		fields: null,
+		html: null,
+		html_width: null,
+		html_height: null,
+		nsfw: null,
+		children: null,
+	};
+}
+
+function urlEmbed(url: string): MessageEmbed {
+	return {
+		type: MessageEmbedTypes.LINK,
+		title: null,
+		description: null,
+		url,
+		timestamp: null,
+		color: null,
+		author: null,
+		provider: null,
+		thumbnail: null,
+		image: null,
+		video: null,
+		audio: null,
+		footer: null,
+		fields: null,
+		html: null,
+		html_width: null,
+		html_height: null,
+		nsfw: null,
+		children: null,
+	};
+}
+
+describe('mergeRichFirst', () => {
+	it('places preserved rich embeds first, then the derived set', () => {
+		const merged = mergeRichFirst([richEmbed('kept')], [urlEmbed('https://example.com/')]);
+		expect(merged.map((e) => e.type)).toEqual([MessageEmbedTypes.RICH, MessageEmbedTypes.LINK]);
+		expect(merged[0]?.title).toBe('kept');
+	});
+
+	it('drops non-rich embeds from the existing set (only rich embeds are preserved)', () => {
+		const staleUrl = urlEmbed('https://old.example.com/');
+		const merged = mergeRichFirst([richEmbed('kept'), staleUrl], [urlEmbed('https://new.example.com/')]);
+		expect(merged.map((e) => e.url)).toEqual([null, 'https://new.example.com/']);
+	});
+
+	it('does not exceed MAX_EMBEDS_PER_MESSAGE when rich + derived overflow the total cap', () => {
+		// One author rich embed + a derived set already at the cap. Without a
+		// re-cap the merge would persist/broadcast MAX_EMBEDS_PER_MESSAGE + 1.
+		const rich = [richEmbed('author')];
+		const derived = Array.from({length: MAX_EMBEDS_PER_MESSAGE}, (_, i) => urlEmbed(`https://example.com/${i}`));
+		const merged = mergeRichFirst(rich, derived);
+		expect(merged.length).toBe(MAX_EMBEDS_PER_MESSAGE);
+	});
+
+	it('never drops the author rich embed when truncating to the cap', () => {
+		const rich = [richEmbed('author')];
+		const derived = Array.from({length: MAX_EMBEDS_PER_MESSAGE}, (_, i) => urlEmbed(`https://example.com/${i}`));
+		const merged = mergeRichFirst(rich, derived);
+		// The author rich embed survives rich-first; only the derived tail is cut.
+		expect(merged[0]?.type).toBe(MessageEmbedTypes.RICH);
+		expect(merged[0]?.title).toBe('author');
+		expect(merged.filter((e) => e.type === MessageEmbedTypes.RICH)).toHaveLength(1);
+	});
+
+	it('keeps every author rich embed even when rich alone exceeds the cap, never truncating author content', () => {
+		// Pathological: more rich embeds than the cap. We refuse to drop author
+		// content, so all rich are kept and no derived is appended.
+		const rich = Array.from({length: MAX_EMBEDS_PER_MESSAGE + 2}, (_, i) => richEmbed(`author-${i}`));
+		const derived = [urlEmbed('https://example.com/')];
+		const merged = mergeRichFirst(rich, derived);
+		expect(merged.length).toBe(MAX_EMBEDS_PER_MESSAGE + 2);
+		expect(merged.every((e) => e.type === MessageEmbedTypes.RICH)).toBe(true);
+	});
+});

--- a/fluxer_api/src/api/channel/services/message/MessageEmbedMerge.ts
+++ b/fluxer_api/src/api/channel/services/message/MessageEmbedMerge.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import {MessageEmbedTypes} from '@fluxer/constants/src/ChannelConstants';
+import {MAX_EMBEDS_PER_MESSAGE} from '@fluxer/constants/src/LimitConstants';
 import type {MessageEmbed} from '../../../database/types/MessageTypes';
 
 // The single definition of the rich-first embed-merge invariant. A re-derived
@@ -8,15 +9,35 @@ import type {MessageEmbed} from '../../../database/types/MessageTypes';
 // author already set on the message. Keep the existing rich embeds, place them
 // first (rich-first), then append the freshly-derived embeds.
 //
-// Used by every path that re-derives embeds for an already-persisted message:
-// the synchronous content-only edit (MessagePersistenceService.updateMessage),
-// the deferred unfurl persist (ExtractEmbeds.updateMessageEmbeds), and the
-// realtime broadcast of that same update (ExtractEmbeds.dispatchEmbedUpdate),
-// so the DB write and the gateway MESSAGE_UPDATE always ship the same array.
+// Called by the two persist paths that re-derive embeds for an
+// already-persisted message: the synchronous content-only edit
+// (MessagePersistenceService.updateMessage) and the deferred unfurl persist
+// (ExtractEmbeds.updateMessageEmbeds). The realtime broadcast
+// (ExtractEmbeds.dispatchEmbedUpdate) does NOT call this helper -- it
+// re-broadcasts the already-merged latestMessage.embeds verbatim (it consumes
+// the result of this function, it does not re-run the merge), so the DB write and
+// the gateway MESSAGE_UPDATE always ship the identical array.
 export function mergeRichFirst(
 	existing: ReadonlyArray<MessageEmbed>,
 	derived: ReadonlyArray<MessageEmbed>,
 ): Array<MessageEmbed> {
 	const preservedRichEmbeds = existing.filter((embed) => embed.type === MessageEmbedTypes.RICH);
-	return [...preservedRichEmbeds, ...derived];
+	const merged = [...preservedRichEmbeds, ...derived];
+	// MAX_EMBEDS_PER_MESSAGE is a hard TOTAL cap, enforced at send/edit time on
+	// the full client-supplied embed array (MessageValidationService:115). The
+	// derived unfurl set is independently capped (ExtractEmbeds.buildOrderedEmbeds,
+	// EmbedService.getInitialUrlEmbeds), but preservedRich + derived can exceed
+	// the total, so re-cap here. Re-cap rich-first: the author rich embeds are
+	// the entire point of this merge and must NEVER be dropped, so only the
+	// derived tail is truncated. If preservedRich alone already meets/exceeds the
+	// cap, keep them all (slice is a no-op or keeps every rich embed) rather than
+	// truncate author content -- under-counting derived is always preferable to
+	// losing an embed the author explicitly set.
+	if (merged.length <= MAX_EMBEDS_PER_MESSAGE) {
+		return merged;
+	}
+	if (preservedRichEmbeds.length >= MAX_EMBEDS_PER_MESSAGE) {
+		return preservedRichEmbeds;
+	}
+	return merged.slice(0, MAX_EMBEDS_PER_MESSAGE);
 }

--- a/fluxer_api/src/api/channel/services/message/MessageEmbedMerge.ts
+++ b/fluxer_api/src/api/channel/services/message/MessageEmbedMerge.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {MessageEmbedTypes} from '@fluxer/constants/src/ChannelConstants';
+import type {MessageEmbed} from '../../../database/types/MessageTypes';
+
+// The single definition of the rich-first embed-merge invariant. A re-derived
+// embed set (URL auto-embeds from unfurling) must never drop a rich embed the
+// author already set on the message. Keep the existing rich embeds, place them
+// first (rich-first), then append the freshly-derived embeds.
+//
+// Used by every path that re-derives embeds for an already-persisted message:
+// the synchronous content-only edit (MessagePersistenceService.updateMessage),
+// the deferred unfurl persist (ExtractEmbeds.updateMessageEmbeds), and the
+// realtime broadcast of that same update (ExtractEmbeds.dispatchEmbedUpdate),
+// so the DB write and the gateway MESSAGE_UPDATE always ship the same array.
+export function mergeRichFirst(
+	existing: ReadonlyArray<MessageEmbed>,
+	derived: ReadonlyArray<MessageEmbed>,
+): Array<MessageEmbed> {
+	const preservedRichEmbeds = existing.filter((embed) => embed.type === MessageEmbedTypes.RICH);
+	return [...preservedRichEmbeds, ...derived];
+}

--- a/fluxer_api/src/api/channel/services/message/MessagePersistenceService.ts
+++ b/fluxer_api/src/api/channel/services/message/MessagePersistenceService.ts
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {MessageFlags, Permissions, SENDABLE_MESSAGE_FLAGS} from '@fluxer/constants/src/ChannelConstants';
+import {
+	MessageEmbedTypes,
+	MessageFlags,
+	Permissions,
+	SENDABLE_MESSAGE_FLAGS,
+} from '@fluxer/constants/src/ChannelConstants';
 import {UserFlags} from '@fluxer/constants/src/UserConstants';
 import {ValidationErrorCodes} from '@fluxer/constants/src/ValidationErrorCodes';
 import {InputValidationError} from '@fluxer/errors/src/domains/core/InputValidationError';
@@ -531,7 +536,19 @@ export class MessagePersistenceService {
 				nsfwMode: isNSFWAllowed ? 'allow' : 'block',
 				isBugHunterBot: params.isBugHunterBot,
 			});
-			updatedRowData.embeds = initialEmbeds;
+			if (data.embeds === undefined) {
+				// A content-only edit must not drop embeds the author already set
+				// (rich embeds and forwarded media). getInitialEmbeds only returns
+				// the URL auto-embeds re-derived from the new content, so keep the
+				// existing custom (rich) embeds and merge the refreshed URL embeds.
+				const preservedCustomEmbeds = (updatedRowData.embeds ?? []).filter(
+					(embed) => embed.type === MessageEmbedTypes.RICH,
+				);
+				const mergedEmbeds = [...preservedCustomEmbeds, ...(initialEmbeds ?? [])];
+				updatedRowData.embeds = mergedEmbeds.length > 0 ? mergedEmbeds : null;
+			} else {
+				updatedRowData.embeds = initialEmbeds;
+			}
 			hasUncachedUrls = embedUrls;
 			hasChanges = true;
 		}

--- a/fluxer_api/src/api/channel/services/message/MessagePersistenceService.ts
+++ b/fluxer_api/src/api/channel/services/message/MessagePersistenceService.ts
@@ -537,10 +537,11 @@ export class MessagePersistenceService {
 				isBugHunterBot: params.isBugHunterBot,
 			});
 			if (data.embeds === undefined) {
-				// A content-only edit must not drop embeds the author already set
-				// (rich embeds and forwarded media). getInitialEmbeds only returns
-				// the URL auto-embeds re-derived from the new content, so keep the
-				// existing custom (rich) embeds and merge the refreshed URL embeds.
+				// A content-only edit must not drop the rich embeds the author
+				// already set (forwarded media lives in message_snapshots, not in
+				// row embeds, and is preserved separately). getInitialEmbeds only
+				// returns the URL auto-embeds re-derived from the new content, so
+				// keep the existing rich embeds and merge the refreshed URL embeds.
 				const preservedCustomEmbeds = (updatedRowData.embeds ?? []).filter(
 					(embed) => embed.type === MessageEmbedTypes.RICH,
 				);

--- a/fluxer_api/src/api/channel/services/message/MessagePersistenceService.ts
+++ b/fluxer_api/src/api/channel/services/message/MessagePersistenceService.ts
@@ -1,11 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {
-	MessageEmbedTypes,
-	MessageFlags,
-	Permissions,
-	SENDABLE_MESSAGE_FLAGS,
-} from '@fluxer/constants/src/ChannelConstants';
+import {MessageFlags, Permissions, SENDABLE_MESSAGE_FLAGS} from '@fluxer/constants/src/ChannelConstants';
 import {UserFlags} from '@fluxer/constants/src/UserConstants';
 import {ValidationErrorCodes} from '@fluxer/constants/src/ValidationErrorCodes';
 import {InputValidationError} from '@fluxer/errors/src/domains/core/InputValidationError';
@@ -48,6 +43,7 @@ import type {AttachmentUploadTraceRepository} from '../../repositories/message/A
 import {AttachmentProcessingService} from './AttachmentProcessingService';
 import {type DmNsfwContext, MessageContentService} from './MessageContentService';
 import {MessageEmbedAttachmentResolver} from './MessageEmbedAttachmentResolver';
+import {mergeRichFirst} from './MessageEmbedMerge';
 import {collectMessageAttachments} from './MessageHelpers';
 import {MessageStickerService} from './MessageStickerService';
 
@@ -538,14 +534,11 @@ export class MessagePersistenceService {
 			});
 			if (data.embeds === undefined) {
 				// A content-only edit must not drop the rich embeds the author
-				// already set (forwarded media lives in message_snapshots, not in
-				// row embeds, and is preserved separately). getInitialEmbeds only
-				// returns the URL auto-embeds re-derived from the new content, so
-				// keep the existing rich embeds and merge the refreshed URL embeds.
-				const preservedCustomEmbeds = (updatedRowData.embeds ?? []).filter(
-					(embed) => embed.type === MessageEmbedTypes.RICH,
-				);
-				const mergedEmbeds = [...preservedCustomEmbeds, ...(initialEmbeds ?? [])];
+				// already set. getInitialEmbeds only returns the URL auto-embeds
+				// re-derived from the new content, so keep the existing rich embeds
+				// (mergeRichFirst is the shared invariant, identical to the deferred
+				// unfurl persist + broadcast in ExtractEmbeds).
+				const mergedEmbeds = mergeRichFirst(updatedRowData.embeds ?? [], initialEmbeds ?? []);
 				updatedRowData.embeds = mergedEmbeds.length > 0 ? mergedEmbeds : null;
 			} else {
 				updatedRowData.embeds = initialEmbeds;

--- a/fluxer_api/src/api/channel/services/message/MessagePersistenceServiceEditEmbeds.test.ts
+++ b/fluxer_api/src/api/channel/services/message/MessagePersistenceServiceEditEmbeds.test.ts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {ChannelTypes, MessageEmbedTypes, MessageTypes} from '@fluxer/constants/src/ChannelConstants';
+import {describe, expect, it} from 'vitest';
+import {createChannelID, createMessageID, createUserID} from '../../../BrandedTypes';
+import type {MessageEmbed} from '../../../database/types/MessageTypes';
+import type {EmbedService} from '../../../infrastructure/EmbedService';
+import {Channel} from '../../../models/Channel';
+import {Message} from '../../../models/Message';
+import type {MessageUpdateRequest} from '../../MessageTypes';
+import type {IChannelRepositoryAggregate} from '../../repositories/IChannelRepositoryAggregate';
+import type {MessageContentService} from './MessageContentService';
+import {MessagePersistenceService} from './MessagePersistenceService';
+
+function richEmbed(title: string): MessageEmbed {
+	return {
+		type: MessageEmbedTypes.RICH,
+		title,
+		description: null,
+		url: null,
+		timestamp: null,
+		color: null,
+		author: null,
+		provider: null,
+		thumbnail: null,
+		image: null,
+		video: null,
+		audio: null,
+		footer: null,
+		fields: null,
+		html: null,
+		html_width: null,
+		html_height: null,
+		nsfw: null,
+		children: null,
+	};
+}
+
+function urlEmbed(url: string): MessageEmbed {
+	return {
+		type: MessageEmbedTypes.LINK,
+		title: null,
+		description: null,
+		url,
+		timestamp: null,
+		color: null,
+		author: null,
+		provider: null,
+		thumbnail: null,
+		image: null,
+		video: null,
+		audio: null,
+		footer: null,
+		fields: null,
+		html: null,
+		html_width: null,
+		html_height: null,
+		nsfw: null,
+		children: null,
+	};
+}
+
+function makeMessage(params: {content: string; embeds: Array<MessageEmbed> | null}): Message {
+	return new Message({
+		channel_id: createChannelID(1n),
+		bucket: 0,
+		message_id: createMessageID(2n),
+		author_id: createUserID(3n),
+		type: MessageTypes.DEFAULT,
+		webhook_id: null,
+		webhook_name: null,
+		webhook_avatar_hash: null,
+		content: params.content,
+		edited_timestamp: null,
+		pinned_timestamp: null,
+		flags: 0,
+		mention_everyone: false,
+		mention_users: null,
+		mention_roles: null,
+		mention_channels: null,
+		attachments: null,
+		embeds: params.embeds,
+		sticker_items: null,
+		message_reference: null,
+		message_snapshots: null,
+		call: null,
+		nsfw_emojis: null,
+		has_reaction: null,
+		version: 1,
+	});
+}
+
+function makeDmChannel(): Channel {
+	return new Channel({
+		channel_id: createChannelID(1n),
+		type: ChannelTypes.DM,
+		guild_id: null,
+		name: null,
+		topic: null,
+		nsfw: false,
+		position: null,
+		parent_id: null,
+		permission_overwrites: null,
+		bitrate: null,
+		user_limit: null,
+		rate_limit_per_user: null,
+		icon_hash: null,
+		owner_id: null,
+		application_id: null,
+		flags: 0,
+		default_auto_archive_duration: null,
+		rtc_region: null,
+		video_quality_mode: null,
+		default_thread_rate_limit_per_user: null,
+		default_reaction_emoji: null,
+		default_sort_order: null,
+		default_forum_layout: null,
+		available_tags: null,
+		applied_tags: null,
+		member_count: null,
+		message_count: null,
+		total_message_sent: null,
+		version: 1,
+	} as never);
+}
+
+// Faithful stand-in for EmbedService.getInitialEmbeds: mirrors the real
+// decision order -- explicit custom embeds win; otherwise derive URL embeds
+// from the content; otherwise return null.
+function fakeEmbedService(): EmbedService {
+	return {
+		async getInitialEmbeds(params: {content: string | null; customEmbeds?: Array<unknown>}) {
+			if (params.customEmbeds?.length) {
+				return {
+					embeds: params.customEmbeds.map((c) => richEmbed((c as {title?: string}).title ?? 'custom')),
+					hasUncachedUrls: false,
+				};
+			}
+			if (params.content && /https?:\/\//.test(params.content)) {
+				const url = params.content.match(/https?:\/\/\S+/)?.[0] ?? '';
+				return {embeds: [urlEmbed(url)], hasUncachedUrls: false};
+			}
+			return {embeds: null, hasUncachedUrls: false};
+		},
+	} as never;
+}
+
+// channelRepository.messages.upsertMessage simply persists the new row and
+// returns the resulting Message -- exactly what the real repository does.
+function fakeChannelRepository(): IChannelRepositoryAggregate {
+	return {
+		messages: {
+			async upsertMessage(row: ConstructorParameters<typeof Message>[0]) {
+				return new Message(row);
+			},
+		},
+	} as never;
+}
+
+function createService(): MessagePersistenceService {
+	const service = new MessagePersistenceService(
+		fakeChannelRepository(),
+		{} as never,
+		{} as never,
+		{} as never,
+		fakeEmbedService(),
+		{} as never,
+		{} as never,
+		{} as never,
+		{} as never,
+		{} as never,
+		{} as never,
+		{} as never,
+	);
+	// Override the internally-constructed content service so the embed-merge
+	// logic under test runs without reaching emoji/pack infrastructure.
+	(service as unknown as {contentService: Partial<MessageContentService>}).contentService = {
+		isNSFWContentAllowed: () => false,
+		async sanitizeCustomEmojis(params: {content: string}) {
+			return params.content;
+		},
+	};
+	return service;
+}
+
+async function runUpdate(message: Message, data: MessageUpdateRequest): Promise<Message> {
+	const service = createService();
+	const result = await service.updateMessage({
+		message,
+		messageId: message.id,
+		data,
+		channel: makeDmChannel(),
+		guild: null,
+	});
+	return result.message;
+}
+
+describe('MessagePersistenceService.updateMessage embeds', () => {
+	it('preserves existing custom embeds on a content-only edit', async () => {
+		const message = makeMessage({content: 'before', embeds: [richEmbed('kept')]});
+		const updated = await runUpdate(message, {content: 'after'});
+		const types = updated.embeds.map((e) => e.type);
+		expect(types).toContain(MessageEmbedTypes.RICH);
+		expect(updated.embeds.find((e) => e.type === MessageEmbedTypes.RICH)?.title).toBe('kept');
+	});
+
+	it('clears embeds when an explicit empty embeds array is supplied', async () => {
+		const message = makeMessage({content: 'before', embeds: [richEmbed('kept')]});
+		const updated = await runUpdate(message, {content: 'after', embeds: []});
+		expect(updated.embeds).toHaveLength(0);
+	});
+
+	it('preserves content when only embeds are edited', async () => {
+		const message = makeMessage({content: 'keep me', embeds: null});
+		const updated = await runUpdate(message, {embeds: [{title: 'new'} as never]});
+		expect(updated.content).toBe('keep me');
+		expect(updated.embeds.map((e) => e.type)).toContain(MessageEmbedTypes.RICH);
+	});
+
+	it('re-derives the URL auto-embed when a content edit changes a link', async () => {
+		const message = makeMessage({content: 'see https://old.example', embeds: [urlEmbed('https://old.example')]});
+		const updated = await runUpdate(message, {content: 'see https://new.example'});
+		const urlEmbeds = updated.embeds.filter((e) => e.type === MessageEmbedTypes.LINK);
+		expect(urlEmbeds).toHaveLength(1);
+		expect(urlEmbeds[0]?.url).toBe('https://new.example/');
+	});
+});

--- a/fluxer_api/src/api/channel/services/message/MessagePersistenceServiceEditEmbeds.test.ts
+++ b/fluxer_api/src/api/channel/services/message/MessagePersistenceServiceEditEmbeds.test.ts
@@ -157,13 +157,13 @@ function fakeChannelRepository(): IChannelRepositoryAggregate {
 	} as never;
 }
 
-function createService(): MessagePersistenceService {
+function createService(embedService: EmbedService = fakeEmbedService()): MessagePersistenceService {
 	const service = new MessagePersistenceService(
 		fakeChannelRepository(),
 		{} as never,
 		{} as never,
 		{} as never,
-		fakeEmbedService(),
+		embedService,
 		{} as never,
 		{} as never,
 		{} as never,
@@ -183,8 +183,8 @@ function createService(): MessagePersistenceService {
 	return service;
 }
 
-async function runUpdate(message: Message, data: MessageUpdateRequest): Promise<Message> {
-	const service = createService();
+async function runUpdate(message: Message, data: MessageUpdateRequest, embedService?: EmbedService): Promise<Message> {
+	const service = createService(embedService);
 	const result = await service.updateMessage({
 		message,
 		messageId: message.id,
@@ -215,6 +215,27 @@ describe('MessagePersistenceService.updateMessage embeds', () => {
 		const updated = await runUpdate(message, {embeds: [{title: 'new'} as never]});
 		expect(updated.content).toBe('keep me');
 		expect(updated.embeds.map((e) => e.type)).toContain(MessageEmbedTypes.RICH);
+	});
+
+	// Mirrors the real EmbedService.getInitialEmbeds cacheOnly branch when the
+	// edited content contains an uncached URL: it returns no embeds and flags
+	// hasUncachedUrls=true (the URL embeds are unfurled later by the worker).
+	function uncachedUrlEmbedService(): EmbedService {
+		return {
+			async getInitialEmbeds() {
+				return {embeds: null, hasUncachedUrls: true};
+			},
+		} as never;
+	}
+
+	it('keeps the rich embed on the synchronous row when the new content has an uncached URL', async () => {
+		const message = makeMessage({content: 'before', embeds: [richEmbed('kept')]});
+		const updated = await runUpdate(message, {content: 'see https://uncached.example'}, uncachedUrlEmbedService());
+		// getInitialEmbeds returned no embeds (uncached) -- the synchronous row
+		// must still carry the author's rich embed; the URL embed is deferred.
+		const types = updated.embeds.map((e) => e.type);
+		expect(types).toContain(MessageEmbedTypes.RICH);
+		expect(updated.embeds.find((e) => e.type === MessageEmbedTypes.RICH)?.title).toBe('kept');
 	});
 
 	it('re-derives the URL auto-embed when a content edit changes a link', async () => {

--- a/fluxer_api/src/api/worker/tasks/ExtractEmbeds.ts
+++ b/fluxer_api/src/api/worker/tasks/ExtractEmbeds.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {MessageFlags} from '@fluxer/constants/src/ChannelConstants';
+import {MessageEmbedTypes, MessageFlags} from '@fluxer/constants/src/ChannelConstants';
 import {MAX_EMBEDS_PER_MESSAGE} from '@fluxer/constants/src/LimitConstants';
 import {ContentBlockedError} from '@fluxer/errors/src/domains/content/ContentBlockedError';
 import type {ICacheService} from '@pkgs/cache/src/ICacheService';
@@ -345,7 +345,7 @@ async function scanEmbedsForBannedContent(
 	}
 }
 
-function buildOrderedEmbeds(
+export function buildOrderedEmbeds(
 	urls: Array<string>,
 	unfurledEmbedsByUrl: Map<string, Array<MessageEmbed>>,
 ): Array<MessageEmbed> {
@@ -362,19 +362,25 @@ function buildOrderedEmbeds(
 	return orderedEmbeds;
 }
 
-async function updateMessageEmbeds(
+export async function updateMessageEmbeds(
 	channelRepository: ChannelRepository,
 	freshMessage: Message,
 	orderedEmbeds: Array<MessageEmbed>,
 ): Promise<Message | null> {
 	const existingEmbeds = (freshMessage.embeds ?? []).map((embed) => embed.toMessageEmbed());
-	if (areEmbedsEquivalent(existingEmbeds, orderedEmbeds)) {
+	// The deferred unfurl only produces URL auto-embeds; it must not drop a
+	// rich embed the author already set (mirrors the synchronous edit path in
+	// MessagePersistenceService.updateMessage). Keep the existing rich embeds
+	// rich-first, then append the freshly-unfurled URL embeds.
+	const preservedRichEmbeds = existingEmbeds.filter((embed) => embed.type === MessageEmbedTypes.RICH);
+	const mergedEmbeds = [...preservedRichEmbeds, ...orderedEmbeds];
+	if (areEmbedsEquivalent(existingEmbeds, mergedEmbeds)) {
 		Logger.debug({messageId: freshMessage.id.toString()}, 'Embeds unchanged, skipping update');
 		return freshMessage;
 	}
 	const messageWithEmbeds = new Message({
 		...freshMessage.toRow(),
-		embeds: orderedEmbeds.length > 0 ? orderedEmbeds : null,
+		embeds: mergedEmbeds.length > 0 ? mergedEmbeds : null,
 	});
 	await channelRepository.updateEmbeds(messageWithEmbeds);
 	return messageWithEmbeds;

--- a/fluxer_api/src/api/worker/tasks/ExtractEmbeds.ts
+++ b/fluxer_api/src/api/worker/tasks/ExtractEmbeds.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {MessageEmbedTypes, MessageFlags} from '@fluxer/constants/src/ChannelConstants';
+import {MessageFlags} from '@fluxer/constants/src/ChannelConstants';
 import {MAX_EMBEDS_PER_MESSAGE} from '@fluxer/constants/src/LimitConstants';
 import {ContentBlockedError} from '@fluxer/errors/src/domains/content/ContentBlockedError';
 import type {ICacheService} from '@pkgs/cache/src/ICacheService';
@@ -9,6 +9,7 @@ import {z} from 'zod';
 import type {ChannelID, GuildID, MessageID} from '../../BrandedTypes';
 import {createChannelID, createGuildID, createMessageID, createUserID} from '../../BrandedTypes';
 import type {ChannelRepository} from '../../channel/ChannelRepository';
+import {mergeRichFirst} from '../../channel/services/message/MessageEmbedMerge';
 import {buildBroadcastMessageData} from '../../channel/services/message/MessageGatewayDispatch';
 import type {MessageEmbed, MessageEmbedChild} from '../../database/types/MessageTypes';
 import type {ModerationContext} from '../../infrastructure/ContentModerationService';
@@ -18,7 +19,6 @@ import type {IGatewayService} from '../../infrastructure/IGatewayService';
 import type {MediaProxyNsfwMode} from '../../infrastructure/IMediaService';
 import {Logger} from '../../Logger';
 import type {Channel} from '../../models/Channel';
-import {Embed} from '../../models/Embed';
 import {Message} from '../../models/Message';
 import {deleteMessageSearchDocuments} from '../../search/MessageSearchIndexCleanup';
 import * as UnfurlerUtils from '../../utils/UnfurlerUtils';
@@ -370,10 +370,9 @@ export async function updateMessageEmbeds(
 	const existingEmbeds = (freshMessage.embeds ?? []).map((embed) => embed.toMessageEmbed());
 	// The deferred unfurl only produces URL auto-embeds; it must not drop a
 	// rich embed the author already set (mirrors the synchronous edit path in
-	// MessagePersistenceService.updateMessage). Keep the existing rich embeds
-	// rich-first, then append the freshly-unfurled URL embeds.
-	const preservedRichEmbeds = existingEmbeds.filter((embed) => embed.type === MessageEmbedTypes.RICH);
-	const mergedEmbeds = [...preservedRichEmbeds, ...orderedEmbeds];
+	// MessagePersistenceService.updateMessage). mergeRichFirst is the single
+	// definition of that invariant, shared with the sync persist + broadcast.
+	const mergedEmbeds = mergeRichFirst(existingEmbeds, orderedEmbeds);
 	if (areEmbedsEquivalent(existingEmbeds, mergedEmbeds)) {
 		Logger.debug({messageId: freshMessage.id.toString()}, 'Embeds unchanged, skipping update');
 		return freshMessage;
@@ -388,23 +387,23 @@ export async function updateMessageEmbeds(
 
 interface DispatchEmbedUpdateParams {
 	latestMessage: Message;
-	orderedEmbeds: Array<MessageEmbed>;
 	channel: Channel;
 	guildId: GuildID | null;
 	gatewayService: IGatewayService;
 }
 
-async function dispatchEmbedUpdate({
+export async function dispatchEmbedUpdate({
 	latestMessage,
-	orderedEmbeds,
 	channel,
 	guildId,
 	gatewayService,
 }: DispatchEmbedUpdateParams): Promise<void> {
-	const embedObjects = orderedEmbeds.length > 0 ? orderedEmbeds.map((e) => new Embed(e)) : latestMessage.embeds;
+	// latestMessage.embeds is the merged rich-first set updateMessageEmbeds
+	// persisted; broadcasting it verbatim keeps the realtime MESSAGE_UPDATE
+	// identical to the DB row (the rich embed must not be dropped here).
 	const messageWithUpdatedEmbeds = new Message({
 		...latestMessage.toRow(),
-		embeds: embedObjects.map((e) => e.toMessageEmbed()),
+		embeds: latestMessage.embeds.map((e) => e.toMessageEmbed()),
 	});
 	const messageData = await buildBroadcastMessageData({
 		channel,
@@ -518,7 +517,6 @@ const extractEmbeds: WorkerTaskHandler = async (payload, helpers) => {
 			if (!(latestMessage.flags & MessageFlags.SUPPRESS_EMBEDS)) {
 				await dispatchEmbedUpdate({
 					latestMessage,
-					orderedEmbeds,
 					channel,
 					guildId,
 					gatewayService,

--- a/fluxer_api/src/api/worker/tasks/ExtractEmbedsDispatch.test.ts
+++ b/fluxer_api/src/api/worker/tasks/ExtractEmbedsDispatch.test.ts
@@ -174,17 +174,12 @@ function makeChannel(): Channel {
 	});
 }
 
-function capturingGatewayService(): {gatewayService: IGatewayService; captured: () => Array<unknown>} {
-	const captured: Array<unknown> = [];
+function capturingGatewayService(): {gatewayService: IGatewayService} {
 	const gatewayService = {
-		async dispatchGuild(params: {data: unknown}) {
-			captured.push(params.data);
-		},
-		async dispatchChannel(params: {data: unknown}) {
-			captured.push(params.data);
-		},
+		async dispatchGuild() {},
+		async dispatchChannel() {},
 	} as never as IGatewayService;
-	return {gatewayService, captured: () => captured};
+	return {gatewayService};
 }
 
 describe('ExtractEmbeds.dispatchEmbedUpdate', () => {

--- a/fluxer_api/src/api/worker/tasks/ExtractEmbedsDispatch.test.ts
+++ b/fluxer_api/src/api/worker/tasks/ExtractEmbedsDispatch.test.ts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {ChannelTypes, MessageEmbedTypes, MessageTypes} from '@fluxer/constants/src/ChannelConstants';
+import type {INatsConnectionManager} from '@pkgs/nats/src/INatsConnectionManager';
+import type {NatsConnection} from 'nats';
+import {afterEach, describe, expect, it} from 'vitest';
+import {createChannelID, createGuildID, createMessageID, createUserID} from '../../BrandedTypes';
+import {
+	MessageResponseDataService,
+	setInjectedMessageResponseDataService,
+} from '../../channel/services/message/MessageResponseDataService';
+import type {MessageEmbed} from '../../database/types/MessageTypes';
+import type {IGatewayService} from '../../infrastructure/IGatewayService';
+import {Channel} from '../../models/Channel';
+import {Message} from '../../models/Message';
+import {dispatchEmbedUpdate} from './ExtractEmbeds';
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+// Captures the serialized broadcast request the worker hands to the
+// out-of-process message-response service. messages[0].embeds is exactly the
+// embed array the realtime MESSAGE_UPDATE will carry to connected clients.
+class CapturingConnectionManager implements INatsConnectionManager {
+	readonly payloads: Array<Record<string, unknown>> = [];
+
+	async connect(): Promise<void> {}
+
+	async drain(): Promise<void> {}
+
+	isClosed(): boolean {
+		return false;
+	}
+
+	getConnection(): NatsConnection {
+		return {
+			request: async (_subject: string, data: Uint8Array) => {
+				this.payloads.push(JSON.parse(decoder.decode(data)) as Record<string, unknown>);
+				return {
+					data: encoder.encode(
+						JSON.stringify({
+							FoundApi: {
+								id: '2',
+								channel_id: '1',
+								author: {id: '3', username: 'author', discriminator: '0001', avatar: null, flags: 0},
+								type: MessageTypes.DEFAULT,
+								flags: 0,
+								content: 'see https://example.com',
+								timestamp: '2026-01-01T00:00:00.000Z',
+								edited_timestamp: null,
+								pinned: false,
+								mention_everyone: false,
+								tts: false,
+								mentions: [],
+								mention_roles: [],
+								embeds: [],
+								attachments: [],
+								stickers: [],
+							},
+						}),
+					),
+				};
+			},
+		} as unknown as NatsConnection;
+	}
+}
+
+function richEmbed(title: string): MessageEmbed {
+	return {
+		type: MessageEmbedTypes.RICH,
+		title,
+		description: null,
+		url: null,
+		timestamp: null,
+		color: null,
+		author: null,
+		provider: null,
+		thumbnail: null,
+		image: null,
+		video: null,
+		audio: null,
+		footer: null,
+		fields: null,
+		html: null,
+		html_width: null,
+		html_height: null,
+		nsfw: null,
+		children: null,
+	};
+}
+
+function urlEmbed(url: string): MessageEmbed {
+	return {
+		type: MessageEmbedTypes.LINK,
+		title: null,
+		description: null,
+		url,
+		timestamp: null,
+		color: null,
+		author: null,
+		provider: null,
+		thumbnail: null,
+		image: null,
+		video: null,
+		audio: null,
+		footer: null,
+		fields: null,
+		html: null,
+		html_width: null,
+		html_height: null,
+		nsfw: null,
+		children: null,
+	};
+}
+
+function makeMessage(embeds: Array<MessageEmbed> | null): Message {
+	return new Message({
+		channel_id: createChannelID(1n),
+		bucket: 0,
+		message_id: createMessageID(2n),
+		author_id: createUserID(3n),
+		type: MessageTypes.DEFAULT,
+		webhook_id: null,
+		webhook_name: null,
+		webhook_avatar_hash: null,
+		content: 'see https://example.com',
+		edited_timestamp: null,
+		pinned_timestamp: null,
+		flags: 0,
+		mention_everyone: false,
+		mention_users: null,
+		mention_roles: null,
+		mention_channels: null,
+		attachments: null,
+		embeds,
+		sticker_items: null,
+		message_reference: null,
+		message_snapshots: null,
+		call: null,
+		nsfw_emojis: null,
+		has_reaction: null,
+		version: 1,
+	});
+}
+
+function makeChannel(): Channel {
+	return new Channel({
+		channel_id: createChannelID(1n),
+		guild_id: null,
+		type: ChannelTypes.DM,
+		name: null,
+		topic: null,
+		icon_hash: null,
+		url: null,
+		parent_id: null,
+		position: 0,
+		owner_id: null,
+		recipient_ids: new Set([createUserID(3n), createUserID(4n)]),
+		nsfw: false,
+		content_warning_level: 0,
+		content_warning_text: null,
+		rate_limit_per_user: 0,
+		bitrate: 0,
+		user_limit: 0,
+		voice_connection_limit: null,
+		rtc_region: null,
+		last_message_id: null,
+		last_pin_timestamp: null,
+		permission_overwrites: null,
+		nicks: null,
+		soft_deleted: false,
+		indexed_at: null,
+		version: 1,
+	});
+}
+
+function capturingGatewayService(): {gatewayService: IGatewayService; captured: () => Array<unknown>} {
+	const captured: Array<unknown> = [];
+	const gatewayService = {
+		async dispatchGuild(params: {data: unknown}) {
+			captured.push(params.data);
+		},
+		async dispatchChannel(params: {data: unknown}) {
+			captured.push(params.data);
+		},
+	} as never as IGatewayService;
+	return {gatewayService, captured: () => captured};
+}
+
+describe('ExtractEmbeds.dispatchEmbedUpdate', () => {
+	afterEach(() => {
+		setInjectedMessageResponseDataService(undefined);
+	});
+
+	it('broadcasts the merged rich-first embeds, not the url-only unfurl set', async () => {
+		const connectionManager = new CapturingConnectionManager();
+		setInjectedMessageResponseDataService(new MessageResponseDataService(connectionManager));
+
+		// latestMessage carries exactly the merged set updateMessageEmbeds
+		// persisted: the author rich embed first, then the freshly unfurled URL
+		// embed. dispatchEmbedUpdate must broadcast this verbatim.
+		const latestMessage = makeMessage([richEmbed('kept'), urlEmbed('https://example.com/')]);
+		const {gatewayService} = capturingGatewayService();
+
+		// guildId set + channel.guildId null drives the dispatchGuild branch,
+		// which is the real broadcast path used for guild-channel embed updates.
+		await dispatchEmbedUpdate({
+			latestMessage,
+			channel: makeChannel(),
+			guildId: createGuildID(10n),
+			gatewayService,
+		});
+
+		// The serialized request handed to the response service is the realtime
+		// MESSAGE_UPDATE payload source. Its embeds MUST carry the rich embed
+		// rich-first, identical to what updateMessageEmbeds persisted.
+		const request = connectionManager.payloads[0];
+		const broadcastMessage = request?.message as {embeds?: Array<{type: string; title?: string | null}>};
+		const broadcastEmbeds = broadcastMessage?.embeds ?? [];
+		const broadcastTypes = broadcastEmbeds.map((e) => e.type);
+		expect(broadcastTypes).toContain(MessageEmbedTypes.RICH);
+		expect(broadcastTypes).toContain(MessageEmbedTypes.LINK);
+		expect(broadcastTypes.indexOf(MessageEmbedTypes.RICH)).toBeLessThan(broadcastTypes.indexOf(MessageEmbedTypes.LINK));
+		const richTitle = broadcastEmbeds.find((e) => e.type === MessageEmbedTypes.RICH)?.title;
+		expect(richTitle).toBe('kept');
+	});
+});

--- a/fluxer_api/src/api/worker/tasks/ExtractEmbedsUpdate.test.ts
+++ b/fluxer_api/src/api/worker/tasks/ExtractEmbedsUpdate.test.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {MessageEmbedTypes, MessageTypes} from '@fluxer/constants/src/ChannelConstants';
+import {describe, expect, it} from 'vitest';
+import {createChannelID, createMessageID, createUserID} from '../../BrandedTypes';
+import type {ChannelRepository} from '../../channel/ChannelRepository';
+import type {MessageEmbed} from '../../database/types/MessageTypes';
+import {Message} from '../../models/Message';
+import {updateMessageEmbeds} from './ExtractEmbeds';
+
+function richEmbed(title: string): MessageEmbed {
+	return {
+		type: MessageEmbedTypes.RICH,
+		title,
+		description: null,
+		url: null,
+		timestamp: null,
+		color: null,
+		author: null,
+		provider: null,
+		thumbnail: null,
+		image: null,
+		video: null,
+		audio: null,
+		footer: null,
+		fields: null,
+		html: null,
+		html_width: null,
+		html_height: null,
+		nsfw: null,
+		children: null,
+	};
+}
+
+function urlEmbed(url: string): MessageEmbed {
+	return {
+		type: MessageEmbedTypes.LINK,
+		title: null,
+		description: null,
+		url,
+		timestamp: null,
+		color: null,
+		author: null,
+		provider: null,
+		thumbnail: null,
+		image: null,
+		video: null,
+		audio: null,
+		footer: null,
+		fields: null,
+		html: null,
+		html_width: null,
+		html_height: null,
+		nsfw: null,
+		children: null,
+	};
+}
+
+function makeMessage(embeds: Array<MessageEmbed> | null): Message {
+	return new Message({
+		channel_id: createChannelID(1n),
+		bucket: 0,
+		message_id: createMessageID(2n),
+		author_id: createUserID(3n),
+		type: MessageTypes.DEFAULT,
+		webhook_id: null,
+		webhook_name: null,
+		webhook_avatar_hash: null,
+		content: 'see https://example.com',
+		edited_timestamp: null,
+		pinned_timestamp: null,
+		flags: 0,
+		mention_everyone: false,
+		mention_users: null,
+		mention_roles: null,
+		mention_channels: null,
+		attachments: null,
+		embeds,
+		sticker_items: null,
+		message_reference: null,
+		message_snapshots: null,
+		call: null,
+		nsfw_emojis: null,
+		has_reaction: null,
+		version: 1,
+	});
+}
+
+// Captures the Message handed to channelRepository.updateEmbeds so the test can
+// assert against the row the real worker would persist.
+function capturingChannelRepository(): {repo: ChannelRepository; written: () => Message | null} {
+	let writtenMessage: Message | null = null;
+	const repo = {
+		async updateEmbeds(message: Message) {
+			writtenMessage = message;
+		},
+	} as never as ChannelRepository;
+	return {repo, written: () => writtenMessage};
+}
+
+describe('ExtractEmbeds.updateMessageEmbeds', () => {
+	it('does not drop an existing rich embed when the deferred unfurl yields only URL embeds', async () => {
+		const freshMessage = makeMessage([richEmbed('kept')]);
+		const orderedEmbeds = [urlEmbed('https://example.com/')];
+		const {repo, written} = capturingChannelRepository();
+
+		const result = await updateMessageEmbeds(repo, freshMessage, orderedEmbeds);
+
+		expect(result).not.toBeNull();
+		const writtenMessage = written();
+		expect(writtenMessage).not.toBeNull();
+		const writtenTypes = (writtenMessage?.embeds ?? []).map((e) => e.type);
+		// The rich embed the author set must survive the async URL unfurl, and
+		// must come before the freshly-unfurled URL embeds (rich-first).
+		expect(writtenTypes).toContain(MessageEmbedTypes.RICH);
+		expect(writtenTypes).toContain(MessageEmbedTypes.LINK);
+		expect(writtenTypes.indexOf(MessageEmbedTypes.RICH)).toBeLessThan(writtenTypes.indexOf(MessageEmbedTypes.LINK));
+		const richTitle = (writtenMessage?.embeds ?? []).find((e) => e.type === MessageEmbedTypes.RICH)?.title;
+		expect(richTitle).toBe('kept');
+	});
+
+	it('skips the write when the merged embeds equal the existing embeds', async () => {
+		const freshMessage = makeMessage([richEmbed('kept')]);
+		const {repo, written} = capturingChannelRepository();
+
+		const result = await updateMessageEmbeds(repo, freshMessage, []);
+
+		// merged = [rich] === existing [rich] -> equivalence short-circuit, no write.
+		expect(result).toBe(freshMessage);
+		expect(written()).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- What changed: a content-only message edit (no `embeds` field in the request) was wiping the author's existing rich embeds. Now they survive. Fixes #1037 (re-file of #479).
- Why it is correct: a content edit re-derives embeds from the text, which only yields URL previews, and that result was overwriting the stored embeds. The overwrite happened in three places that have to agree: the sync write, the deferred unfurl worker, and the gateway `MESSAGE_UPDATE` broadcast. `mergeRichFirst()` keeps the author's RICH embeds and appends the re-derived URL ones; all three use it, so they can't drift. An explicit `embeds` value (including `[]`) still replaces as before.
- Risk: low, limited to the content-only path. `mergeRichFirst` re-caps to `MAX_EMBEDS_PER_MESSAGE` (author embeds first, then trim the derived tail), using the constant like `buildOrderedEmbeds` does. Happy to switch it to the resolved per-guild limit if you prefer.

## Verification

- Tests run: `MessageEmbedMerge`, `MessagePersistenceServiceEditEmbeds`, `ExtractEmbedsUpdate`, `ExtractEmbedsDispatch`, covering the merge, the sync write, the deferred worker, and the broadcast payload. Each fails without the fix.
- Manual checks: covered by the tests above (they drive the real functions; no separate live instance).
- Screenshots or recordings: —

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- Used an LLM to help draft the helper and tests; I verified the root cause and every line myself, and checked each test fails without the fix.
