### PR TITLE
ci(dart-sdk-validation): update call

### DIFF
--- a/.github/workflows/dart-sdk-validation.yaml
+++ b/.github/workflows/dart-sdk-validation.yaml
@@ -53,6 +53,4 @@ jobs:
       - name: Validate Dart SDK generation
         if: steps.changes.outputs.openapi == 'true'
         working-directory: dart_sdk
-        run: |
-          chmod +x scripts/validate_upstream_spec.sh
-          ./scripts/validate_upstream_spec.sh "file://${GITHUB_WORKSPACE}/fluxer_api/src/api/openapi/openapi.json"
+        run: ./scripts/openapi_sdk.sh validate


### PR DESCRIPTION
Due to recent deduplications in the dart_sdk repository, this just needs to be `run: ./scripts/openapi_sdk.sh validate`.