### PR TITLE
fix(app): channel list doesn't scroll on mobile

### DIFF
--- a/fluxer_app/src/features/app/components/layout/ChannelListContent.module.css
+++ b/fluxer_app/src/features/app/components/layout/ChannelListContent.module.css
@@ -11,6 +11,10 @@
 	min-width: 0;
 }
 
+.channelListScrollerWrapperMobile {
+	max-height: calc(100% - 20px);
+}
+
 .navigationContainer {
 	width: 100%;
 	min-width: 0;

--- a/fluxer_app/src/features/app/components/layout/ChannelListContent.tsx
+++ b/fluxer_app/src/features/app/components/layout/ChannelListContent.tsx
@@ -282,7 +282,7 @@ export const ChannelListContent = observer(({guild, scrollY}: {guild: Guild; scr
 	};
 	return (
 		<div
-			className={styles.channelListScrollerWrapper}
+			className={clsx(styles.channelListScrollerWrapper, isMobile && styles.channelListScrollerWrapperMobile)}
 			data-flx="app.channel-list-content.channel-list-scroller-wrapper"
 		>
 			<Scroller

--- a/fluxer_app/src/features/app/components/layout/GuildNavbar.module.css
+++ b/fluxer_app/src/features/app/components/layout/GuildNavbar.module.css
@@ -17,6 +17,7 @@
 
 .guildNavbarContainerMobile {
 	width: 100%;
+	height: 100%;
 }
 
 .guildNavbarReserveMobileBottomNav {


### PR DESCRIPTION
## Summary

- What changed: The channel list on mobile does not scroll due to CSS issues. This PR adjusts the CSS so that the channel list can properly scroll on mobile.

- Why it is correct: The view scrolls properly on mobile with only some tweaks to the CSS.

- Risk: Low

Resolves #1069 

## Verification

Tested locally in Firefox and Chrome and on iOS in Safari both in the web and as a PWA.

## Checklist

- [X] I understand every change in this PR.
- [X] I can explain what it does and why it is correct.
- [X] I disclosed any LLM coding help below.

## LLM Disclosure

None

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
