### PR TITLE
chore: remove duplicate security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Ideas and feature requests
     url: https://github.com/orgs/fluxerapp/discussions
     about: Suggest an improvement or new capability.
-  - name: Security reports
-    url: https://fluxer.app/security
-    about: Report vulnerabilities privately.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,0 @@
-# Security
-
-Please report security issues through the Fluxer security page:
-
-https://fluxer.app/security


### PR DESCRIPTION
Defining it in .github/ISSUE_TEMPLATE/config.yml makes it come up twice when opening an issue because security policies are enabled. Additionally, removed SECURITY.md as it would be picked up from fluxerapp/.github.