### PR TITLE
chore: add version to metadata

### DIFF
--- a/fluxer_desktop/electron-builder.config.cjs
+++ b/fluxer_desktop/electron-builder.config.cjs
@@ -1073,6 +1073,7 @@ module.exports = {
 	extraMetadata: {
 		main: 'dist/main/index.js',
 		name: metadataName,
+		...(Boolean(process.env.VERSION) ? {version: process.env.VERSION} : {}),
 		...(targetPlatform === 'linux' ? {desktopName: `${linuxPackageName}.desktop`} : {}),
 	},
 	extraResources: [


### PR DESCRIPTION
## Summary

- What changed: Added version to `extraMetadata` in `fluxer_desktop/electron-builder.config.cjs`
- Why it is correct: Removes the need to use `cargo run --locked --quiet --manifest-path tools/ci/Cargo.toml -- build-desktop --step update_version` as long as environment variables are exposed. Also checks if var is defined in env if not then just falls back to `package.json`. 
- Risk: None I guess

## Verification

- Tests run: It builds
- Manual checks: The version is shown in client without running the fancy `CI` script 
- Screenshots or recordings: 
<img width="324" height="146" alt="image" src="https://github.com/user-attachments/assets/5c245a2b-b84b-4d90-9fd9-daf101ce53fb" />


## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

None


<!--
"I am A.I.: Actually Indian."
– Me
-->


<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
