### PR TITLE
fix: linux notification actions

### DIFF
--- a/fluxer_desktop/native/linux-notifications/src/lib.rs
+++ b/fluxer_desktop/native/linux-notifications/src/lib.rs
@@ -547,7 +547,7 @@ fn spawn_signal_thread(
                 let conn = zbus::Connection::session().await?;
                 let rule = MatchRule::builder()
                     .msg_type(MessageType::Signal)
-                    .sender(NOTIFY_DEST)?
+                    .path(NOTIFY_PATH)?
                     .interface(NOTIFY_IFACE)?
                     .build();
                 let stream = MessageStream::for_match_rule(rule, &conn, Some(64)).await?;


### PR DESCRIPTION
## Summary

- What changed: Changed match filtering rule from `sender` to `path` in `linux-notification` native module of the desktop app
- Why it is correct: `NOTIFY_DEST` is set to `org.freedesktop.Notifications`  which was being used to check against `sender` but in dbus signals the sender is usually an unique id of the object, and not the owner. Which is why the path from which the signal was sent is a better way to filter out unwanted signals. 
- Risk: None, other than user being able to click on notifications but that is intended design 

## Verification

- Tests run:  It builds and clicking the notification works
- Manual checks: Got my friend to send an message and clicking the notification opened the DM
- Screenshots or recordings: 
The screenshot is from command `dbus-monitor "interface='org.freedesktop.Notifications'"` showing unique sender IDs and path. 
<img width="860" height="665" alt="image" src="https://github.com/user-attachments/assets/d57ad444-bab4-4de3-851d-3b46df6972e8" />


## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

None

<!--
"I am A.I.: Actually Indian."
– Me
-->


<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
