### PR TITLE
fix: reset password link expired warning

### DIFF
--- a/fluxer_app/src/features/auth/components/pages/ResetPasswordPage.tsx
+++ b/fluxer_app/src/features/auth/components/pages/ResetPasswordPage.tsx
@@ -111,7 +111,7 @@ const ResetPasswordPage = observer(function ResetPasswordPage() {
 					<Trans>Reset link invalid or expired</Trans>
 				</h1>
 				<p className={styles.description} data-flx="auth.reset-password-page.description">
-					<Trans>This reset link has expired. Reset links last 24 hours. Request a new one.</Trans>
+					<Trans>This reset link has expired. Reset links last 1 hour. Please request a new one.</Trans>
 				</p>
 				<div className={styles.footer} data-flx="auth.reset-password-page.footer">
 					<AuthRouterLink to="/forgot" className={styles.link} data-flx="auth.reset-password-page.link">


### PR DESCRIPTION
## Summary

- What changed: Password reset page warning to reflect the token expiration of 1 hour instead of 24 hours.
- Why it is correct: Message on page now matches the generated password reset email.
- Risk: None

## Verification

- Tests run: None
- Manual checks: Password reset page renders new expiry warning of 1 hour based on `auth/TokenRepository.ts` TTL
- Screenshots or recordings:
<img width="881" height="488" alt="Screenshot 2026-07-07 at 8 29 16 AM" src="https://github.com/user-attachments/assets/48fd88ba-d636-47ea-baad-9237e2cd009e" />
<img width="541" height="136" alt="Screenshot 2026-07-07 at 8 30 14 AM" src="https://github.com/user-attachments/assets/02fb7d8b-d152-4c2c-994e-8598efce10e0" />



## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
