### PR TITLE
feat(sso): implement sudo sso

### DIFF
--- a/fluxer_admin/openapi-admin.json
+++ b/fluxer_admin/openapi-admin.json
@@ -12388,6 +12388,7 @@
 						"properties": {
 							"enabled": {"type": "boolean"},
 							"enforced": {"type": "boolean"},
+							"disable_additional_auth": {"type": "boolean"},
 							"display_name": {"nullable": true, "type": "string"},
 							"issuer": {"nullable": true, "type": "string"},
 							"authorization_url": {"nullable": true, "type": "string"},
@@ -12404,6 +12405,7 @@
 						"required": [
 							"enabled",
 							"enforced",
+							"disable_additional_auth",
 							"display_name",
 							"issuer",
 							"authorization_url",
@@ -12929,6 +12931,7 @@
 						"properties": {
 							"enabled": {"type": "boolean"},
 							"enforced": {"type": "boolean"},
+							"disable_additional_auth": {"type": "boolean"},
 							"display_name": {"nullable": true, "type": "string"},
 							"issuer": {"nullable": true, "type": "string"},
 							"authorization_url": {"nullable": true, "type": "string"},

--- a/fluxer_admin/src/api/types/instance_config.rs
+++ b/fluxer_admin/src/api/types/instance_config.rs
@@ -356,6 +356,8 @@ pub struct SsoConfigResponse {
     pub enabled: bool,
     #[serde(default)]
     pub enforced: bool,
+    #[serde(default)]
+    pub disable_additional_auth: bool,
     pub display_name: Option<String>,
     pub issuer: Option<String>,
     pub authorization_url: Option<String>,
@@ -733,6 +735,8 @@ pub struct SsoConfigUpdateRequest {
     pub enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enforced: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disable_additional_auth: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/fluxer_admin/src/routes/system_actions.rs
+++ b/fluxer_admin/src/routes/system_actions.rs
@@ -384,6 +384,7 @@ fn build_sso_update(form: &MultiValueForm) -> InstanceConfigUpdateRequest {
         sso: Some(SsoConfigUpdateRequest {
             enabled: Some(flag("sso_enabled")),
             enforced: Some(flag("sso_enforced")),
+            disable_additional_auth: Some(flag("sso_disable_additional_auth")),
             auto_provision: Some(flag("sso_auto_provision")),
             display_name: get("sso_display_name"),
             issuer: get("sso_issuer"),

--- a/fluxer_admin/src/templates/pages/instance_config.rs
+++ b/fluxer_admin/src/templates/pages/instance_config.rs
@@ -1387,7 +1387,32 @@ fn sso_config_section(base: &str, csrf_token: &str, sso: &SsoConfigResponse) -> 
                     div class="flex flex-col gap-2" {
                         (checkbox("sso_enabled", "true", "Enable SSO", sso.enabled, true))
                         (checkbox("sso_enforced", "true", "Require SSO (disables local password login and registration)", sso.enforced, true))
+                        div id="sso_disable_additional_auth_container" style=(if sso.enforced { "display: none;" } else { "" }) {
+                            (checkbox("sso_disable_additional_auth", "true", "Disallow SSO accounts from adding different authentication methods (e.g. passwords, TOTP)", sso.disable_additional_auth, true))
+                        }
                         (checkbox("sso_auto_provision", "true", "Automatically provision users on first SSO login", sso.auto_provision, true))
+                    }
+                    script {
+                        (maud::PreEscaped(r#"
+                            (function() {
+                                const enforcedCheckbox = document.querySelector('input[name="sso_enforced"]');
+                                const container = document.getElementById('sso_disable_additional_auth_container');
+                                if (enforcedCheckbox && container) {
+                                    function updateVisibility() {
+                                        if (enforcedCheckbox.checked) {
+                                            container.style.display = 'none';
+                                            const innerCheckbox = container.querySelector('input[type="checkbox"]');
+                                            if (innerCheckbox) {
+                                                innerCheckbox.checked = false;
+                                            }
+                                        } else {
+                                            container.style.display = '';
+                                        }
+                                    }
+                                    enforcedCheckbox.addEventListener('change', updateVisibility);
+                                }
+                            })();
+                        "#))
                     }
                     div class="grid grid-cols-1 gap-4 sm:grid-cols-2" {
                         (text_input("sso_display_name", "Display Name", sso.display_name.as_deref().unwrap_or(""), "Example Identity Provider"))

--- a/fluxer_api/src/api/admin/controllers/InstanceConfigAdminController.ts
+++ b/fluxer_api/src/api/admin/controllers/InstanceConfigAdminController.ts
@@ -68,6 +68,7 @@ async function buildInstanceConfigResponse(): Promise<InstanceConfigResponse> {
 		sso: {
 			enabled: ssoConfig.enabled,
 			enforced: ssoConfig.enforced,
+			disable_additional_auth: ssoConfig.disableAdditionalAuth,
 			display_name: ssoConfig.displayName,
 			issuer: ssoConfig.issuer,
 			authorization_url: ssoConfig.authorizationUrl,
@@ -215,6 +216,10 @@ export function InstanceConfigAdminController(app: HonoApp) {
 				const next = {
 					enabled: mergeOptionalField(current.enabled, readOptionalField(sso, 'enabled')),
 					enforced: mergeOptionalField(current.enforced, readOptionalField(sso, 'enforced')),
+					disableAdditionalAuth: mergeOptionalField(
+						current.disableAdditionalAuth,
+						readOptionalField(sso, 'disable_additional_auth'),
+					),
 					displayName: mergeOptionalField(current.displayName, readOptionalField(sso, 'display_name')),
 					issuer: mergeOptionalField(current.issuer, readOptionalField(sso, 'issuer')),
 					authorizationUrl: mergeOptionalField(current.authorizationUrl, readOptionalField(sso, 'authorization_url')),
@@ -235,6 +240,7 @@ export function InstanceConfigAdminController(app: HonoApp) {
 				await instanceConfigRepository.setSsoConfig({
 					enabled: validated.enabled,
 					enforced: validated.enforced,
+					disableAdditionalAuth: validated.disableAdditionalAuth,
 					displayName: next.displayName,
 					issuer: validated.issuer,
 					authorizationUrl: validated.authorizationUrl,
@@ -314,7 +320,10 @@ export function InstanceConfigAdminController(app: HonoApp) {
 									provider: readOptionalField(data.integrations.email, 'provider'),
 									from_email: readOptionalField(data.integrations.email, 'from_email'),
 									from_name: readOptionalField(data.integrations.email, 'from_name'),
-									disable_new_ip_authorization: readOptionalField(data.integrations.email, 'disable_new_ip_authorization'),
+									disable_new_ip_authorization: readOptionalField(
+										data.integrations.email,
+										'disable_new_ip_authorization',
+									),
 								}),
 								smtp: data.integrations.email.smtp
 									? omitUndefinedFields({

--- a/fluxer_api/src/api/auth/AuthController.ts
+++ b/fluxer_api/src/api/auth/AuthController.ts
@@ -28,6 +28,7 @@ import {
 	SsoStartRequest,
 	SsoStartResponse,
 	SsoStatusResponse,
+	SsoSudoCompleteResponse,
 	SudoVerificationSchema,
 	UsernameSuggestionsRequest,
 	UsernameSuggestionsResponse,
@@ -43,9 +44,10 @@ import {CaptchaMiddleware} from '../middleware/CaptchaMiddleware';
 import {LocalAuthMiddleware} from '../middleware/LocalAuthMiddleware';
 import {RateLimitMiddleware} from '../middleware/RateLimitMiddleware';
 import {OpenAPI} from '../middleware/ResponseTypeMiddleware';
-import {SudoModeMiddleware} from '../middleware/SudoModeMiddleware';
+import {SUDO_MODE_HEADER, SudoModeMiddleware} from '../middleware/SudoModeMiddleware';
 import {RateLimitConfigs} from '../RateLimitConfig';
 import type {HonoApp} from '../types/HonoEnv';
+import {setSudoCookie} from '../utils/SudoCookieUtils';
 import {Validator} from '../Validator';
 import {requireSudoMode} from './services/SudoVerificationService';
 
@@ -102,6 +104,50 @@ export function AuthController(app: HonoApp) {
 		}),
 		async (ctx) => {
 			const result = await ctx.get('authRequestService').completeSso(ctx.req.valid('json'), ctx.req.raw);
+			return ctx.json(result);
+		},
+	);
+	app.post(
+		'/auth/sso/sudo/start',
+		LoginRequiredAllowSuspicious,
+		DefaultUserOnly,
+		RateLimitMiddleware(RateLimitConfigs.AUTH_SSO_START),
+		Validator('json', SsoStartRequest),
+		OpenAPI({
+			operationId: 'start_sso_sudo',
+			summary: 'Start SSO sudo verification',
+			responseSchema: SsoStartResponse,
+			statusCode: 200,
+			security: ['bearerToken', 'sessionToken'],
+			tags: ['Auth'],
+			description: 'Initiate a Single Sign-On (SSO) reauthentication session for sudo mode verification.',
+		}),
+		async (ctx) => {
+			const result = await ctx.get('authRequestService').startSsoSudo(ctx.get('user'), ctx.req.valid('json'));
+			return ctx.json(result);
+		},
+	);
+	app.post(
+		'/auth/sso/sudo/complete',
+		LoginRequiredAllowSuspicious,
+		DefaultUserOnly,
+		RateLimitMiddleware(RateLimitConfigs.AUTH_SSO_COMPLETE),
+		Validator('json', SsoCompleteRequest),
+		OpenAPI({
+			operationId: 'complete_sso_sudo',
+			summary: 'Complete SSO sudo verification',
+			responseSchema: SsoSudoCompleteResponse,
+			statusCode: 200,
+			security: ['bearerToken', 'sessionToken'],
+			tags: ['Auth'],
+			description:
+				'Complete an SSO reauthentication flow and issue a short-lived sudo mode token for the current user.',
+		}),
+		async (ctx) => {
+			const user = ctx.get('user');
+			const result = await ctx.get('authRequestService').completeSsoSudo(user, ctx.req.valid('json'));
+			ctx.header(SUDO_MODE_HEADER, result.sudo_token);
+			setSudoCookie(ctx, result.sudo_token, user.id.toString());
 			return ctx.json(result);
 		},
 	);

--- a/fluxer_api/src/api/auth/AuthPassword.ts
+++ b/fluxer_api/src/api/auth/AuthPassword.ts
@@ -4,6 +4,7 @@ import crypto from 'node:crypto';
 import {FLUXER_USER_AGENT} from '@fluxer/constants/src/Core';
 import {UserAuthenticatorTypes, UserFlags} from '@fluxer/constants/src/UserConstants';
 import {ValidationErrorCodes} from '@fluxer/constants/src/ValidationErrorCodes';
+import {SsoRequiredError} from '@fluxer/errors/src/domains/auth/SsoRequiredError';
 import {InputValidationError} from '@fluxer/errors/src/domains/core/InputValidationError';
 import {RateLimitError} from '@fluxer/errors/src/domains/core/RateLimitError';
 import {requireClientIp} from '@fluxer/ip_utils/src/ClientIp';
@@ -13,6 +14,7 @@ import {ms, seconds} from 'itty-time';
 import type {ApiContext} from '../ApiContext';
 import {createMfaTicket, createPasswordResetToken} from '../BrandedTypes';
 import {Logger} from '../Logger';
+import {getInstanceConfigRepository} from '../middleware/ServiceSingletons';
 import type {User} from '../models/User';
 import {EXTERNAL_RESPONSE_LIMITS} from '../utils/ExternalResponseLimits';
 import * as FetchUtils from '../utils/FetchUtils';
@@ -212,6 +214,12 @@ export async function forgotPassword(ctx: ApiContext, {data, request}: ForgotPas
 		return;
 	}
 	AuthUtility.assertNonBotUser(ctx, user);
+	if (user.traits.has('sso')) {
+		const ssoConfig = await getInstanceConfigRepository().getSsoConfig();
+		if ((ssoConfig.enabled && ssoConfig.enforced) || ssoConfig.disableAdditionalAuth) {
+			throw new SsoRequiredError();
+		}
+	}
 	const token = createPasswordResetToken(await AuthUtility.generateSecureToken(ctx));
 	await users.createPasswordResetToken({
 		token_: token,
@@ -251,6 +259,12 @@ export async function resetPassword(
 		throw InputValidationError.fromCode('token', ValidationErrorCodes.INVALID_OR_EXPIRED_RESET_TOKEN);
 	}
 	AuthUtility.assertNonBotUser(ctx, user);
+	if (user.traits.has('sso')) {
+		const ssoConfig = await getInstanceConfigRepository().getSsoConfig();
+		if ((ssoConfig.enabled && ssoConfig.enforced) || ssoConfig.disableAdditionalAuth) {
+			throw new SsoRequiredError();
+		}
+	}
 	if (user.flags & UserFlags.DELETED) {
 		throw InputValidationError.fromCode('token', ValidationErrorCodes.INVALID_OR_EXPIRED_RESET_TOKEN);
 	}

--- a/fluxer_api/src/api/auth/AuthRequestService.ts
+++ b/fluxer_api/src/api/auth/AuthRequestService.ts
@@ -161,6 +161,18 @@ export class AuthRequestService {
 		return this.toSsoCompleteResponse(this.ssoService.completeLogin({code: data.code, state: data.state, request}));
 	}
 
+	startSsoSudo(user: User, data: SsoStartRequest) {
+		return this.ssoService.startSudo({
+			user,
+			redirectTo: data.redirect_to ?? undefined,
+			redirectUri: data.redirect_uri ?? undefined,
+		});
+	}
+
+	completeSsoSudo(user: User, data: SsoCompleteRequest) {
+		return this.ssoService.completeSudo({code: data.code, state: data.state, user});
+	}
+
 	async register({data, request, requestCache}: AuthRegisterRequest): Promise<AuthRegisterResponse> {
 		const result = await AuthRegistration.register(this.apiContext, this.registrationDependencies, {
 			data,

--- a/fluxer_api/src/api/auth/services/SsoService.ts
+++ b/fluxer_api/src/api/auth/services/SsoService.ts
@@ -48,6 +48,7 @@ import {deriveUsernameFromDisplayName} from '../../utils/UsernameSuggestionUtils
 import * as AuthSession from '../AuthSession';
 import {SsoIdentityRepository} from './SsoIdentityRepository';
 import {parseTokenEndpointResponse, sanitizeSsoRedirectTo, tryDiscoverOidcProviderMetadata} from './SsoUtils';
+import {getSudoModeService} from './SudoModeService';
 
 interface SsoStatePayload {
 	codeVerifier: string;
@@ -55,11 +56,14 @@ interface SsoStatePayload {
 	redirectTo?: string;
 	redirectUri?: string;
 	createdAt: number;
+	purpose?: 'login' | 'sudo';
+	sudoUserId?: string;
 }
 
 interface PublicSsoStatus {
 	enabled: boolean;
 	enforced: boolean;
+	disable_additional_auth: boolean;
 	display_name: string | null;
 	redirect_uri: string;
 }
@@ -254,6 +258,7 @@ export class SsoService {
 		return {
 			enabled,
 			enforced: enabled && config.enforced,
+			disable_additional_auth: config.disableAdditionalAuth,
 			display_name: config.displayName ?? null,
 			redirect_uri: config.redirectUri,
 		};
@@ -265,6 +270,40 @@ export class SsoService {
 	}
 
 	async startLogin({redirectTo, redirectUri}: {redirectTo?: string; redirectUri?: string} = {}): Promise<{
+		authorization_url: string;
+		state: string;
+		redirect_uri: string;
+	}> {
+		return this.startAuthorization({redirectTo, redirectUri, purpose: 'login'});
+	}
+
+	async startSudo({user, redirectTo, redirectUri}: {user: User; redirectTo?: string; redirectUri?: string}): Promise<{
+		authorization_url: string;
+		state: string;
+		redirect_uri: string;
+	}> {
+		if (!user.traits.has('sso')) {
+			throw new SsoRequiredError();
+		}
+		return this.startAuthorization({
+			redirectTo,
+			redirectUri,
+			purpose: 'sudo',
+			sudoUserId: user.id.toString(),
+		});
+	}
+
+	private async startAuthorization({
+		redirectTo,
+		redirectUri,
+		purpose,
+		sudoUserId,
+	}: {
+		redirectTo?: string;
+		redirectUri?: string;
+		purpose: 'login' | 'sudo';
+		sudoUserId?: string;
+	}): Promise<{
 		authorization_url: string;
 		state: string;
 		redirect_uri: string;
@@ -281,6 +320,8 @@ export class SsoService {
 			redirectTo: sanitizeSsoRedirectTo(redirectTo),
 			redirectUri: ssoRedirectUri,
 			createdAt: Date.now(),
+			purpose,
+			sudoUserId,
 		};
 		const {cache} = this.apiContext.services;
 		await cache.set(buildStateCacheKey(state), statePayload, SsoService.STATE_TTL_SECONDS);
@@ -317,6 +358,34 @@ export class SsoService {
 		user_id: string;
 		redirect_to: string;
 	}> {
+		const {config, statePayload, tokenResponse} = await this.completeAuthorization({code, state});
+		if ((statePayload.purpose ?? 'login') !== 'login') {
+			throw InputValidationError.fromCode('state', ValidationErrorCodes.INVALID_OR_EXPIRED_SSO_STATE);
+		}
+		const claims = await this.resolveClaims(tokenResponse, config, statePayload.nonce);
+		const user = await this.resolveUserFromClaims(claims, config);
+		const [token] = await AuthSession.createAuthSession(this.apiContext, {user, request});
+		return {token, user_id: user.id.toString(), redirect_to: statePayload.redirectTo ?? ''};
+	}
+
+	async completeSudo({code, state, user}: {code: string; state: string; user: User}): Promise<{
+		sudo_token: string;
+	}> {
+		const {config, statePayload, tokenResponse} = await this.completeAuthorization({code, state});
+		if (statePayload.purpose !== 'sudo' || statePayload.sudoUserId !== user.id.toString()) {
+			throw InputValidationError.fromCode('state', ValidationErrorCodes.INVALID_OR_EXPIRED_SSO_STATE);
+		}
+		const claims = await this.resolveClaims(tokenResponse, config, statePayload.nonce);
+		await this.resolveSudoUserFromClaims(user, claims, config);
+		const sudoModeService = getSudoModeService();
+		return {sudo_token: await sudoModeService.generateSudoToken(user.id)};
+	}
+
+	private async completeAuthorization({code, state}: {code: string; state: string}): Promise<{
+		config: ResolvedSsoConfig;
+		statePayload: SsoStatePayload;
+		tokenResponse: {id_token?: string; access_token?: string};
+	}> {
 		const config = await this.requireReadyConfig();
 		const {cache} = this.apiContext.services;
 		const statePayload = await cache.getAndDelete<SsoStatePayload>(buildStateCacheKey(state));
@@ -329,10 +398,29 @@ export class SsoService {
 			redirectUri: statePayload.redirectUri ?? config.redirectUri,
 			config,
 		});
-		const claims = await this.resolveClaims(tokenResponse, config, statePayload.nonce);
-		const user = await this.resolveUserFromClaims(claims, config);
-		const [token] = await AuthSession.createAuthSession(this.apiContext, {user, request});
-		return {token, user_id: user.id.toString(), redirect_to: statePayload.redirectTo ?? ''};
+		return {config, statePayload, tokenResponse};
+	}
+
+	private async resolveSudoUserFromClaims(
+		user: User,
+		claims: ResolvedSsoClaims,
+		config: ResolvedSsoConfig,
+	): Promise<User> {
+		if (!claims.emailVerified) {
+			throw InputValidationError.fromCode('email_verified', ValidationErrorCodes.INVALID_SSO_TOKEN);
+		}
+		const identityUserId = await this.ssoIdentityRepository.findUserId(config.providerId, claims.sub);
+		if (identityUserId) {
+			if (identityUserId.toString() !== user.id.toString()) {
+				throw InputValidationError.fromCode('sub', ValidationErrorCodes.SSO_IDENTITY_MISMATCH);
+			}
+			return user;
+		}
+		const boundUser = await this.bindSsoIdentity(user, claims.sub, config);
+		if (boundUser.id.toString() !== user.id.toString()) {
+			throw InputValidationError.fromCode('sub', ValidationErrorCodes.SSO_IDENTITY_MISMATCH);
+		}
+		return boundUser;
 	}
 
 	private async resolveUserFromClaims(claims: ResolvedSsoClaims, config: ResolvedSsoConfig): Promise<User> {

--- a/fluxer_api/src/api/auth/services/SudoVerificationService.ts
+++ b/fluxer_api/src/api/auth/services/SudoVerificationService.ts
@@ -8,6 +8,7 @@ import type {AuthenticationResponseJSON} from '@simplewebauthn/server';
 import type {Context} from 'hono';
 import * as AuthMfa from '../../auth/AuthMfa';
 import * as AuthPassword from '../../auth/AuthPassword';
+import {getInstanceConfigRepository} from '../../middleware/ServiceSingletons';
 import {SUDO_MODE_HEADER} from '../../middleware/SudoModeMiddleware';
 import type {User} from '../../models/User';
 import type {HonoEnv} from '../../types/HonoEnv';
@@ -31,15 +32,31 @@ export function userHasMfa(user: {authenticatorTypes?: Set<number> | null}): boo
 	);
 }
 
-export function deriveSudoMethods(user: {
-	totpSecret?: string | null;
-	authenticatorTypes?: Set<number> | null;
-}): SudoModeMethods {
+interface DeriveSudoMethodsOptions {
+	includeLocal?: boolean;
+	sso?: boolean;
+}
+
+export function deriveSudoMethods(
+	user: {
+		totpSecret?: string | null;
+		authenticatorTypes?: Set<number> | null;
+	},
+	options: DeriveSudoMethodsOptions = {},
+): SudoModeMethods {
+	const includeLocal = options.includeLocal ?? true;
 	const authenticatorTypes = user.authenticatorTypes ?? null;
-	return {
-		totp: (user.totpSecret ?? null) !== null && (authenticatorTypes?.has(UserAuthenticatorTypes.TOTP) ?? false),
-		webauthn: authenticatorTypes?.has(UserAuthenticatorTypes.WEBAUTHN) ?? false,
+	const methods: SudoModeMethods = {
+		totp:
+			includeLocal &&
+			(user.totpSecret ?? null) !== null &&
+			(authenticatorTypes?.has(UserAuthenticatorTypes.TOTP) ?? false),
+		webauthn: includeLocal && (authenticatorTypes?.has(UserAuthenticatorTypes.WEBAUTHN) ?? false),
 	};
+	if (options.sso) {
+		methods.sso = true;
+	}
+	return methods;
 }
 
 export interface SudoVerificationResult {
@@ -61,15 +78,23 @@ async function verifySudoMode(
 	if (user.isBot) {
 		return {verified: true, method: 'sudo_token'};
 	}
+	const ssoConfig = await getInstanceConfigRepository().getSsoConfig();
+	const ssoSudoRequired =
+		user.traits.has('sso') && ((ssoConfig.enabled && ssoConfig.enforced) || ssoConfig.disableAdditionalAuth);
+	const hasSsoOption = user.traits.has('sso') && ssoConfig.enabled;
 	const hasMfa = userHasMfa(user);
-	const issueSudoToken = options.issueSudoToken ?? hasMfa;
+	const issueSudoToken = options.issueSudoToken ?? (hasMfa || ssoSudoRequired);
 	if (hasMfa && ctx.get('sudoModeValid')) {
 		const sudoToken = ctx.get('sudoModeToken') ?? ctx.req.header(SUDO_MODE_HEADER) ?? undefined;
 		return {verified: true, method: 'sudo_token', sudoToken: issueSudoToken ? sudoToken : undefined};
 	}
 	const incomingToken = ctx.req.header(SUDO_MODE_HEADER);
-	if (!hasMfa && incomingToken && ctx.get('sudoModeValid')) {
-		return {verified: true, method: 'sudo_token', sudoToken: issueSudoToken ? incomingToken : undefined};
+	if (!hasMfa && ctx.get('sudoModeValid') && (incomingToken || ssoSudoRequired)) {
+		const sudoToken = ctx.get('sudoModeToken') ?? incomingToken ?? undefined;
+		return {verified: true, method: 'sudo_token', sudoToken: issueSudoToken ? sudoToken : undefined};
+	}
+	if (ssoSudoRequired) {
+		throw new SudoModeRequiredError(true, deriveSudoMethods(user, {includeLocal: false, sso: true}));
 	}
 	if (hasMfa && body.mfa_method) {
 		const result = await AuthMfa.verifySudoMfa(ctx.get('apiContext'), {
@@ -103,7 +128,7 @@ async function verifySudoMode(
 		}
 		return {verified: true, method: 'password'};
 	}
-	throw new SudoModeRequiredError(hasMfa, deriveSudoMethods(user));
+	throw new SudoModeRequiredError(hasMfa, deriveSudoMethods(user, {sso: hasSsoOption}));
 }
 
 function setSudoTokenHeader(

--- a/fluxer_api/src/api/auth/tests/AuthTestUtils.ts
+++ b/fluxer_api/src/api/auth/tests/AuthTestUtils.ts
@@ -307,6 +307,7 @@ export async function unclaimAccount(harness: ApiTestHarness, userId: string): P
 interface SsoConfig {
 	enabled: boolean;
 	enforced: boolean;
+	disable_additional_auth?: boolean;
 	authorization_url: string;
 	token_url: string;
 	client_id: string;
@@ -326,6 +327,7 @@ export async function enableSso(
 	const ssoConfig: SsoConfig = {
 		enabled: true,
 		enforced: true,
+		disable_additional_auth: false,
 		authorization_url: 'test',
 		token_url: 'test',
 		client_id: 'itest-client',

--- a/fluxer_api/src/api/auth/tests/SsoFlow.test.ts
+++ b/fluxer_api/src/api/auth/tests/SsoFlow.test.ts
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import type {AuthSessionResponse} from '@fluxer/schema/src/domains/auth/AuthSchemas';
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from 'vitest';
 import type {ApiTestHarness} from '../../test/ApiTestHarness';
 import {createBuilder, createBuilderWithoutAuth} from '../../test/TestRequestBuilder';
 import {
 	createAuthHarness,
 	createTestAccount,
+	createTotpSecret,
 	createUniqueEmail,
 	disableSso,
 	enableSso,
@@ -28,8 +30,19 @@ interface SsoCompleteResponse {
 interface SsoStatusResponse {
 	enabled: boolean;
 	enforced: boolean;
+	disable_additional_auth: boolean;
 	display_name?: string;
 	redirect_uri: string;
+}
+
+interface SudoModeRequiredResponse {
+	code: 'SUDO_MODE_REQUIRED';
+	has_mfa: boolean;
+	methods: {
+		totp: boolean;
+		webauthn: boolean;
+		sso?: boolean;
+	};
 }
 
 function getAuthorizationUrlParam(authorizationUrlString: string, param: string): string | null {
@@ -681,6 +694,96 @@ describe('Auth SSO flow', () => {
 				.execute();
 		});
 	});
+	describe('sudo verification', () => {
+		let admin: TestAccount;
+		beforeEach(async () => {
+			admin = await createTestAccount(harness);
+			admin = await setUserACLs(harness, admin, [
+				'admin:authenticate',
+				'instance:config:update',
+				'instance:config:view',
+			]);
+			await enableSso(harness, admin.token);
+		});
+		afterEach(async () => {
+			await disableSso(harness, admin.token);
+		});
+		it('issues a sudo token after the current SSO user reauthenticates with SSO', async () => {
+			const email = createUniqueEmail('sso-sudo');
+			const subject = `itest-sso-sudo-${Date.now()}`;
+			const loginStart = await createBuilderWithoutAuth<SsoStartResponse>(harness)
+				.post('/auth/sso/start')
+				.body({})
+				.execute();
+			const login = await createBuilderWithoutAuth<SsoCompleteResponse>(harness)
+				.post('/auth/sso/complete')
+				.body({
+					code: JSON.stringify({email, sub: subject, email_verified: true}),
+					state: loginStart.state,
+				})
+				.execute();
+			const sessions = await createBuilder<Array<AuthSessionResponse>>(harness, login.token)
+				.get('/auth/sessions')
+				.execute();
+			expect(sessions.length).toBeGreaterThan(0);
+			await createBuilder(harness, login.token)
+				.post('/auth/sessions/logout')
+				.body({session_id_hashes: [sessions[0]!.id_hash]})
+				.expect(403)
+				.execute();
+			const sudoStart = await createBuilder<SsoStartResponse>(harness, login.token)
+				.post('/auth/sso/sudo/start')
+				.body({})
+				.execute();
+			const {response, json} = await createBuilder<{sudo_token: string}>(harness, login.token)
+				.post('/auth/sso/sudo/complete')
+				.body({
+					code: JSON.stringify({email, sub: subject, email_verified: true}),
+					state: sudoStart.state,
+				})
+				.executeWithResponse();
+			const sudoToken = response.headers.get('X-Fluxer-Sudo-Mode-JWT');
+			expect(sudoToken).toBeTruthy();
+			expect(json.sudo_token).toBe(sudoToken);
+			await createBuilder(harness, login.token)
+				.post('/auth/sessions/logout')
+				.header('X-Fluxer-Sudo-Mode-JWT', sudoToken!)
+				.body({session_id_hashes: [sessions[0]!.id_hash]})
+				.expect(204)
+				.execute();
+		});
+		it('rejects SSO sudo completion when the provider identity belongs to another user', async () => {
+			const email = createUniqueEmail('sso-sudo-owner');
+			const subject = `itest-sso-sudo-owner-${Date.now()}`;
+			const loginStart = await createBuilderWithoutAuth<SsoStartResponse>(harness)
+				.post('/auth/sso/start')
+				.body({})
+				.execute();
+			const login = await createBuilderWithoutAuth<SsoCompleteResponse>(harness)
+				.post('/auth/sso/complete')
+				.body({
+					code: JSON.stringify({email, sub: subject, email_verified: true}),
+					state: loginStart.state,
+				})
+				.execute();
+			const sudoStart = await createBuilder<SsoStartResponse>(harness, login.token)
+				.post('/auth/sso/sudo/start')
+				.body({})
+				.execute();
+			await createBuilder(harness, login.token)
+				.post('/auth/sso/sudo/complete')
+				.body({
+					code: JSON.stringify({
+						email: createUniqueEmail('sso-sudo-other'),
+						sub: `itest-sso-sudo-other-${Date.now()}`,
+						email_verified: true,
+					}),
+					state: sudoStart.state,
+				})
+				.expect(400, 'INVALID_FORM_BODY')
+				.execute();
+		});
+	});
 	describe('status endpoint', () => {
 		let admin: TestAccount;
 		beforeEach(async () => {
@@ -711,6 +814,7 @@ describe('Auth SSO flow', () => {
 			const status = await createBuilderWithoutAuth<SsoStatusResponse>(harness).get('/auth/sso/status').execute();
 			expect(status.enabled).toBe(true);
 			expect(status.enforced).toBe(false);
+			expect(status.disable_additional_auth).toBe(false);
 			await disableSso(harness, admin.token);
 		});
 		it('does not advertise enabled SSO when optional SSO cannot resolve claims', async () => {
@@ -736,7 +840,166 @@ describe('Auth SSO flow', () => {
 			const status = await createBuilderWithoutAuth<SsoStatusResponse>(harness).get('/auth/sso/status').execute();
 			expect(status.enabled).toBe(false);
 			expect(status.enforced).toBe(false);
+			expect(status.disable_additional_auth).toBe(false);
 			await disableSso(harness, admin.token);
+		});
+	});
+
+	describe('SSO local credentials restrictions', () => {
+		let admin: TestAccount;
+		beforeEach(async () => {
+			admin = await createTestAccount(harness);
+			admin = await setUserACLs(harness, admin, [
+				'admin:authenticate',
+				'instance:config:update',
+				'instance:config:view',
+			]);
+		});
+		afterEach(async () => {
+			await disableSso(harness, admin.token);
+		});
+
+		it('enforces password and MFA restrictions based on sso configuration', async () => {
+			// 1. Enable SSO allowing additional auth, not enforced
+			await enableSso(harness, admin.token, {enforced: false, disable_additional_auth: false});
+
+			// Login via SSO
+			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness).post('/auth/sso/start').execute();
+			const email = `sso-user-restrict-${Date.now()}@example.com`;
+			const completeData = await createBuilderWithoutAuth<SsoCompleteResponse>(harness)
+				.post('/auth/sso/complete')
+				.body({
+					code: email,
+					state: startData.state,
+				})
+				.execute();
+
+			// SSO user obtains a sudo token via OIDC re-authentication
+			const sudoStart = await createBuilder<SsoStartResponse>(harness, completeData.token)
+				.post('/auth/sso/sudo/start')
+				.body({})
+				.execute();
+			const sudoTokenRes = await createBuilder<{sudo_token: string}>(harness, completeData.token)
+				.post('/auth/sso/sudo/complete')
+				.body({
+					code: email,
+					state: sudoStart.state,
+				})
+				.execute();
+			const sudoToken = sudoTokenRes.sudo_token;
+
+			// Under disable_additional_auth: false and enforced: false, SSO user CAN start password change
+			const pwStartResult = await createBuilder(harness, completeData.token)
+				.post('/users/@me/password-change/start')
+				.expect(200)
+				.execute();
+			expect(pwStartResult).toHaveProperty('ticket');
+
+			const validSecret = createTotpSecret();
+
+			// Under disable_additional_auth: false and enforced: false, SSO user CAN start TOTP enable (will fail on bad secret/code, but shouldn't be blocked by SSO)
+			await createBuilder(harness, completeData.token)
+				.post('/users/@me/mfa/totp/enable')
+				.header('X-Fluxer-Sudo-Mode-JWT', sudoToken)
+				.body({secret: validSecret, code: '000000'})
+				.expect(400) // Expect validation / code failure, NOT SSO_REQUIRED (403)
+				.execute();
+
+			// 2. Update config to disallow additional auth
+			await enableSso(harness, admin.token, {enforced: false, disable_additional_auth: true});
+
+			// Now, password change start should be blocked (403 Forbidden)
+			await createBuilder(harness, completeData.token).post('/users/@me/password-change/start').expect(403).execute();
+
+			// TOTP enable should be blocked (403 Forbidden)
+			await createBuilder(harness, completeData.token)
+				.post('/users/@me/mfa/totp/enable')
+				.header('X-Fluxer-Sudo-Mode-JWT', sudoToken)
+				.body({secret: validSecret, code: '000000'})
+				.expect(403)
+				.execute();
+
+			// 3. Update config to enforce SSO (and allow additional auth: true)
+			await enableSso(harness, admin.token, {enforced: true, disable_additional_auth: false});
+
+			// Should still be blocked because SSO is enforced!
+			await createBuilder(harness, completeData.token).post('/users/@me/password-change/start').expect(403).execute();
+
+			await createBuilder(harness, completeData.token)
+				.post('/users/@me/mfa/totp/enable')
+				.header('X-Fluxer-Sudo-Mode-JWT', sudoToken)
+				.body({secret: validSecret, code: '000000'})
+				.expect(403)
+				.execute();
+		});
+
+		it('normalizes disable_additional_auth to false when SSO is enforced', async () => {
+			// Update config with enforced: true and disable_additional_auth: true
+			await enableSso(harness, admin.token, {enforced: true, disable_additional_auth: true});
+
+			// Verify that the configuration fetched from the admin API has disable_additional_auth set to false
+			const config = await createBuilder<{sso: {enforced: boolean; disable_additional_auth: boolean}}>(
+				harness,
+				admin.token,
+			)
+				.post('/admin/instance-config/get')
+				.expect(200)
+				.execute();
+
+			expect(config.sso.enforced).toBe(true);
+			expect(config.sso.disable_additional_auth).toBe(false);
+		});
+
+		it('requires SSO sudo for SSO-managed accounts when additional auth is disabled', async () => {
+			await enableSso(harness, admin.token, {enforced: false, disable_additional_auth: true});
+
+			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness).post('/auth/sso/start').execute();
+			const email = `sso-sudo-restricted-${Date.now()}@example.com`;
+			const completeData = await createBuilderWithoutAuth<SsoCompleteResponse>(harness)
+				.post('/auth/sso/complete')
+				.body({
+					code: email,
+					state: startData.state,
+				})
+				.execute();
+			const sessions = await createBuilder<Array<AuthSessionResponse>>(harness, completeData.token)
+				.get('/auth/sessions')
+				.execute();
+			const sudoRequired = await createBuilder<SudoModeRequiredResponse>(harness, completeData.token)
+				.post('/auth/sessions/logout')
+				.body({
+					session_id_hashes: [sessions[0]!.id_hash],
+				})
+				.expect(403, 'SUDO_MODE_REQUIRED')
+				.execute();
+
+			expect(sudoRequired.methods).toEqual({totp: false, webauthn: false, sso: true});
+		});
+
+		it('includes SSO under allowed methods for SSO-managed accounts when SSO is optional', async () => {
+			await enableSso(harness, admin.token, {enforced: false, disable_additional_auth: false});
+
+			const startData = await createBuilderWithoutAuth<SsoStartResponse>(harness).post('/auth/sso/start').execute();
+			const email = `sso-sudo-optional-${Date.now()}@example.com`;
+			const completeData = await createBuilderWithoutAuth<SsoCompleteResponse>(harness)
+				.post('/auth/sso/complete')
+				.body({
+					code: email,
+					state: startData.state,
+				})
+				.execute();
+			const sessions = await createBuilder<Array<AuthSessionResponse>>(harness, completeData.token)
+				.get('/auth/sessions')
+				.execute();
+			const sudoRequired = await createBuilder<SudoModeRequiredResponse>(harness, completeData.token)
+				.post('/auth/sessions/logout')
+				.body({
+					session_id_hashes: [sessions[0]!.id_hash],
+				})
+				.expect(403, 'SUDO_MODE_REQUIRED')
+				.execute();
+
+			expect(sudoRequired.methods.sso).toBe(true);
 		});
 	});
 });

--- a/fluxer_api/src/api/instance/InstanceConfigRepository.ts
+++ b/fluxer_api/src/api/instance/InstanceConfigRepository.ts
@@ -754,6 +754,7 @@ function isLimitConfigSnapshot(value: unknown): value is LimitConfigSnapshot {
 export interface InstanceSsoConfig {
 	enabled: boolean;
 	enforced: boolean;
+	disableAdditionalAuth: boolean;
 	displayName: string | null;
 	issuer: string | null;
 	authorizationUrl: string | null;
@@ -1558,6 +1559,7 @@ export class InstanceConfigRepository {
 		return {
 			enabled,
 			enforced: enforcedRaw == null ? enabled : enforcedRaw === 'true',
+			disableAdditionalAuth: configs.get('sso_disable_additional_auth') === 'true',
 			displayName: read('sso_display_name'),
 			issuer: read('sso_issuer'),
 			authorizationUrl: read('sso_authorization_url'),
@@ -1600,6 +1602,7 @@ export class InstanceConfigRepository {
 		const entries: Array<[string, string]> = [
 			['sso_enabled', next.enabled ? 'true' : 'false'],
 			['sso_enforced', next.enforced ? 'true' : 'false'],
+			['sso_disable_additional_auth', next.disableAdditionalAuth ? 'true' : 'false'],
 			['sso_display_name', next.displayName ?? ''],
 			['sso_issuer', next.issuer ?? ''],
 			['sso_authorization_url', next.authorizationUrl ?? ''],

--- a/fluxer_api/src/api/instance/SsoConfigValidation.ts
+++ b/fluxer_api/src/api/instance/SsoConfigValidation.ts
@@ -8,6 +8,7 @@ import {createPublicInternetRequestUrlPolicy} from '@pkgs/http_client/src/Public
 interface SsoConfigValidationInput {
 	enabled: boolean;
 	enforced: boolean;
+	disableAdditionalAuth: boolean;
 	issuer: string | null;
 	authorizationUrl: string | null;
 	tokenUrl: string | null;
@@ -52,6 +53,10 @@ export function isTestSsoProvider(
 		config.tokenUrl === 'test' ||
 		(testModeEnabled && (config.authorizationUrl?.startsWith('test-') ?? false))
 	);
+}
+
+function normalizeSsoDisableAdditionalAuth(disableAdditionalAuth: boolean, enforced: boolean): boolean {
+	return enforced ? false : disableAdditionalAuth;
 }
 
 export function normalizeSsoAllowedEmailDomains(domains: Array<string>): Array<string> {
@@ -142,6 +147,7 @@ export async function normalizeAndValidateSsoConfig(
 ): Promise<NormalizedSsoConfigValidationResult> {
 	const baseConfig = {
 		...config,
+		disableAdditionalAuth: normalizeSsoDisableAdditionalAuth(config.disableAdditionalAuth, config.enforced),
 		issuer: normalizeOptionalSsoString(config.issuer),
 		authorizationUrl: normalizeOptionalSsoString(config.authorizationUrl),
 		tokenUrl: normalizeOptionalSsoString(config.tokenUrl),

--- a/fluxer_api/src/api/openapi/openapi.json
+++ b/fluxer_api/src/api/openapi/openapi.json
@@ -1546,6 +1546,148 @@
 				"description": "Retrieve the current status of the SSO authentication session without authentication required."
 			}
 		},
+		"/auth/sso/sudo/complete": {
+			"post": {
+				"operationId": "complete_sso_sudo",
+				"summary": "Complete SSO sudo verification",
+				"tags": ["Auth"],
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {"application/json": {"schema": {"$ref": "#/components/schemas/SsoSudoCompleteResponse"}}}
+					},
+					"400": {
+						"description": "Bad Request - The request was malformed or contained invalid data",
+						"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+					},
+					"401": {
+						"description": "Unauthorized - Authentication is required or the token is invalid",
+						"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+					},
+					"403": {
+						"description": "Forbidden - You do not have permission to perform this action",
+						"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+					},
+					"429": {
+						"description": "Too Many Requests - You are being rate limited",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"code": {"type": "string", "enum": ["RATE_LIMITED"]},
+										"message": {"type": "string"},
+										"retry_after": {"type": "number", "description": "Seconds to wait before retrying"},
+										"global": {"type": "boolean", "description": "Whether this is a global rate limit"}
+									},
+									"required": ["code", "message", "retry_after"]
+								}
+							}
+						},
+						"headers": {
+							"Retry-After": {
+								"description": "Number of seconds to wait before retrying (only on 429)",
+								"schema": {"type": "integer"}
+							},
+							"X-RateLimit-Limit": {
+								"description": "The number of requests that can be made in the current window",
+								"schema": {"type": "integer"}
+							},
+							"X-RateLimit-Remaining": {
+								"description": "The number of remaining requests that can be made",
+								"schema": {"type": "integer"}
+							},
+							"X-RateLimit-Reset": {
+								"description": "Unix timestamp when the rate limit resets",
+								"schema": {"type": "integer"}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error - An unexpected error occurred",
+						"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+					}
+				},
+				"x-mint": {"metadata": {"title": "Complete SSO sudo verification"}},
+				"description": "Complete an SSO reauthentication flow and issue a short-lived sudo mode token for the current user.",
+				"security": [{"sessionToken": []}],
+				"requestBody": {
+					"required": true,
+					"content": {"application/json": {"schema": {"$ref": "#/components/schemas/SsoCompleteRequest"}}}
+				}
+			}
+		},
+		"/auth/sso/sudo/start": {
+			"post": {
+				"operationId": "start_sso_sudo",
+				"summary": "Start SSO sudo verification",
+				"tags": ["Auth"],
+				"responses": {
+					"200": {
+						"description": "Success",
+						"content": {"application/json": {"schema": {"$ref": "#/components/schemas/SsoStartResponse"}}}
+					},
+					"400": {
+						"description": "Bad Request - The request was malformed or contained invalid data",
+						"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+					},
+					"401": {
+						"description": "Unauthorized - Authentication is required or the token is invalid",
+						"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+					},
+					"403": {
+						"description": "Forbidden - You do not have permission to perform this action",
+						"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+					},
+					"429": {
+						"description": "Too Many Requests - You are being rate limited",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"code": {"type": "string", "enum": ["RATE_LIMITED"]},
+										"message": {"type": "string"},
+										"retry_after": {"type": "number", "description": "Seconds to wait before retrying"},
+										"global": {"type": "boolean", "description": "Whether this is a global rate limit"}
+									},
+									"required": ["code", "message", "retry_after"]
+								}
+							}
+						},
+						"headers": {
+							"Retry-After": {
+								"description": "Number of seconds to wait before retrying (only on 429)",
+								"schema": {"type": "integer"}
+							},
+							"X-RateLimit-Limit": {
+								"description": "The number of requests that can be made in the current window",
+								"schema": {"type": "integer"}
+							},
+							"X-RateLimit-Remaining": {
+								"description": "The number of remaining requests that can be made",
+								"schema": {"type": "integer"}
+							},
+							"X-RateLimit-Reset": {
+								"description": "Unix timestamp when the rate limit resets",
+								"schema": {"type": "integer"}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error - An unexpected error occurred",
+						"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+					}
+				},
+				"x-mint": {"metadata": {"title": "Start SSO sudo verification"}},
+				"description": "Initiate a Single Sign-On (SSO) reauthentication session for sudo mode verification.",
+				"security": [{"sessionToken": []}],
+				"requestBody": {
+					"required": true,
+					"content": {"application/json": {"schema": {"$ref": "#/components/schemas/SsoStartRequest"}}}
+				}
+			}
+		},
 		"/auth/username-suggestions": {
 			"post": {
 				"operationId": "get_username_suggestions",
@@ -24823,13 +24965,17 @@
 						"properties": {
 							"enabled": {"type": "boolean", "description": "Whether SSO is enabled for this instance"},
 							"enforced": {"type": "boolean", "description": "Whether SSO is required for all users"},
+							"disable_additional_auth": {
+								"type": "boolean",
+								"description": "Whether SSO-managed accounts are prevented from adding or using local authentication methods"
+							},
 							"display_name": {
 								"anyOf": [{"type": "string"}, {"type": "null"}],
 								"description": "Display name of the SSO provider"
 							},
 							"redirect_uri": {"type": "string", "description": "OAuth redirect URI for SSO"}
 						},
-						"required": ["enabled", "enforced", "display_name", "redirect_uri"],
+						"required": ["enabled", "enforced", "disable_additional_auth", "display_name", "redirect_uri"],
 						"description": "Single sign-on configuration"
 					},
 					"registration": {
@@ -26342,13 +26488,24 @@
 				"properties": {
 					"enabled": {"type": "boolean", "description": "Whether SSO is enabled for this instance"},
 					"enforced": {"type": "boolean", "description": "Whether SSO is required for all users"},
+					"disable_additional_auth": {
+						"type": "boolean",
+						"description": "Whether SSO-managed accounts are prevented from adding or using local authentication methods"
+					},
 					"display_name": {
 						"anyOf": [{"type": "string"}, {"type": "null"}],
 						"description": "Display name of the SSO provider"
 					},
 					"redirect_uri": {"type": "string", "description": "OAuth redirect URI for SSO"}
 				},
-				"required": ["enabled", "enforced", "display_name", "redirect_uri"]
+				"required": ["enabled", "enforced", "disable_additional_auth", "display_name", "redirect_uri"]
+			},
+			"SsoSudoCompleteResponse": {
+				"type": "object",
+				"properties": {
+					"sudo_token": {"type": "string", "description": "Short-lived sudo token issued after SSO reauthentication"}
+				},
+				"required": ["sudo_token"]
 			},
 			"UsernameSuggestionsResponse": {
 				"type": "object",

--- a/fluxer_api/src/api/user/services/PasswordChangeService.ts
+++ b/fluxer_api/src/api/user/services/PasswordChangeService.ts
@@ -8,10 +8,12 @@ import {
 	getActiveChangeTicketForUser,
 } from '@app/api/user/services/UserChangeChallengeUtils';
 import {ValidationErrorCodes} from '@fluxer/constants/src/ValidationErrorCodes';
+import {SsoRequiredError} from '@fluxer/errors/src/domains/auth/SsoRequiredError';
 import {InputValidationError} from '@fluxer/errors/src/domains/core/InputValidationError';
 import {ms} from 'itty-time';
 import type {ApiContext} from '../../ApiContext';
 import * as AuthPassword from '../../auth/AuthPassword';
+import {getInstanceConfigRepository} from '../../middleware/ServiceSingletons';
 import type {User} from '../../models/User';
 import type {PasswordChangeRepository} from '../repositories/auth/PasswordChangeRepository';
 
@@ -35,6 +37,12 @@ export class PasswordChangeService {
 	) {}
 
 	async start(user: User): Promise<StartPasswordChangeResult> {
+		if (user.traits.has('sso')) {
+			const ssoConfig = await getInstanceConfigRepository().getSsoConfig();
+			if ((ssoConfig.enabled && ssoConfig.enforced) || ssoConfig.disableAdditionalAuth) {
+				throw new SsoRequiredError();
+			}
+		}
 		const {email, rateLimit} = this.apiContext.services;
 		if (!user.email) {
 			throw InputValidationError.fromCode('email', ValidationErrorCodes.MUST_HAVE_EMAIL_TO_CHANGE_IT);

--- a/fluxer_api/src/api/user/services/UserAuthRequestService.ts
+++ b/fluxer_api/src/api/user/services/UserAuthRequestService.ts
@@ -3,6 +3,7 @@
 import {GuildVerificationLevel} from '@fluxer/constants/src/GuildConstants';
 import {UserAuthenticatorTypes} from '@fluxer/constants/src/UserConstants';
 import {PhoneAddNotEligibleError} from '@fluxer/errors/src/domains/auth/PhoneAddNotEligibleError';
+import {SsoRequiredError} from '@fluxer/errors/src/domains/auth/SsoRequiredError';
 import type {
 	DisableTotpRequest,
 	EnableMfaTotpRequest,
@@ -24,6 +25,7 @@ import * as AuthPhone from '../../auth/AuthPhone';
 import {requireEmailVerified} from '../../auth/EmailVerificationUtils';
 import type {SudoVerificationResult} from '../../auth/services/SudoVerificationService';
 import type {IGuildRepositoryAggregate} from '../../guild/repositories/IGuildRepositoryAggregate';
+import {getInstanceConfigRepository} from '../../middleware/ServiceSingletons';
 import type {User} from '../../models/User';
 import type {IUserRepository} from '../IUserRepository';
 import * as UserAuth from './UserAuth';
@@ -62,6 +64,15 @@ export class UserAuthRequestService {
 		private guildRepository: IGuildRepositoryAggregate,
 	) {}
 
+	private async assertCanAddCredentials(user: User): Promise<void> {
+		if (user.traits.has('sso')) {
+			const ssoConfig = await getInstanceConfigRepository().getSsoConfig();
+			if ((ssoConfig.enabled && ssoConfig.enforced) || ssoConfig.disableAdditionalAuth) {
+				throw new SsoRequiredError();
+			}
+		}
+	}
+
 	private async assertPhoneEligible(user: User): Promise<void> {
 		if (user.hasVerifiedPhone) {
 			return;
@@ -87,6 +98,7 @@ export class UserAuthRequestService {
 		data,
 		sudoContext,
 	}: UserAuthWithSudoRequest<EnableMfaTotpRequest>): Promise<MfaBackupCodesResponse> {
+		await this.assertCanAddCredentials(user);
 		requireEmailVerified(user, 'mfa');
 		const backupCodes = await UserAuth.enableMfaTotp(this.apiContext, {
 			user,
@@ -176,12 +188,14 @@ export class UserAuthRequestService {
 	}
 
 	async generateWebAuthnRegistrationOptions(user: User): Promise<WebAuthnChallengeResponse> {
+		await this.assertCanAddCredentials(user);
 		requireEmailVerified(user, 'mfa');
 		const options = await AuthMfa.generateWebAuthnRegistrationOptions(this.apiContext, user.id);
 		return this.toWebAuthnChallengeResponse(options);
 	}
 
 	async registerWebAuthnCredential({user, data}: UserAuthWebAuthnRegisterRequest): Promise<void> {
+		await this.assertCanAddCredentials(user);
 		requireEmailVerified(user, 'mfa');
 		await AuthMfa.verifyWebAuthnRegistration(this.apiContext, user.id, data.response, data.challenge, data.name);
 	}

--- a/fluxer_app/src/features/app/constants/Endpoints.ts
+++ b/fluxer_app/src/features/app/constants/Endpoints.ts
@@ -34,6 +34,8 @@ export const Endpoints = {
 	},
 	AUTH_SSO_START: '/auth/sso/start',
 	AUTH_SSO_COMPLETE: '/auth/sso/complete',
+	AUTH_SSO_SUDO_START: '/auth/sso/sudo/start',
+	AUTH_SSO_SUDO_COMPLETE: '/auth/sso/sudo/complete',
 	ADMIN_INSTANCE_CONFIG_GET: '/admin/instance-config/get',
 	ADMIN_INSTANCE_CONFIG_UPDATE: '/admin/instance-config/update',
 	ADMIN_INSTANCE_CONFIG_BRANDING_ASSET: '/admin/instance-config/branding-asset',

--- a/fluxer_app/src/features/auth/commands/AuthenticationCommands.ts
+++ b/fluxer_app/src/features/auth/commands/AuthenticationCommands.ts
@@ -19,6 +19,7 @@ import type {
 	SsoCompleteResponse,
 	SsoStartRequest,
 	SsoStartResponse,
+	SsoSudoCompleteResponse,
 } from '@fluxer/schema/src/domains/auth/AuthSchemas';
 import type {UserPartial} from '@fluxer/schema/src/domains/user/UserResponseSchemas';
 import type {AuthenticationResponseJSON, PublicKeyCredentialRequestOptionsJSON} from '@simplewebauthn/browser';
@@ -650,6 +651,32 @@ export async function startSso({
 
 export async function completeSso({code, state}: {code: string; state: string}): Promise<SsoCompleteResponse> {
 	const response = await http.post<SsoCompleteResponse>(Endpoints.AUTH_SSO_COMPLETE, {
+		body: {code, state},
+		headers: withPlatformHeader(),
+	});
+	return response.body;
+}
+
+export async function startSsoSudo({
+	redirectTo,
+	redirectUri,
+}: {
+	redirectTo?: string;
+	redirectUri?: string;
+} = {}): Promise<SsoStartResponse> {
+	const body: SsoStartRequest = {
+		redirect_to: redirectTo,
+		redirect_uri: redirectUri,
+	};
+	const response = await http.post<SsoStartResponse>(Endpoints.AUTH_SSO_SUDO_START, {
+		body,
+		headers: withPlatformHeader(),
+	});
+	return response.body;
+}
+
+export async function completeSsoSudo({code, state}: {code: string; state: string}): Promise<SsoSudoCompleteResponse> {
+	const response = await http.post<SsoSudoCompleteResponse>(Endpoints.AUTH_SSO_SUDO_COMPLETE, {
 		body: {code, state},
 		headers: withPlatformHeader(),
 	});

--- a/fluxer_app/src/features/auth/components/modals/SudoVerificationModal.tsx
+++ b/fluxer_app/src/features/auth/components/modals/SudoVerificationModal.tsx
@@ -3,6 +3,7 @@
 import * as Modal from '@app/features/app/components/dialogs/Modal';
 import {Endpoints} from '@app/features/app/constants/Endpoints';
 import styles from '@app/features/auth/components/modals/SudoVerificationModal.module.css';
+import {SSO_SUDO_COMPLETE_MESSAGE, startSsoSudo} from '@app/features/auth/state/SsoSudoFlow';
 import SudoPrompt, {SudoVerificationMethod} from '@app/features/auth/state/SudoPrompt';
 import * as WebAuthnUtils from '@app/features/auth/utils/WebAuthnUtils';
 import {PASSWORD_DESCRIPTOR, VERIFY_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
@@ -25,6 +26,10 @@ const PASSKEYS_REQUIRE_A_SIGNED_MACOS_BUNDLE_WITH_A_DESCRIPTOR = msg({
 		'Passkeys require a signed macOS bundle with a valid application identifier. Install the signed desktop client and retry.',
 	comment:
 		'Sudo (re-auth) modal body shown on unsigned macOS desktop bundles where passkeys cannot work. Direct the user to install the signed client.',
+});
+const COULDN_T_VERIFY_WITH_SSO_PLEASE_TRY_AGAIN_DESCRIPTOR = msg({
+	message: "Couldn't verify with SSO. Try again.",
+	comment: 'Sudo (re-auth) modal toast error shown when SSO verification fails. Keep plain.',
 });
 const COULDN_T_VERIFY_WITH_PASSKEY_PLEASE_TRY_AGAIN_DESCRIPTOR = msg({
 	message: "Couldn't verify with passkey. Try again.",
@@ -71,15 +76,32 @@ const SudoVerificationModal: React.FC = observer(() => {
 	const form = useForm<FormInputs>({defaultValues: {password: '', totp: ''}});
 	const [webAuthnInFlight, setWebAuthnInFlight] = useState(false);
 	const [webAuthnError, setWebAuthnError] = useState<string | null>(null);
+	const [ssoInFlight, setSsoInFlight] = useState(false);
+	const [ssoError, setSsoError] = useState<string | null>(null);
 	const autoTriggeredRef = useRef(false);
+	const popupTimerRef = useRef<number | null>(null);
+	const messageListenerRef = useRef<((event: MessageEvent) => void) | null>(null);
 	const showPasskey = availableMethods.webauthn;
 	const showTotp = availableMethods.totp;
 	const showPassword = availableMethods.password;
-	const noMethodsAvailable = !showPasskey && !showTotp && !showPassword;
+	const showSso = availableMethods.sso;
+	const noMethodsAvailable = !showPasskey && !showTotp && !showPassword && !showSso;
+	useEffect(() => {
+		return () => {
+			if (popupTimerRef.current) {
+				window.clearInterval(popupTimerRef.current);
+			}
+			if (messageListenerRef.current) {
+				window.removeEventListener('message', messageListenerRef.current);
+			}
+		};
+	}, []);
 	useEffect(() => {
 		form.reset({password: '', totp: ''});
 		setWebAuthnError(null);
 		setWebAuthnInFlight(false);
+		setSsoError(null);
+		setSsoInFlight(false);
 		autoTriggeredRef.current = false;
 	}, [form]);
 	useEffect(() => {
@@ -91,9 +113,74 @@ const SudoVerificationModal: React.FC = observer(() => {
 			form.setError(fallback, {type: 'server', message: verificationError});
 		}
 		setWebAuthnInFlight(false);
+		setSsoInFlight(false);
 	}, [form, verificationError, rawError, i18n, showPassword, showTotp]);
+	const handleSso = async () => {
+		if (ssoInFlight || isVerifying) return;
+		setSsoError(null);
+		form.clearErrors();
+		setSsoInFlight(true);
+		try {
+			const redirectTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+			const result = await startSsoSudo({redirectTo});
+			const popup = window.open(result.authorizationUrl, 'fluxer-sso-sudo', 'popup,width=520,height=720');
+			if (!popup) {
+				window.location.assign(result.authorizationUrl);
+				return;
+			}
+			if (popupTimerRef.current) {
+				window.clearInterval(popupTimerRef.current);
+				popupTimerRef.current = null;
+			}
+			if (messageListenerRef.current) {
+				window.removeEventListener('message', messageListenerRef.current);
+				messageListenerRef.current = null;
+			}
+			const handleMessage = (event: MessageEvent) => {
+				if (event.origin !== window.location.origin) return;
+				const data = event.data as {type?: unknown; state?: unknown; sudoToken?: unknown};
+				if (data.type !== SSO_SUDO_COMPLETE_MESSAGE || data.state !== result.state) return;
+				if (popupTimerRef.current) {
+					window.clearInterval(popupTimerRef.current);
+					popupTimerRef.current = null;
+				}
+				window.removeEventListener('message', handleMessage);
+				messageListenerRef.current = null;
+				if (typeof data.sudoToken !== 'string' || !data.sudoToken) {
+					setSsoInFlight(false);
+					setSsoError(i18n._(COULDN_T_VERIFY_WITH_SSO_PLEASE_TRY_AGAIN_DESCRIPTOR));
+					return;
+				}
+				SudoPrompt.completeWithSsoToken(data.sudoToken);
+			};
+			messageListenerRef.current = handleMessage;
+			window.addEventListener('message', handleMessage);
+			popupTimerRef.current = window.setInterval(() => {
+				if (!popup.closed) return;
+				if (popupTimerRef.current) {
+					window.clearInterval(popupTimerRef.current);
+					popupTimerRef.current = null;
+				}
+				window.removeEventListener('message', handleMessage);
+				messageListenerRef.current = null;
+				setSsoInFlight(false);
+			}, 500);
+		} catch (err) {
+			logger.error('SSO verification failed', err);
+			if (popupTimerRef.current) {
+				window.clearInterval(popupTimerRef.current);
+				popupTimerRef.current = null;
+			}
+			if (messageListenerRef.current) {
+				window.removeEventListener('message', messageListenerRef.current);
+				messageListenerRef.current = null;
+			}
+			setSsoInFlight(false);
+			setSsoError(i18n._(COULDN_T_VERIFY_WITH_SSO_PLEASE_TRY_AGAIN_DESCRIPTOR));
+		}
+	};
 	const handleWebAuthn = async () => {
-		if (webAuthnInFlight || isVerifying) return;
+		if (webAuthnInFlight || isVerifying || ssoInFlight) return;
 		setWebAuthnError(null);
 		form.clearErrors();
 		setWebAuthnInFlight(true);
@@ -118,11 +205,12 @@ const SudoVerificationModal: React.FC = observer(() => {
 	};
 	useEffect(() => {
 		if (autoTriggeredRef.current) return;
+		if (showSso) return;
 		if (!showPasskey || showPassword || showTotp) return;
 		if (lastUsedMfaMethod && lastUsedMfaMethod !== 'webauthn') return;
 		autoTriggeredRef.current = true;
 		void handleWebAuthn();
-	}, [showPasskey, showPassword, showTotp]);
+	}, [showPasskey, showPassword, showTotp, showSso]);
 	const handleClose = () => {
 		SudoPrompt.reject(new DOMException('User cancelled verification', 'AbortError'));
 	};
@@ -204,6 +292,27 @@ const SudoVerificationModal: React.FC = observer(() => {
 									/>
 								)}
 
+								{showSso && (
+									<>
+										<Button
+											type="button"
+											onClick={handleSso}
+											submitting={ssoInFlight}
+											disabled={isVerifying || webAuthnInFlight || ssoInFlight}
+											fitContainer
+											autoFocus
+											data-flx="auth.sudo-verification-modal.button.sso"
+										>
+											<Trans>Continue with SSO</Trans>
+										</Button>
+										{ssoError && (
+											<p className={styles.formError} role="alert" data-flx="auth.sudo-verification-modal.sso-error">
+												{ssoError}
+											</p>
+										)}
+									</>
+								)}
+
 								{showPasskey && (
 									<>
 										{webAuthnInFlight ? (
@@ -266,7 +375,7 @@ const SudoVerificationModal: React.FC = observer(() => {
 						<Button
 							type="submit"
 							submitting={isVerifying}
-							disabled={isVerifying || webAuthnInFlight}
+							disabled={isVerifying || webAuthnInFlight || ssoInFlight}
 							data-flx="auth.sudo-verification-modal.button.submit"
 						>
 							{i18n._(VERIFY_DESCRIPTOR)}

--- a/fluxer_app/src/features/auth/components/pages/SsoCallbackPage.tsx
+++ b/fluxer_app/src/features/auth/components/pages/SsoCallbackPage.tsx
@@ -8,6 +8,13 @@ import {
 	getPendingSsoRedirectTo,
 	startSsoLogin,
 } from '@app/features/auth/state/AuthFlow';
+import {
+	clearPendingSsoSudoState,
+	completeSsoSudo,
+	getPendingSsoSudoState,
+	SSO_SUDO_COMPLETE_MESSAGE,
+	startSsoSudo,
+} from '@app/features/auth/state/SsoSudoFlow';
 import {safeRedirectTarget} from '@app/features/auth/utils/SafeRedirect';
 import {BACK_TO_SIGN_IN_DESCRIPTOR, TRY_AGAIN_DESCRIPTOR} from '@app/features/i18n/utils/CommonMessageDescriptors';
 import * as RouterUtils from '@app/features/navigation/utils/RouterUtils';
@@ -40,6 +47,16 @@ const SsoCallbackPage = observer(function SsoCallbackPage() {
 	const [error, setError] = useState<string | null>(null);
 	const [isProcessing, setIsProcessing] = useState(true);
 	const abortControllerRef = useRef<AbortController | null>(null);
+	const isSudoRef = useRef(false);
+	const originalStateRef = useRef<string | null>(null);
+	if (state) {
+		const parentState = window.localStorage.getItem(`fluxer:sso:sudo:parent:${state}`);
+		const resolvedState = parentState || state;
+		if (getPendingSsoSudoState(state) || parentState) {
+			isSudoRef.current = true;
+			originalStateRef.current = resolvedState;
+		}
+	}
 	const handleBackToLogin = useCallback(() => {
 		RouterUtils.replaceWith('/login');
 	}, []);
@@ -47,8 +64,16 @@ const SsoCallbackPage = observer(function SsoCallbackPage() {
 		setError(null);
 		setIsProcessing(true);
 		try {
-			const {authorizationUrl} = await startSsoLogin({redirectTo: getPendingSsoRedirectTo()});
-			window.location.assign(authorizationUrl);
+			if (isSudoRef.current) {
+				const {authorizationUrl, state: newState} = await startSsoSudo({redirectTo: getPendingSsoRedirectTo()});
+				if (originalStateRef.current) {
+					window.localStorage.setItem(`fluxer:sso:sudo:parent:${newState}`, originalStateRef.current);
+				}
+				window.location.assign(authorizationUrl);
+			} else {
+				const {authorizationUrl} = await startSsoLogin({redirectTo: getPendingSsoRedirectTo()});
+				window.location.assign(authorizationUrl);
+			}
 		} catch {
 			RouterUtils.replaceWith('/login');
 		}
@@ -75,6 +100,28 @@ const SsoCallbackPage = observer(function SsoCallbackPage() {
 				return;
 			}
 			try {
+				const parentState = state ? window.localStorage.getItem(`fluxer:sso:sudo:parent:${state}`) : null;
+				const pendingSudo = getPendingSsoSudoState(state);
+				if (pendingSudo || parentState) {
+					const result = await completeSsoSudo({code, state});
+					if (controller.signal.aborted) return;
+					const resolvedParentState = parentState || state;
+					if (parentState) {
+						window.localStorage.removeItem(`fluxer:sso:sudo:parent:${state}`);
+					}
+					window.opener?.postMessage(
+						{type: SSO_SUDO_COMPLETE_MESSAGE, state: resolvedParentState, sudoToken: result.sudoToken},
+						window.location.origin,
+					);
+					if (window.opener && !window.opener.closed) {
+						window.close();
+						return;
+					}
+					const redirectTo = safeRedirectTarget(pendingSudo?.redirectTo) ?? '/';
+					clearPendingSsoSudoState(state);
+					RouterUtils.replaceWith(redirectTo);
+					return;
+				}
 				const result = await completeSsoLogin({code, state});
 				if (controller.signal.aborted) return;
 				await AuthenticationCommands.completeLogin(result);
@@ -116,14 +163,25 @@ const SsoCallbackPage = observer(function SsoCallbackPage() {
 					>
 						{i18n._(TRY_AGAIN_DESCRIPTOR)}
 					</button>
-					<button
-						type="button"
-						onClick={handleBackToLogin}
-						className={styles.ssoBackButton}
-						data-flx="auth.sso-callback-page.sso-back-button.back-to-login"
-					>
-						{i18n._(BACK_TO_SIGN_IN_DESCRIPTOR)}
-					</button>
+					{isSudoRef.current ? (
+						<button
+							type="button"
+							onClick={() => window.close()}
+							className={styles.ssoBackButton}
+							data-flx="auth.sso-callback-page.sso-back-button.close"
+						>
+							<Trans>Cancel</Trans>
+						</button>
+					) : (
+						<button
+							type="button"
+							onClick={handleBackToLogin}
+							className={styles.ssoBackButton}
+							data-flx="auth.sso-callback-page.sso-back-button.back-to-login"
+						>
+							{i18n._(BACK_TO_SIGN_IN_DESCRIPTOR)}
+						</button>
+					)}
 				</div>
 			</div>
 		);

--- a/fluxer_app/src/features/auth/state/SsoSudoFlow.ts
+++ b/fluxer_app/src/features/auth/state/SsoSudoFlow.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as AuthenticationCommands from '@app/features/auth/commands/AuthenticationCommands';
+import {safeRedirectTarget} from '@app/features/auth/utils/SafeRedirect';
+
+const SSO_SUDO_STATE_STORAGE_PREFIX = 'fluxer:sso:sudo:';
+
+export const SSO_SUDO_COMPLETE_MESSAGE = 'fluxer:sso-sudo-complete';
+
+interface PendingSsoSudoState {
+	redirectTo?: string;
+	createdAt: number;
+}
+
+function sudoStateStorageKey(state: string): string {
+	return `${SSO_SUDO_STATE_STORAGE_PREFIX}${state}`;
+}
+
+function storePendingSsoSudoState(state: string, redirectTo?: string): void {
+	try {
+		const payload: PendingSsoSudoState = {createdAt: Date.now()};
+		if (redirectTo) payload.redirectTo = redirectTo;
+		window.localStorage.setItem(sudoStateStorageKey(state), JSON.stringify(payload));
+	} catch {}
+}
+
+export function getPendingSsoSudoState(state: string): PendingSsoSudoState | null {
+	try {
+		const raw = window.localStorage.getItem(sudoStateStorageKey(state));
+		if (!raw) return null;
+		const parsed: unknown = JSON.parse(raw);
+		if (!parsed || typeof parsed !== 'object') return null;
+		const record = parsed as Record<string, unknown>;
+		return {
+			redirectTo: typeof record.redirectTo === 'string' ? record.redirectTo : undefined,
+			createdAt: typeof record.createdAt === 'number' ? record.createdAt : 0,
+		};
+	} catch {
+		return null;
+	}
+}
+
+export function clearPendingSsoSudoState(state: string): void {
+	try {
+		window.localStorage.removeItem(sudoStateStorageKey(state));
+	} catch {}
+}
+
+export async function startSsoSudo({
+	redirectTo,
+	redirectUri,
+}: {
+	redirectTo?: string;
+	redirectUri?: string;
+} = {}): Promise<{
+	authorizationUrl: string;
+	redirectUri: string;
+	state: string;
+}> {
+	const safeRedirectTo = safeRedirectTarget(redirectTo);
+	const result = await AuthenticationCommands.startSsoSudo({
+		redirectTo: safeRedirectTo ?? undefined,
+		redirectUri,
+	});
+	storePendingSsoSudoState(result.state, safeRedirectTo ?? undefined);
+	return {authorizationUrl: result.authorization_url, redirectUri: result.redirect_uri, state: result.state};
+}
+
+export async function completeSsoSudo({code, state}: {code: string; state: string}): Promise<{sudoToken: string}> {
+	const result = await AuthenticationCommands.completeSsoSudo({code, state});
+	clearPendingSsoSudoState(state);
+	return {sudoToken: result.sudo_token};
+}

--- a/fluxer_app/src/features/auth/state/SudoPrompt.tsx
+++ b/fluxer_app/src/features/auth/state/SudoPrompt.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import RuntimeConfig from '@app/features/app/state/RuntimeConfig';
 import SudoVerificationModal from '@app/features/auth/components/modals/SudoVerificationModal';
 import Sudo from '@app/features/auth/state/AuthSudo';
 import type {SudoVerificationPayload} from '@app/features/auth/types/AuthSudoTypes';
@@ -11,6 +12,7 @@ import * as ModalCommands from '@app/features/ui/commands/ModalCommands';
 import {modal} from '@app/features/ui/commands/ModalCommands';
 import {makeSyncedField} from '@app/features/user/state/SyncedField';
 import Users from '@app/features/user/state/Users';
+import {isSsoManagedUser} from '@app/features/user/utils/AccountSecurityCapabilities';
 import {UserAuthenticatorTypes} from '@fluxer/constants/src/UserConstants';
 import {MfaMethod, SudoPromptStateSchema} from '@fluxer/schema/src/gen/fluxer/user/preferences/v1/preferences_pb';
 import {makeAutoObservable, runInAction} from 'mobx';
@@ -20,6 +22,7 @@ interface SudoErrorPayload {
 	methods?: {
 		totp?: boolean;
 		webauthn?: boolean;
+		sso?: boolean;
 	};
 }
 
@@ -57,6 +60,7 @@ export interface AvailableMethods {
 	password: boolean;
 	totp: boolean;
 	webauthn: boolean;
+	sso: boolean;
 	hasMfa: boolean;
 }
 
@@ -75,6 +79,7 @@ const EMPTY_METHODS: AvailableMethods = {
 	password: false,
 	totp: false,
 	webauthn: false,
+	sso: false,
 	hasMfa: false,
 };
 
@@ -85,10 +90,22 @@ function deriveMethodsFromCurrentUser(): AvailableMethods {
 	const totp = types?.includes(UserAuthenticatorTypes.TOTP) ?? false;
 	const webauthn = types?.includes(UserAuthenticatorTypes.WEBAUTHN) ?? false;
 	const hasMfa = user.mfaEnabled ?? (totp || webauthn);
+	const isSso = isSsoManagedUser(user);
+	const ssoEnforced = RuntimeConfig.sso?.enforced ?? false;
+	const ssoDisableAdditional = RuntimeConfig.sso?.disable_additional_auth ?? false;
+	const ssoRestricted = isSso && (ssoEnforced || ssoDisableAdditional);
+	if (ssoRestricted) {
+		return {
+			...EMPTY_METHODS,
+			sso: true,
+			hasMfa: false,
+		};
+	}
 	return {
 		password: !hasMfa,
 		totp,
 		webauthn,
+		sso: isSso,
 		hasMfa,
 	};
 }
@@ -183,6 +200,14 @@ class SudoPrompt {
 		if (!payload) return;
 		const baseline = deriveMethodsFromCurrentUser();
 		const hasMfa = typeof payload.has_mfa === 'boolean' ? payload.has_mfa : baseline.hasMfa;
+		const isSso = isSsoManagedUser(Users.currentUser!);
+		const ssoEnforced = RuntimeConfig.sso?.enforced ?? false;
+		const ssoDisableAdditional = RuntimeConfig.sso?.disable_additional_auth ?? false;
+		const ssoRestricted = isSso && (ssoEnforced || ssoDisableAdditional);
+		if (ssoRestricted) {
+			this.availableMethods = {...EMPTY_METHODS, sso: true};
+			return;
+		}
 		const methods = payload.methods ?? {};
 		const totp = methods.totp === true || (methods.totp === undefined && baseline.totp);
 		const webauthn = methods.webauthn === true || (methods.webauthn === undefined && baseline.webauthn);
@@ -190,6 +215,7 @@ class SudoPrompt {
 			password: !hasMfa,
 			totp,
 			webauthn,
+			sso: baseline.sso,
 			hasMfa,
 		};
 	}
@@ -231,6 +257,11 @@ class SudoPrompt {
 			this.rejecter = null;
 			resolver(payload);
 		}
+	}
+
+	completeWithSsoToken(token: string): void {
+		Sudo.setToken(token);
+		this.submit({});
 	}
 
 	reject(reason?: unknown): void {

--- a/fluxer_app/src/features/user/components/modals/tabs/account_security_tab/AccountSecuritySections.tsx
+++ b/fluxer_app/src/features/user/components/modals/tabs/account_security_tab/AccountSecuritySections.tsx
@@ -13,12 +13,14 @@ import {LinkedDevicesManagementModal} from '@app/features/user/components/modals
 import type {AccountSettingsManagementSectionId} from '@app/features/user/components/settings_utils/SettingsNavigationGroups';
 import type {User} from '@app/features/user/models/User';
 import type {WebAuthnCredential} from '@app/features/user/state/WebAuthnCredentials';
+import {getAccountSecurityCapabilities} from '@app/features/user/utils/AccountSecurityCapabilities';
 import * as FormUtils from '@app/lib/forms';
 import {msg} from '@lingui/core/macro';
-import {useLingui} from '@lingui/react/macro';
+import {Trans, useLingui} from '@lingui/react/macro';
 import {observer} from 'mobx-react-lite';
 import type React from 'react';
 import {useCallback, useRef, useState} from 'react';
+import styles from './SecurityTab.module.css';
 
 const SIGN_IN_DETAILS_DESCRIPTOR = msg({
 	message: 'Sign-in details',
@@ -53,6 +55,8 @@ interface AccountSecuritySectionsProps {
 export const AccountSecuritySections: React.FC<AccountSecuritySectionsProps> = observer(
 	({user, isClaimed, passkeys, showMaskedEmail, setShowMaskedEmail, targetSection}) => {
 		const {i18n} = useLingui();
+		const capabilities = getAccountSecurityCapabilities(user);
+		const showSignInDetails = isClaimed && (capabilities.canManageLocalEmail || capabilities.canManageLocalPassword);
 		const [authorizedAppsSubmitting, setAuthorizedAppsSubmitting] = useState(false);
 		const authorizedAppsSubmittingRef = useRef(false);
 		const openAuthorizedAppsModal = useCallback(() => {
@@ -91,13 +95,24 @@ export const AccountSecuritySections: React.FC<AccountSecuritySectionsProps> = o
 						title={i18n._(SIGN_IN_DETAILS_DESCRIPTOR)}
 						data-flx="user.account-security-sections.account"
 					>
-						<AccountTabContent
-							user={user}
-							isClaimed={isClaimed}
-							showMaskedEmail={showMaskedEmail}
-							setShowMaskedEmail={setShowMaskedEmail}
-							data-flx="user.account-security-sections.account-tab-content"
-						/>
+						{showSignInDetails ? (
+							<AccountTabContent
+								user={user}
+								isClaimed={isClaimed}
+								showMaskedEmail={showMaskedEmail}
+								setShowMaskedEmail={setShowMaskedEmail}
+								data-flx="user.account-security-sections.account-tab-content"
+							/>
+						) : (
+							<div className={styles.notice} data-flx="user.account-security-sections.notice">
+								<p className={styles.noticeText} data-flx="user.account-security-sections.notice-text">
+									<Trans>
+										This account is managed via Single Sign-On (SSO). Sign-in details and two-factor authentication are
+										managed by your provider.
+									</Trans>
+								</p>
+							</div>
+						)}
 					</SettingsSection>
 				)}
 				{isClaimed && (
@@ -109,6 +124,7 @@ export const AccountSecuritySections: React.FC<AccountSecuritySectionsProps> = o
 					>
 						<SecurityTabContent
 							user={user}
+							capabilities={capabilities}
 							isClaimed={isClaimed}
 							passkeys={passkeys}
 							authorizedAppsSubmitting={authorizedAppsSubmitting}

--- a/fluxer_app/src/features/user/components/modals/tabs/account_security_tab/SecurityTab.module.css
+++ b/fluxer_app/src/features/user/components/modals/tabs/account_security_tab/SecurityTab.module.css
@@ -89,3 +89,18 @@
 .claimButton {
 	align-self: flex-start;
 }
+
+.notice {
+	border: 0.0625rem solid var(--background-modifier-accent);
+	border-radius: 0.375rem;
+	padding: var(--spacing-3);
+	background: var(--background-secondary-alt);
+	margin-bottom: var(--spacing-4);
+}
+
+.noticeText {
+	margin: 0;
+	color: var(--text-primary-muted);
+	font-size: 0.875rem;
+	line-height: 1.35;
+}

--- a/fluxer_app/src/features/user/components/modals/tabs/account_security_tab/SecurityTab.tsx
+++ b/fluxer_app/src/features/user/components/modals/tabs/account_security_tab/SecurityTab.tsx
@@ -20,6 +20,7 @@ import * as UserCommands from '@app/features/user/commands/UserCommands';
 import styles from '@app/features/user/components/modals/tabs/account_security_tab/SecurityTab.module.css';
 import type {User} from '@app/features/user/models/User';
 import type {WebAuthnCredential} from '@app/features/user/state/WebAuthnCredentials';
+import type {AccountSecurityCapabilities} from '@app/features/user/utils/AccountSecurityCapabilities';
 import * as DateUtils from '@app/features/user/utils/DateFormatting';
 import {pushApiErrorModal} from '@app/lib/forms';
 import {UserAuthenticatorTypes} from '@fluxer/constants/src/UserConstants';
@@ -74,6 +75,7 @@ const logger = new Logger('SecurityTab');
 
 interface SecurityTabProps {
 	user: User;
+	capabilities: AccountSecurityCapabilities;
 	isClaimed: boolean;
 	passkeys: ReadonlyArray<WebAuthnCredential>;
 	authorizedAppsSubmitting?: boolean;
@@ -82,7 +84,15 @@ interface SecurityTabProps {
 }
 
 export const SecurityTabContent: React.FC<SecurityTabProps> = observer(
-	({user, isClaimed, passkeys, authorizedAppsSubmitting, onManageAuthorizedApps, onManageLinkedDevices}) => {
+	({
+		user,
+		capabilities,
+		isClaimed,
+		passkeys,
+		authorizedAppsSubmitting,
+		onManageAuthorizedApps,
+		onManageLinkedDevices,
+	}) => {
 		const {i18n} = useLingui();
 		const hasTotpMfa = user.authenticatorTypes?.includes(UserAuthenticatorTypes.TOTP) ?? false;
 		const needsEmailVerification = user.email != null && user.verified === false;
@@ -187,225 +197,232 @@ export const SecurityTabContent: React.FC<SecurityTabProps> = observer(
 		}
 		return (
 			<>
-				<SettingsTabSection
-					title={i18n._(TWO_FACTOR_AUTHENTICATION_DESCRIPTOR)}
-					description={<Trans>Add an extra layer of security to your account</Trans>}
-					data-flx="user.account-security-tab.security-tab.security-tab-content.settings-tab-section--2"
-				>
-					<div className={styles.row} data-flx="user.account-security-tab.security-tab.security-tab-content.row">
-						<div
-							className={styles.rowContent}
-							data-flx="user.account-security-tab.security-tab.security-tab-content.row-content"
-						>
+				{capabilities.canManageLocalTotp && (
+					<SettingsTabSection
+						title={i18n._(TWO_FACTOR_AUTHENTICATION_DESCRIPTOR)}
+						description={<Trans>Add an extra layer of security to your account</Trans>}
+						data-flx="user.account-security-tab.security-tab.security-tab-content.settings-tab-section--2"
+					>
+						<div className={styles.row} data-flx="user.account-security-tab.security-tab.security-tab-content.row">
 							<div
-								className={styles.label}
-								data-flx="user.account-security-tab.security-tab.security-tab-content.label"
+								className={styles.rowContent}
+								data-flx="user.account-security-tab.security-tab.security-tab-content.row-content"
 							>
-								<Trans>Authenticator app</Trans>
-							</div>
-							<div
-								className={styles.description}
-								data-flx="user.account-security-tab.security-tab.security-tab-content.description"
-							>
-								{hasTotpMfa ? (
-									<Trans>Two-factor authentication is enabled</Trans>
-								) : (
-									<Trans>Use an authenticator app to generate codes for two-factor authentication</Trans>
+								<div
+									className={styles.label}
+									data-flx="user.account-security-tab.security-tab.security-tab-content.label"
+								>
+									<Trans>Authenticator app</Trans>
+								</div>
+								<div
+									className={styles.description}
+									data-flx="user.account-security-tab.security-tab.security-tab-content.description"
+								>
+									{hasTotpMfa ? (
+										<Trans>Two-factor authentication is enabled</Trans>
+									) : (
+										<Trans>Use an authenticator app to generate codes for two-factor authentication</Trans>
+									)}
+								</div>
+								{needsEmailVerification && !hasTotpMfa && (
+									<div
+										className={styles.warningText}
+										data-flx="user.account-security-tab.security-tab.security-tab-content.warning-text"
+									>
+										{i18n._(VERIFY_EMAIL_BEFORE_AUTHENTICATOR_APP_DESCRIPTOR)}
+									</div>
 								)}
 							</div>
-							{needsEmailVerification && !hasTotpMfa && (
-								<div
-									className={styles.warningText}
-									data-flx="user.account-security-tab.security-tab.security-tab-content.warning-text"
-								>
-									{i18n._(VERIFY_EMAIL_BEFORE_AUTHENTICATOR_APP_DESCRIPTOR)}
-								</div>
-							)}
-						</div>
-						{hasTotpMfa ? (
-							<Button
-								variant="danger"
-								small={true}
-								onClick={() =>
-									ModalCommands.push(
-										modal(() => (
-											<MfaTotpDisableModal data-flx="user.account-security-tab.security-tab.security-tab-content.mfa-totp-disable-modal" />
-										)),
-									)
-								}
-								data-flx="user.account-security-tab.security-tab.security-tab-content.button.push"
-							>
-								<Trans>Disable</Trans>
-							</Button>
-						) : (
-							<Button
-								small={true}
-								disabled={!canAddSecurityCredential}
-								onClick={() =>
-									ModalCommands.push(
-										modal(() => (
-											<MfaTotpEnableModal
-												user={user}
-												data-flx="user.account-security-tab.security-tab.security-tab-content.mfa-totp-enable-modal"
-											/>
-										)),
-									)
-								}
-								data-flx="user.account-security-tab.security-tab.security-tab-content.button.push--2"
-							>
-								<Trans>Enable</Trans>
-							</Button>
-						)}
-					</div>
-					{hasTotpMfa && (
-						<div
-							className={styles.divider}
-							data-flx="user.account-security-tab.security-tab.security-tab-content.divider"
-						>
-							<div className={styles.row} data-flx="user.account-security-tab.security-tab.security-tab-content.row--2">
-								<div
-									className={styles.rowContent}
-									data-flx="user.account-security-tab.security-tab.security-tab-content.row-content--2"
-								>
-									<div
-										className={styles.label}
-										data-flx="user.account-security-tab.security-tab.security-tab-content.label--2"
-									>
-										<Trans>Backup codes</Trans>
-									</div>
-									<div
-										className={styles.description}
-										data-flx="user.account-security-tab.security-tab.security-tab-content.description--2"
-									>
-										<Trans>View and manage your backup codes for account recovery</Trans>
-									</div>
-								</div>
+							{hasTotpMfa ? (
 								<Button
-									variant="secondary"
+									variant="danger"
 									small={true}
 									onClick={() =>
 										ModalCommands.push(
 											modal(() => (
-												<BackupCodesViewModal
+												<MfaTotpDisableModal data-flx="user.account-security-tab.security-tab.security-tab-content.mfa-totp-disable-modal" />
+											)),
+										)
+									}
+									data-flx="user.account-security-tab.security-tab.security-tab-content.button.push"
+								>
+									<Trans>Disable</Trans>
+								</Button>
+							) : (
+								<Button
+									small={true}
+									disabled={!canAddSecurityCredential}
+									onClick={() =>
+										ModalCommands.push(
+											modal(() => (
+												<MfaTotpEnableModal
 													user={user}
-													data-flx="user.account-security-tab.security-tab.security-tab-content.backup-codes-view-modal"
+													data-flx="user.account-security-tab.security-tab.security-tab-content.mfa-totp-enable-modal"
 												/>
 											)),
 										)
 									}
-									data-flx="user.account-security-tab.security-tab.security-tab-content.button.push--3"
+									data-flx="user.account-security-tab.security-tab.security-tab-content.button.push--2"
 								>
-									<Trans>View codes</Trans>
+									<Trans>Enable</Trans>
 								</Button>
-							</div>
-						</div>
-					)}
-				</SettingsTabSection>
-				<SettingsTabSection
-					title={<Trans>Passkeys</Trans>}
-					description={<Trans>Use passkeys for passwordless sign-in and two-factor authentication</Trans>}
-					data-flx="user.account-security-tab.security-tab.security-tab-content.settings-tab-section--3"
-				>
-					<div className={styles.row} data-flx="user.account-security-tab.security-tab.security-tab-content.row--3">
-						<div
-							className={styles.rowContent}
-							data-flx="user.account-security-tab.security-tab.security-tab-content.row-content--3"
-						>
-							<div
-								className={styles.label}
-								data-flx="user.account-security-tab.security-tab.security-tab-content.label--3"
-							>
-								<Trans>Registered passkeys</Trans>
-							</div>
-							{needsEmailVerification && (
-								<div
-									className={styles.warningText}
-									data-flx="user.account-security-tab.security-tab.security-tab-content.warning-text--2"
-								>
-									{i18n._(VERIFY_EMAIL_BEFORE_PASSKEY_DESCRIPTOR)}
-								</div>
 							)}
 						</div>
-						<Button
-							small={true}
-							disabled={!canAddPasskey}
-							onClick={handleAddPasskey}
-							data-flx="user.account-security-tab.security-tab.security-tab-content.button.add-passkey"
-						>
-							<Trans>Add passkey</Trans>
-						</Button>
-					</div>
-					{passkeys.length > 0 && (
-						<div
-							className={styles.divider}
-							data-flx="user.account-security-tab.security-tab.security-tab-content.divider--2"
-						>
+						{hasTotpMfa && (
 							<div
-								className={styles.passkeyList}
-								data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-list"
+								className={styles.divider}
+								data-flx="user.account-security-tab.security-tab.security-tab-content.divider"
 							>
-								{passkeys.map((passkey) => {
-									const createdDate = DateUtils.getRelativeDateString(new Date(passkey.created_at), i18n);
-									const lastUsedDate = passkey.last_used_at
-										? DateUtils.getRelativeDateString(new Date(passkey.last_used_at), i18n)
-										: null;
-									return (
+								<div
+									className={styles.row}
+									data-flx="user.account-security-tab.security-tab.security-tab-content.row--2"
+								>
+									<div
+										className={styles.rowContent}
+										data-flx="user.account-security-tab.security-tab.security-tab-content.row-content--2"
+									>
 										<div
-											key={passkey.id}
-											className={styles.passkeyItem}
-											data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-item"
+											className={styles.label}
+											data-flx="user.account-security-tab.security-tab.security-tab-content.label--2"
 										>
-											<div
-												className={styles.passkeyInfo}
-												data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-info"
-											>
-												<div
-													className={styles.passkeyName}
-													data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-name"
-												>
-													{passkey.name}
-												</div>
-												<div
-													className={styles.passkeyDetails}
-													data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-details"
-												>
-													{lastUsedDate ? (
-														<Trans>
-															Added: {createdDate} • last used: {lastUsedDate}
-														</Trans>
-													) : (
-														<Trans>Added: {createdDate}</Trans>
-													)}
-												</div>
-											</div>
-											<div
-												className={styles.passkeyActions}
-												data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-actions"
-											>
-												<Button
-													variant="secondary"
-													small={true}
-													onClick={() => handleRenamePasskey(passkey.id)}
-													data-flx="user.account-security-tab.security-tab.security-tab-content.button.rename-passkey"
-												>
-													<Trans>Rename</Trans>
-												</Button>
-												<Button
-													variant="danger"
-													small={true}
-													onClick={() => handleDeletePasskey(passkey.id)}
-													data-flx="user.account-security-tab.security-tab.security-tab-content.button.delete-passkey"
-												>
-													<Trans>Delete</Trans>
-												</Button>
-											</div>
+											<Trans>Backup codes</Trans>
 										</div>
-									);
-								})}
+										<div
+											className={styles.description}
+											data-flx="user.account-security-tab.security-tab.security-tab-content.description--2"
+										>
+											<Trans>View and manage your backup codes for account recovery</Trans>
+										</div>
+									</div>
+									<Button
+										variant="secondary"
+										small={true}
+										onClick={() =>
+											ModalCommands.push(
+												modal(() => (
+													<BackupCodesViewModal
+														user={user}
+														data-flx="user.account-security-tab.security-tab.security-tab-content.backup-codes-view-modal"
+													/>
+												)),
+											)
+										}
+										data-flx="user.account-security-tab.security-tab.security-tab-content.button.push--3"
+									>
+										<Trans>View codes</Trans>
+									</Button>
+								</div>
 							</div>
+						)}
+					</SettingsTabSection>
+				)}
+				{capabilities.canManageLocalPasskeys && (
+					<SettingsTabSection
+						title={<Trans>Passkeys</Trans>}
+						description={<Trans>Use passkeys for passwordless sign-in and two-factor authentication</Trans>}
+						data-flx="user.account-security-tab.security-tab.security-tab-content.settings-tab-section--3"
+					>
+						<div className={styles.row} data-flx="user.account-security-tab.security-tab.security-tab-content.row--3">
+							<div
+								className={styles.rowContent}
+								data-flx="user.account-security-tab.security-tab.security-tab-content.row-content--3"
+							>
+								<div
+									className={styles.label}
+									data-flx="user.account-security-tab.security-tab.security-tab-content.label--3"
+								>
+									<Trans>Registered passkeys</Trans>
+								</div>
+								{needsEmailVerification && (
+									<div
+										className={styles.warningText}
+										data-flx="user.account-security-tab.security-tab.security-tab-content.warning-text--2"
+									>
+										{i18n._(VERIFY_EMAIL_BEFORE_PASSKEY_DESCRIPTOR)}
+									</div>
+								)}
+							</div>
+							<Button
+								small={true}
+								disabled={!canAddPasskey}
+								onClick={handleAddPasskey}
+								data-flx="user.account-security-tab.security-tab.security-tab-content.button.add-passkey"
+							>
+								<Trans>Add passkey</Trans>
+							</Button>
 						</div>
-					)}
-				</SettingsTabSection>
+						{passkeys.length > 0 && (
+							<div
+								className={styles.divider}
+								data-flx="user.account-security-tab.security-tab.security-tab-content.divider--2"
+							>
+								<div
+									className={styles.passkeyList}
+									data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-list"
+								>
+									{passkeys.map((passkey) => {
+										const createdDate = DateUtils.getRelativeDateString(new Date(passkey.created_at), i18n);
+										const lastUsedDate = passkey.last_used_at
+											? DateUtils.getRelativeDateString(new Date(passkey.last_used_at), i18n)
+											: null;
+										return (
+											<div
+												key={passkey.id}
+												className={styles.passkeyItem}
+												data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-item"
+											>
+												<div
+													className={styles.passkeyInfo}
+													data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-info"
+												>
+													<div
+														className={styles.passkeyName}
+														data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-name"
+													>
+														{passkey.name}
+													</div>
+													<div
+														className={styles.passkeyDetails}
+														data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-details"
+													>
+														{lastUsedDate ? (
+															<Trans>
+																Added: {createdDate} • last used: {lastUsedDate}
+															</Trans>
+														) : (
+															<Trans>Added: {createdDate}</Trans>
+														)}
+													</div>
+												</div>
+												<div
+													className={styles.passkeyActions}
+													data-flx="user.account-security-tab.security-tab.security-tab-content.passkey-actions"
+												>
+													<Button
+														variant="secondary"
+														small={true}
+														onClick={() => handleRenamePasskey(passkey.id)}
+														data-flx="user.account-security-tab.security-tab.security-tab-content.button.rename-passkey"
+													>
+														<Trans>Rename</Trans>
+													</Button>
+													<Button
+														variant="danger"
+														small={true}
+														onClick={() => handleDeletePasskey(passkey.id)}
+														data-flx="user.account-security-tab.security-tab.security-tab-content.button.delete-passkey"
+													>
+														<Trans>Delete</Trans>
+													</Button>
+												</div>
+											</div>
+										);
+									})}
+								</div>
+							</div>
+						)}
+					</SettingsTabSection>
+				)}
 				{(onManageAuthorizedApps || onManageLinkedDevices) && (
 					<SettingsTabSection
 						title={i18n._(ACCOUNT_ACCESS_DESCRIPTOR)}

--- a/fluxer_app/src/features/user/utils/AccountSecurityCapabilities.test.ts
+++ b/fluxer_app/src/features/user/utils/AccountSecurityCapabilities.test.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {beforeEach, describe, expect, it} from 'vitest';
+
+// Define the global window bootstrap mock before importing RuntimeConfig transitively
+if (typeof window === 'undefined') {
+	global.window = {} as any;
+}
+(window as any).__FLUXER_BOOTSTRAP__ = {
+	instance: {
+		api_code_version: 1,
+		endpoints: {
+			gateway: 'http://gateway',
+			media: 'http://media',
+			static_cdn: 'http://cdn',
+			marketing: 'http://marketing',
+			admin: 'http://admin',
+			invite: 'http://invite',
+			gift: 'http://gift',
+			webapp: 'http://webapp',
+			api: 'http://api',
+		},
+		captcha: {
+			provider: 'none',
+			hcaptcha_site_key: null,
+			turnstile_site_key: null,
+		},
+		features: {},
+		gif: {
+			provider: 'none',
+			display_name: 'none',
+			attribution_required: false,
+		},
+		sso: {
+			enabled: false,
+			enforced: false,
+			disable_additional_auth: false,
+			display_name: null,
+			redirect_uri: '',
+		},
+		registration: {
+			mode: 'open',
+			admin_registration_urls_enabled: true,
+		},
+		community: {
+			single_community: false,
+			single_community_guild_id: null,
+			direct_messages_disabled: false,
+		},
+		services: {
+			gif_enabled: false,
+			youtube_enabled: false,
+			bluesky_enabled: false,
+			emails_enabled: false,
+		},
+		limits: {},
+		push: {
+			public_vapid_key: null,
+		},
+		app_public: {
+			setup: {
+				configured: true,
+			},
+			branding: {
+				product_name: 'Fluxer',
+			},
+		},
+	},
+};
+
+const {getAccountSecurityCapabilities, isSsoManagedUser} = await import('./AccountSecurityCapabilities');
+const {default: RuntimeConfig} = await import('@app/features/app/state/RuntimeConfig');
+
+const userWithTraits = (traits: ReadonlyArray<string>) => ({traits});
+
+describe('account security capabilities', () => {
+	beforeEach(() => {
+		RuntimeConfig.sso = null;
+	});
+
+	it('treats users with the sso trait as SSO-managed', () => {
+		expect(isSsoManagedUser(userWithTraits(['sso']))).toBe(true);
+		expect(isSsoManagedUser(userWithTraits(['sso:provider']))).toBe(false);
+	});
+
+	it('disables local sign-in and MFA management for SSO-managed users when SSO is enforced', () => {
+		RuntimeConfig.sso = {
+			enabled: true,
+			enforced: true,
+			disable_additional_auth: false,
+			display_name: 'Test SSO',
+			redirect_uri: 'http://test',
+		};
+		expect(getAccountSecurityCapabilities(userWithTraits(['sso']))).toEqual({
+			canManageLocalEmail: false,
+			canManageLocalPassword: false,
+			canManageLocalTotp: false,
+			canManageLocalPasskeys: false,
+		});
+	});
+
+	it('disables local sign-in and MFA management for SSO-managed users when disable_additional_auth is true', () => {
+		RuntimeConfig.sso = {
+			enabled: true,
+			enforced: false,
+			disable_additional_auth: true,
+			display_name: 'Test SSO',
+			redirect_uri: 'http://test',
+		};
+		expect(getAccountSecurityCapabilities(userWithTraits(['sso']))).toEqual({
+			canManageLocalEmail: false,
+			canManageLocalPassword: false,
+			canManageLocalTotp: false,
+			canManageLocalPasskeys: false,
+		});
+	});
+
+	it('allows local sign-in and MFA management for SSO-managed users when SSO is not enforced and disable_additional_auth is false', () => {
+		RuntimeConfig.sso = {
+			enabled: true,
+			enforced: false,
+			disable_additional_auth: false,
+			display_name: 'Test SSO',
+			redirect_uri: 'http://test',
+		};
+		expect(getAccountSecurityCapabilities(userWithTraits(['sso']))).toEqual({
+			canManageLocalEmail: true,
+			canManageLocalPassword: true,
+			canManageLocalTotp: true,
+			canManageLocalPasskeys: true,
+		});
+	});
+
+	it('keeps local sign-in and MFA management available for non-SSO users in all cases', () => {
+		RuntimeConfig.sso = {
+			enabled: true,
+			enforced: true,
+			disable_additional_auth: true,
+			display_name: 'Test SSO',
+			redirect_uri: 'http://test',
+		};
+		expect(getAccountSecurityCapabilities(userWithTraits([]))).toEqual({
+			canManageLocalEmail: true,
+			canManageLocalPassword: true,
+			canManageLocalTotp: true,
+			canManageLocalPasskeys: true,
+		});
+	});
+});

--- a/fluxer_app/src/features/user/utils/AccountSecurityCapabilities.ts
+++ b/fluxer_app/src/features/user/utils/AccountSecurityCapabilities.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import RuntimeConfig from '@app/features/app/state/RuntimeConfig';
+
+interface TraitBearingUser {
+	traits: ReadonlyArray<string>;
+}
+
+export interface AccountSecurityCapabilities {
+	canManageLocalEmail: boolean;
+	canManageLocalPassword: boolean;
+	canManageLocalTotp: boolean;
+	canManageLocalPasskeys: boolean;
+}
+
+export function isSsoManagedUser(user: TraitBearingUser): boolean {
+	return user.traits.includes('sso');
+}
+
+export function getAccountSecurityCapabilities(user: TraitBearingUser): AccountSecurityCapabilities {
+	const isSso = isSsoManagedUser(user);
+	const ssoEnforced = RuntimeConfig.sso?.enforced ?? false;
+	const ssoDisableAdditional = RuntimeConfig.sso?.disable_additional_auth ?? false;
+	const canManageLocalAuth = !isSso || (!ssoEnforced && !ssoDisableAdditional);
+	return {
+		canManageLocalEmail: canManageLocalAuth,
+		canManageLocalPassword: canManageLocalAuth,
+		canManageLocalTotp: canManageLocalAuth,
+		canManageLocalPasskeys: canManageLocalAuth,
+	};
+}

--- a/packages/errors/src/domains/auth/SudoModeRequiredError.ts
+++ b/packages/errors/src/domains/auth/SudoModeRequiredError.ts
@@ -6,6 +6,7 @@ import {ForbiddenError} from '@fluxer/errors/src/domains/core/ForbiddenError';
 export interface SudoModeMethods {
 	totp: boolean;
 	webauthn: boolean;
+	sso?: boolean;
 }
 
 const EMPTY_METHODS: SudoModeMethods = {totp: false, webauthn: false};

--- a/packages/instance_bootstrap/src/Types.ts
+++ b/packages/instance_bootstrap/src/Types.ts
@@ -39,6 +39,7 @@ export interface InstanceGif {
 export interface InstanceSso {
 	enabled: boolean;
 	enforced: boolean;
+	disable_additional_auth: boolean;
 	display_name: string | null;
 	redirect_uri: string;
 }

--- a/packages/schema/src/domains/admin/AdminSchemas.ts
+++ b/packages/schema/src/domains/admin/AdminSchemas.ts
@@ -393,6 +393,7 @@ export type GenerateGiftCodesRequest = z.infer<typeof GenerateGiftCodesRequest>;
 const SsoConfigResponse = z.object({
 	enabled: z.boolean(),
 	enforced: z.boolean(),
+	disable_additional_auth: z.boolean(),
 	display_name: z.string().nullable(),
 	issuer: z.string().nullable(),
 	authorization_url: z.string().nullable(),
@@ -629,6 +630,7 @@ export const InstanceConfigUpdateRequest = z.object({
 		.object({
 			enabled: z.boolean().optional(),
 			enforced: z.boolean().optional(),
+			disable_additional_auth: z.boolean().optional(),
 			display_name: z.string().nullish(),
 			issuer: z.string().nullish(),
 			authorization_url: z.string().nullish(),

--- a/packages/schema/src/domains/auth/AuthSchemas.ts
+++ b/packages/schema/src/domains/auth/AuthSchemas.ts
@@ -126,6 +126,9 @@ export const SudoVerificationSchema = z.object({
 export const SsoStatusResponse = z.object({
 	enabled: z.boolean().describe('Whether SSO is enabled for this instance'),
 	enforced: z.boolean().describe('Whether SSO is required for all users'),
+	disable_additional_auth: z
+		.boolean()
+		.describe('Whether SSO-managed accounts are prevented from adding or using local authentication methods'),
 	display_name: z.string().nullable().describe('Display name of the SSO provider'),
 	redirect_uri: z.string().describe('OAuth redirect URI for SSO'),
 });
@@ -148,6 +151,12 @@ export const SsoCompleteResponse = z.object({
 });
 
 export type SsoCompleteResponse = z.infer<typeof SsoCompleteResponse>;
+
+export const SsoSudoCompleteResponse = z.object({
+	sudo_token: z.string().describe('Short-lived sudo token issued after SSO reauthentication'),
+});
+
+export type SsoSudoCompleteResponse = z.infer<typeof SsoSudoCompleteResponse>;
 
 export const AuthTokenWithUserIdResponse = z.object({
 	token: z.string().describe('Authentication token for API requests'),


### PR DESCRIPTION
## Summary

- What changed:
  - Added sso-backed sudo verification for sso-managed users.
  - Added API routes to start/complete sso sudo reauth and issue the sudo token.
  - Wired the frontend sudo prompt to offer sso for users with the `sso` trait.
  - Hid local email/password/totp/passkey management for sso-managed users.
  - Added regression coverage for sso sudo and account security capability gating.
- Why it is correct:
  - sso sudo validates that the callback state was created for the current user and that the provider identity resolves to the same account before issuing a sudo token.
  - Existing sudo retry behavior is reused by storing the issued sudo token in the normal sudo token path.
  - Local auth management controls are gated from the exact `sso` trait, matching how sso-managed accounts are marked.
- Risk:
  - Medium: touches auth, sudo-mode, and account security UI.

Fixes #1254, fixes #1267

## Verification

- Tests run:
  - `fluxer_api`: `SsoFlow.test.ts` passed (39/39).
  - `fluxer_api`: Core authentication, password resets/changes, and sudo modes
  (`AuthSudoPasswordVerification.test.ts`, `AuthSudoRequiredOperations.test.ts`,
  `AuthSudoTOTPVerification.test.ts`, `PasswordChange.test.ts`, `PasswordReset.test.ts`,
  `SudoModeNegativeCases.test.ts`, `PasswordChangeFlow.test.ts`) passed (51/51).
  - `fluxer_app`: `AccountSecurityCapabilities.test.ts` passed (5/5).
  - `fluxer_api typecheck` passed.
  - `biome check` on touched files passed.
- Manual checks:
  - Verified sso sudo re-authentication behavior across success, failure/error, and retry states.
  - Verified that non sso accounts remain completely unaffected by global SSO enforcement.
  - Verified sudo on sso-made accounts with other auth methods (totp & passkeys), allowing for SSO and local verification options.
  - Verified checkbox functionality in admin dashboard
- Screenshots or recordings:
<img width="433" height="242" alt="image" src="https://github.com/user-attachments/assets/32376fda-a97f-417d-8574-ca18a315eca9" />
<img width="437" height="382" alt="image" src="https://github.com/user-attachments/assets/a84441d8-5a86-4f8d-b258-0695911deccb" />
<img width="1095" height="186" alt="image" src="https://github.com/user-attachments/assets/06c7c722-e6b6-48eb-ba6f-84e3866415f0" />
<img width="1047" height="162" alt="image" src="https://github.com/user-attachments/assets/59146200-84b6-4c43-845c-6b7fa0dcefc3" />
<img width="880" height="497" alt="image" src="https://github.com/user-attachments/assets/5d316fba-d22d-4c59-9b81-7d691cf2bc42" />


## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure
Codex and Antigravity assisted with the sso sudo implementation, bug-fixing and targeting test runs. I reviewed the resulting files, edited them as needed and performed manual verification before submitting.

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
