### PR TITLE
ci: add dart_sdk dispatch

### DIFF
--- a/.github/workflows/dispatch-dart-sdk-regeneration.yaml
+++ b/.github/workflows/dispatch-dart-sdk-regeneration.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+name: Dispatch Dart SDK Regeneration
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - fluxer_api/src/api/openapi/openapi.json
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Dispatch regeneration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create token
+        id: create-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ vars.FLUXER_CI_APP_ID }}
+          private-key: ${{ secrets.FLUXER_CI_APP_KEY }}
+          owner: fluxerapp
+          repositories: dart_sdk
+          permission-contents: write
+
+      - name: Dispatch Dart SDK regeneration
+        env:
+          GH_TOKEN: ${{ steps.create-token.outputs.token }}
+        run: |
+          gh api --method POST repos/fluxerapp/dart_sdk/dispatches \
+            --field event_type=fluxer-openapi-updated


### PR DESCRIPTION
Whenever there is a change to fluxer_api/src/api/openapi/openapi.json, https://github.com/fluxerapp/dart_sdk/actions/workflows/regenerate.yaml will be called via `repository_dispatch`.