### PR TITLE
fix(GitHubPullRequestTransformer): use `sender`

### DIFF
--- a/fluxer_api/src/api/webhook/tests/GitHubPullRequestTransformer.test.ts
+++ b/fluxer_api/src/api/webhook/tests/GitHubPullRequestTransformer.test.ts
@@ -60,8 +60,8 @@ describe('GitHub Pull Request Transformer', () => {
 			expect(result?.url).toBe('https://github.com/org/repo/pull/42');
 			expect(result?.color).toBe(0x098efc);
 			expect(result?.description).toContain('amazing feature');
-			expect(result?.author?.name).toBe('prauthor');
-			expect(result?.author?.url).toBe('https://github.com/prauthor');
+			expect(result?.author?.name).toBe('testuser');
+			expect(result?.author?.url).toBe('https://github.com/testuser');
 		});
 		it('transforms a closed pull request', async () => {
 			const payload: GitHubWebhook = {
@@ -75,6 +75,7 @@ describe('GitHub Pull Request Transformer', () => {
 			expect(result?.title).toContain('Pull request closed');
 			expect(result?.color).toBe(0x000000);
 			expect(result?.description).toBeUndefined();
+			expect(result?.author?.name).toBe('testuser');
 		});
 		it('transforms a reopened pull request', async () => {
 			const payload: GitHubWebhook = {
@@ -87,6 +88,7 @@ describe('GitHub Pull Request Transformer', () => {
 			expect(result).not.toBeNull();
 			expect(result?.title).toContain('Pull request reopened');
 			expect(result?.color).toBe(0xfcbd1f);
+			expect(result?.author?.name).toBe('testuser');
 		});
 		it('returns null for unsupported action types', async () => {
 			const payload: GitHubWebhook = {

--- a/fluxer_api/src/api/webhook/transformers/GitHubPullRequestTransformer.ts
+++ b/fluxer_api/src/api/webhook/transformers/GitHubPullRequestTransformer.ts
@@ -14,9 +14,9 @@ export async function transformPullRequest(body: GitHubWebhook): Promise<RichEmb
 	if (!(body.pull_request && body.action && body.repository)) {
 		return null;
 	}
-	const authorIconUrl = body.pull_request.user.avatar_url;
-	const authorName = body.pull_request.user.login;
-	const authorUrl = body.pull_request.user.html_url;
+	const authorIconUrl = body.sender.avatar_url;
+	const authorName = body.sender.login;
+	const authorUrl = body.sender.html_url;
 	const repoName = body.repository.full_name;
 	const prNumber = body.pull_request.number;
 	const prTitle = body.pull_request.title;


### PR DESCRIPTION
`sender` should be used here. Issues already had this treatment:

https://github.com/fluxerapp/fluxer/blob/fa3e8525755dae087c03ceaf83b814cbe46c7228/fluxer_api/src/api/webhook/transformers/GitHubIssueTransformer.ts#L11-L13

Without using `sender`, pull requests being closed by another actor (for example) will show the author of the pull request instead of the sender.