### PR TITLE
fix(desktop): restore window bounds after fullscreen exit on Windows

### DIFF
--- a/fluxer_desktop/src/main/Window.ts
+++ b/fluxer_desktop/src/main/Window.ts
@@ -21,7 +21,6 @@ import {
 } from '@electron/main/DesktopDebugInfo';
 import {hasActiveDesktopTray, refreshDesktopTrayMenu} from '@electron/main/DesktopTray';
 import {drainPendingDisplayMediaRequests, registerDisplayMediaRequestHandler} from '@electron/main/DisplayMedia';
-import {shouldRestoreHtmlFullscreenWindowBounds} from '@electron/main/HtmlFullscreenWindowBounds';
 import {shouldDisableV8CodeCache} from '@electron/main/LaunchOptions';
 import {openExternalDeduped} from '@electron/main/OpenExternal';
 import {registerSpellcheck} from '@electron/main/Spellcheck';
@@ -159,6 +158,7 @@ const windowsHtmlFullscreenStates = new WeakMap<
 	BrowserWindow,
 	{resizable: boolean; bounds: Bounds; isMaximized: boolean; customChromeGuardActive: boolean}
 >();
+let lastGoodWindowBounds: Bounds | null = null;
 
 function getWindowStateFile(): string {
 	if (!windowStateFile) {
@@ -296,6 +296,7 @@ function saveWindowBounds(): void {
 			height: bounds.height,
 			isMaximized,
 		};
+		lastGoodWindowBounds = bounds;
 		const filePath = getWindowStateFile();
 		fs.writeFileSync(filePath, JSON.stringify(windowState, null, 2), 'utf-8');
 		log.debug('Saved window bounds:', windowState);
@@ -501,10 +502,12 @@ function enterWindowsHtmlFullscreenChromeGuard(window: BrowserWindow): void {
 	if (process.platform !== 'win32') return;
 	if (windowsHtmlFullscreenStates.has(window)) return;
 	const customChromeGuardActive = !getActiveUseNativeTitleBar();
+	const bounds = lastGoodWindowBounds ?? window.getNormalBounds();
+	const isMaximized = window.isMaximized();
 	windowsHtmlFullscreenStates.set(window, {
 		resizable: window.isResizable(),
-		bounds: window.getNormalBounds(),
-		isMaximized: window.isMaximized(),
+		bounds,
+		isMaximized,
 		customChromeGuardActive,
 	});
 	if (!customChromeGuardActive) return;
@@ -516,32 +519,10 @@ function restoreWindowsHtmlFullscreenBounds(
 	window: BrowserWindow,
 	previous: {bounds: Bounds; isMaximized: boolean},
 ): void {
-	const restoreIfNeeded = () => {
-		if (!isAliveWindow(window)) return;
-		if (windowsHtmlFullscreenStates.has(window)) return;
-		const currentBounds = window.getBounds();
-		const display = screen.getDisplayMatching(currentBounds);
-		if (
-			!shouldRestoreHtmlFullscreenWindowBounds({
-				previousBounds: previous.bounds,
-				currentBounds,
-				displayBounds: display.bounds,
-				wasMaximized: previous.isMaximized,
-				isMaximized: window.isMaximized(),
-			})
-		) {
-			return;
-		}
-		logger.info('Restoring window bounds after HTML fullscreen exit', {
-			currentBounds,
-			restoredBounds: previous.bounds,
-			displayBounds: display.bounds,
-		});
-		window.setBounds(previous.bounds);
-		saveWindowBounds();
-	};
-	setTimeout(restoreIfNeeded, 0);
-	setTimeout(restoreIfNeeded, 100);
+	if (!isAliveWindow(window) || windowsHtmlFullscreenStates.has(window)) return;
+	if (previous.isMaximized || window.isMaximized()) return;
+	window.setBounds(previous.bounds);
+	saveWindowBounds();
 }
 
 function leaveWindowsHtmlFullscreenChromeGuard(window: BrowserWindow): void {
@@ -783,6 +764,7 @@ export function createWindow(options: CreateWindowOptions = {}): BrowserWindow {
 	mainWindow = new BrowserWindow(windowOptions);
 	mainWindowRendererGone = false;
 	installHtmlFullscreenChromeGuard(mainWindow);
+	lastGoodWindowBounds = mainWindow.getNormalBounds();
 	logPhase('browser-window');
 	if (savedBounds?.isMaximized) {
 		mainWindow.maximize();


### PR DESCRIPTION
## Summary

- What changed: Removed the old detection-based logic (`shouldRestoreHtmlFullscreenWindowBounds`) with its polling at t=0 and t=100ms. Instead, the window's normal bounds are now cached in a variable that survives Chromium's internal state changes. On fullscreen exit, bounds are restored immediately with a single call.
- Why it is correct: On Windows, Chromium resizes the window before the `enter-html-full-screen` event, so querying bounds at that point returns the display size rather than the window's actual pre-fullscreen size. The old code tried to detect and work around this after the fact with heuristics. The new code avoids the problem entirely by caching the last known good bounds ahead of time.
- Risk: Windows only. The new cache variable is only referenced during fullscreen transitions, so any issue that could stem from this is isolated.

## Verification

- Tests run: Build succeeds. No automated tests available for these components.
- Manual checks: As displayed in the recording below, the behaviour has been tested in both windowed and maximised scenarios with both hotkey exit and UI button exit to the desired outcome.
- Screenshots or recordings:

Recording first displays the existing behaviour on the current Canary build, then tests the corrected behaviour in a number of different scenarios.
https://github.com/user-attachments/assets/ab21980e-b305-4ec3-abde-6b14dacb65f4





## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
