### PR TITLE
fix(schema): add missing with_counts fields to GuildResponse and GuildAdminResponse schemas

### DIFF
--- a/fluxer_admin/openapi-admin.json
+++ b/fluxer_admin/openapi-admin.json
@@ -12197,7 +12197,9 @@
 						"description": "Custom content warning text shown before entry",
 						"nullable": true,
 						"type": "string"
-					}
+					},
+					"approximate_member_count": {"$ref": "#/components/schemas/Int32Type"},
+					"approximate_presence_count": {"$ref": "#/components/schemas/Int32Type"}
 				},
 				"required": [
 					"id",

--- a/fluxer_api/src/api/openapi/openapi.json
+++ b/fluxer_api/src/api/openapi/openapi.json
@@ -29981,7 +29981,9 @@
 						"description": "Channels visible to the requesting user from gateway state"
 					},
 					"member_count": {"$ref": "#/components/schemas/Int32Type"},
-					"online_count": {"$ref": "#/components/schemas/Int32Type"}
+					"online_count": {"$ref": "#/components/schemas/Int32Type"},
+					"approximate_member_count": {"$ref": "#/components/schemas/Int32Type"},
+					"approximate_presence_count": {"$ref": "#/components/schemas/Int32Type"}
 				},
 				"required": [
 					"id",

--- a/packages/schema/src/domains/admin/AdminGuildSchemas.ts
+++ b/packages/schema/src/domains/admin/AdminGuildSchemas.ts
@@ -47,6 +47,12 @@ export const GuildAdminResponse = z.object({
 		.nullable()
 		.optional()
 		.describe('Custom content warning text shown before entry'),
+	approximate_member_count: Int32Type.optional().describe(
+		'Approximate total member count (only when with_counts is true)'
+	),
+	approximate_presence_count: Int32Type.optional().describe(
+		'Approximate online member count (only when with_counts is true)'
+	),
 });
 
 export type GuildAdminResponse = z.infer<typeof GuildAdminResponse>;

--- a/packages/schema/src/domains/guild/GuildResponseSchemas.ts
+++ b/packages/schema/src/domains/guild/GuildResponseSchemas.ts
@@ -165,6 +165,12 @@ export const GuildResponse = z.object({
 	channels: z.array(ChannelResponse).optional().describe('Channels visible to the requesting user from gateway state'),
 	member_count: Int32Type.optional().describe('Total number of members in the guild'),
 	online_count: Int32Type.optional().describe('Number of online members visible in the guild'),
+	approximate_member_count: Int32Type.optional().describe(
+		'Approximate total member count (only when with_counts is true)',
+	),
+	approximate_presence_count: Int32Type.optional().describe(
+		'Approximate online member count (only when with_counts is true)',
+	),
 });
 
 export type GuildResponse = z.infer<typeof GuildResponse>;
@@ -232,6 +238,8 @@ export interface Guild {
 	readonly unavailable_hidden?: boolean;
 	readonly member_count?: number;
 	readonly online_count?: number;
+	readonly approximate_member_count?: number;
+	readonly approximate_presence_count?: number;
 	readonly roles?: ReadonlyArray<z.infer<typeof GuildRoleResponse>>;
 	readonly emojis?: ReadonlyArray<z.infer<typeof GuildEmojiResponse>>;
 	readonly stickers?: ReadonlyArray<z.infer<typeof GuildStickerResponse>>;


### PR DESCRIPTION
## Summary

- What changed: Added `approximate_member_count` and `approximate_presence_count` as optional `Int32Type` fields to the `GuildResponse` schema, as well as the `Guild` interface in `GuidlResponseSchemas.ts`
- Why it is correct: The gateway already sends these fields when `with_counts=true` is added onto a `/users/@me/guilds` call, but the response schema never declared them, which resulted in it being silently stripped from the serialized output.
- Risk: Very low. Both fields are optional so existing responses are not affected. This is a fix to previously non-working functionality.

## Verification

- Tests run: pnpm vitest run src/domains/tests/GuildResponseSchemas.test.ts (Test Files: 1 passed (1), Tests: 26 passed (26))
- Manual checks: Manual curl request against dev environment. `GET /users/@me/guilds?with_counts=true` now returns both `approximate_member_count` and `approximate_presence_count`; without the fix they were absent.
- Screenshots or recordings:

Pre-fix:
<img width="561" height="175" alt="image" src="https://github.com/user-attachments/assets/35b6d72e-1987-4b63-9abc-149ee0ef0230" />

Post-fix:
<img width="569" height="215" alt="image" src="https://github.com/user-attachments/assets/77c90084-7316-46cd-a82a-d12e8f3d9233" />


## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
