### PR TITLE
chore(i18n): Change Korean translation for 'New' to '새 메시지'

### DIFF
--- a/fluxer_app/src/features/i18n/locales/ko/messages.po
+++ b/fluxer_app/src/features/i18n/locales/ko/messages.po
@@ -21535,7 +21535,7 @@ msgstr "자동으로 안 함"
 #: src/features/channel/components/ChannelDivider.tsx:52
 #: src/features/channel/components/UnreadDividerSlot.tsx:30
 msgid "New"
-msgstr "새로운"
+msgstr "새 메시지"
 
 #. Small badge on a new or recently added app navigation item.
 #: src/features/app/components/layout/GuildsLayout.tsx:66


### PR DESCRIPTION
## Summary

- What changed: Korean Translation
- Why it is correct: In Korea, it feels unnatural to label unread messages simply as "New."
- Risk: Using this translation in contexts other than unread messages could result in further awkwardness.

## Verification

- Tests run:
```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 5 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/features/gateway/transport/GatewayCompression.test.ts [ src/features/gateway/transport/GatewayCompression.test.ts ]
Error: Cannot find package '@pkgs/libfluxcore/libfluxcore' imported from '/home/sinokadev/fluxer/fluxer_app/src/features/platform/utils/LibFluxcore.ts'
 ❯ src/features/platform/utils/LibFluxcore.ts:5:1
      3| import {Logger} from '@app/features/platform/utils/AppLogger';
      4| import type {InitOutput} from '@pkgs/libfluxcore/libfluxcore';
      5| import initLibfluxcore, * as wasm from '@pkgs/libfluxcore/libfluxcore';
       | ^
      6| 
      7| const logger = new Logger('libfluxcore');
 ❯ src/features/gateway/transport/GatewayCompression.ts:3:1

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/5]⎯

 FAIL  src/features/messaging/utils/EmbeddableCodeLinkContent.test.ts [ src/features/messaging/utils/EmbeddableCodeLinkContent.test.ts ]
Error: Cannot find module './MarkdownParserWasmBytes' imported from '/home/sinokadev/fluxer/fluxer_app/src/features/messaging/utils/markdown/parser/MarkdownParserWasm.ts'
 ❯ src/features/messaging/utils/markdown/parser/MarkdownParserWasm.ts:5:1
      3| import {flattenAST} from './AstUtils';
      4| import {getEmojiParserConfig} from './EmojiParsers';
      5| import {MARKDOWN_PARSER_WASM_BASE64} from './MarkdownParserWasmBytes';
       | ^
      6| import type {Node} from './Nodes';
      7| import * as StringUtils from './StringUtils';
 ❯ src/features/messaging/utils/markdown/parser/WasmParser.ts:3:1

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/5]⎯

 FAIL  src/features/platform/utils/LibFluxcoreWasm.test.ts [ src/features/platform/utils/LibFluxcoreWasm.test.ts ]
Error: Cannot find package '@pkgs/libfluxcore/libfluxcore' imported from '/home/sinokadev/fluxer/fluxer_app/src/features/platform/utils/LibFluxcoreWasm.test.ts'
 ❯ src/features/platform/utils/LibFluxcoreWasm.test.ts:4:1
      2| 
      3| import {readFileSync} from 'node:fs';
      4| import {
       | ^
      5|  create_zstd_stream_decoder,
      6|  crop_rotate_rgba,

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/5]⎯

 FAIL  src/features/user/constants/UserProfileSurfaceGeometry.test.ts [ src/features/user/constants/UserProfileSurfaceGeometry.test.ts ]
Error: Cannot find package '@app/features/ui/constants/AvatarStatusGeometry' imported from '/home/sinokadev/fluxer/fluxer_app/src/features/user/constants/UserProfileSurfaceGeometry.ts'
 ❯ src/features/user/constants/UserProfileSurfaceGeometry.ts:4:1
      2| 
      3| import {remFromPx} from '@app/features/theme/layout/RemFromPx';
      4| import {getStatusGeometry} from '@app/features/ui/constants/AvatarStatusGeometry';
       | ^
      5| 
      6| type CssLengthVariables = Record<`--${string}`, string>;
 ❯ src/features/user/constants/UserProfileSurfaceGeometry.test.ts:3:1

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/5]⎯

 FAIL  src/features/messaging/utils/markdown/parser/MarkdownParserWasm.test.ts [ src/features/messaging/utils/markdown/parser/MarkdownParserWasm.test.ts ]
Error: Cannot find module './MarkdownParserWasmBytes' imported from '/home/sinokadev/fluxer/fluxer_app/src/features/messaging/utils/markdown/parser/MarkdownParserWasm.ts'
 ❯ src/features/messaging/utils/markdown/parser/MarkdownParserWasm.ts:5:1
      3| import {flattenAST} from './AstUtils';
      4| import {getEmojiParserConfig} from './EmojiParsers';
      5| import {MARKDOWN_PARSER_WASM_BASE64} from './MarkdownParserWasmBytes';
       | ^
      6| import type {Node} from './Nodes';
      7| import * as StringUtils from './StringUtils';
 ❯ src/features/messaging/utils/markdown/parser/MarkdownParserWasm.test.ts:4:1

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/5]⎯


 Test Files  5 failed | 206 passed (211)
      Tests  1593 passed (1593)
   Start at  16:48:14
   Duration  4.68s (transform 16.81s, setup 0ms, import 27.81s, tests 9.21s, environment 1.86s)

 ELIFECYCLE  Test failed. See above for more details.
```
- Manual checks: Not applicable (Simple translation update).
- Screenshots or recordings: N/A (Only updated Korean translation strings, no UI/layout changes).

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None, or: PR Text(English is not the native language.)

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
