### PR TITLE
fix(app): auto focus Textarea when attaching files

### DIFF
--- a/fluxer_app/src/features/channel/components/ChannelTextarea.tsx
+++ b/fluxer_app/src/features/channel/components/ChannelTextarea.tsx
@@ -575,6 +575,10 @@ const ChannelTextareaContent = observer(
 						<TooManyAttachmentsModal data-flx="channel.channel-textarea.handle-file-button-click.too-many-attachments-modal" />
 					)),
 				);
+				return;
+			}
+			if (files.length > 0) {
+				textareaRef.current?.focus();
 			}
 		}, [canAttachFiles, channel.id, textareaInputDisabled, maxAttachments, uploadAttachments.length]);
 		const handleUploadMessageAsFile = useCallback(async () => {
@@ -599,6 +603,7 @@ const ChannelTextareaContent = observer(
 			}
 			setValue('');
 			DraftCommands.deleteDraft(channel.id);
+			textareaRef.current?.focus();
 		}, [textareaInputDisabled, canAttachFiles, value, channel.id, uploadAttachments.length, maxAttachments]);
 		useTextareaExpressionHandlers({
 			setValue,

--- a/fluxer_app/src/features/channel/components/UploadManager.tsx
+++ b/fluxer_app/src/features/channel/components/UploadManager.tsx
@@ -49,7 +49,9 @@ export const UploadManager = observer(({channel, canAttachFiles, canSendMessages
 		ModalCommands.popWithKey(UPLOAD_DROP_MODAL_KEY);
 	}, []);
 	const focusTextarea = useCallback(() => {
-		ComponentDispatch.dispatch('FOCUS_TEXTAREA', {channelId: channel.id});
+		setTimeout(() => {
+			ComponentDispatch.dispatch('FOCUS_TEXTAREA', {channelId: channel.id});
+		}, 0);
 	}, [channel.id]);
 	const onDrop = useCallback(
 		async (files: Array<File>, directUpload = false) => {


### PR DESCRIPTION
## Summary

- What changed: Corrected the focus behaviour after adding an attachment to a message when the textarea was not previously focused.
  - In UploadManager.tsx, the FOCUS_TEXTAREA dispatch was wrapped inside a setTimeout(0) call so that it runs after the other microtasks have cleared. This covers both drag and drop as well as paste attachment flows.
  - In ChannelTextarea.tsx, a focusing to the textarea call was added to handle both the "Upload file" flow as well as the "Upload message as file" flow.
- Why it is correct: When files are attached, the user should be able to send the attachment right away without having to click the textarea first. The modal system in the upload manager uses queueMicrotask to restore focus when the drag-drop overlay is dismissed. The synchronous focus call was running before that microtask, so focus was immediately stolen back to the page body. setTimeout(0) defers focus until after all microtasks finish, so the textarea keeps focus and the user can press enter to send the image right away without manual refocus. This flow was not considered at all in UploadManager, but is also expected to be handled the same way to match Discord's textarea focusing behaviour.
- Risk: Low. Call only fires when files are successfully attached. No behavior change outside of correct focus timing.

## Verification

- Tests run: No test files are attached to these components to run. pnpm vitest run on the fluxer_app package shows the following, though the failures are unrelated to the changed files and already existed:
  - Test Files  2 failed | 209 passed (211)
  - Tests  3 failed | 1613 passed (1616)
- Manual checks: Verified the behaviour in client using a sample attachment file as provided in the recordings below. The first recording demonstrates the current behaviour, with the second recording demonstrating the corrected behaviour.
- Screenshots or recordings:
https://github.com/user-attachments/assets/a1df1c70-5e2c-4526-9a9a-b0263adfe53a
https://github.com/user-attachments/assets/6fca86f6-009d-43bc-ab56-3c045bf65c79



## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
