### PR TITLE
feat(app): Add new splash quote

### DIFF
--- a/fluxer_app/src/media/data/SplashQuotes.ts
+++ b/fluxer_app/src/media/data/SplashQuotes.ts
@@ -79,6 +79,7 @@ export function useSplashQuotes(): ReadonlyArray<SplashQuote> {
 			{text: 'Heating up the engine.', source: 'Ray'},
 			{text: 'Pong!', source: 'Cookie'},
 			{text: "Every day I'm fluxin' it.", source: 'Liminalis'},
+			{text: 'MILFS (Man I Love Fluxer)', source: 'Miicat_47'},
 			{text: 'I am the word', source: 'Bird'},
 		];
 		quotes.push({


### PR DESCRIPTION
## Summary

- What changed: Added one new splash quote to the quote rotation.
- Why it is correct: The quote follows the existing `SplashQuote` format with `text` and `source`.
- Risk: Low; this only adds one new static quote entry.

## Verification

- Tests run: Not run
- Manual checks: None
- Screenshots or recordings: None.

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
