### PR TITLE
fix(rspack): limited thread pool size to 4

### DIFF
--- a/fluxer_app/package.json
+++ b/fluxer_app/package.json
@@ -16,7 +16,7 @@
 	},
 	"scripts": {
 		"build": "pnpm wasm:codegen && pnpm generate:colors && pnpm generate:message-layout && pnpm generate:theme-variables && pnpm generate:masks && pnpm generate:css-types && pnpm lingui:compile && rm -rf dist && rspack build --mode production && pnpm tsx scripts/build-sw.mjs",
-		"dev": "cargo run --manifest-path ../tools/ci/Cargo.toml -- app-dev-server",
+		"dev": "TOKIO_WORKER_THREADS=4 RAYON_NUM_THREADS=4 cargo run --manifest-path ../tools/ci/Cargo.toml -- app-dev-server",
 		"test": "vitest run",
 		"bench:member-list": "vitest bench --run src/features/member/utils/MemberListRangeUtils.bench.ts src/features/member/state/MemberListStateMachines.bench.ts src/features/member/state/MemberSidebar.bench.ts",
 		"bench:gif-picker": "vitest bench --run src/features/channel/components/pickers/gif/GifPickerStateMachine.bench.ts src/features/channel/components/pickers/gif/GifPickerGridData.bench.ts src/features/channel/components/pickers/gif/GifPickerLoadingSkeletonGridLayout.bench.ts src/features/channel/components/pickers/shared/MasonryListComputer.bench.ts",


### PR DESCRIPTION
Previously after running pnpm dev, the local machine's performance severely degraded, making development work nigh impossible. Limiting the thread pool size fixed this performance problem.

Tested on 2025 Macbook Air M4, 16GB & 256GB.