### PR TITLE
fix: allow `rate_limit_per_user` on channel creation

### DIFF
--- a/fluxer_api/src/api/guild/services/channel/ChannelOperationsService.ts
+++ b/fluxer_api/src/api/guild/services/channel/ChannelOperationsService.ts
@@ -155,7 +155,7 @@ export class ChannelOperationsService {
 			nsfw: requestedNsfwOverride,
 			content_warning_level: requestedContentWarningLevel,
 			content_warning_text: requestedContentWarningText,
-			rate_limit_per_user: 0,
+			rate_limit_per_user: params.data.rate_limit_per_user ?? 0,
 			bitrate: params.data.type === ChannelTypes.GUILD_VOICE ? (params.data.bitrate ?? 64000) : null,
 			user_limit: params.data.type === ChannelTypes.GUILD_VOICE ? (params.data.user_limit ?? 0) : null,
 			voice_connection_limit:

--- a/fluxer_api/src/api/guild/tests/GuildChannelManagement.test.ts
+++ b/fluxer_api/src/api/guild/tests/GuildChannelManagement.test.ts
@@ -98,6 +98,24 @@ describe('Guild Channel Management', () => {
 		});
 	});
 	describe('Channel Slowmode (rate_limit_per_user)', () => {
+		test('should set slowmode when creating a channel', async () => {
+			const account = await createTestAccount(harness);
+			const guild = await createGuild(harness, account.token, 'We go slow');
+			const channel = await createBuilder<ChannelResponse>(harness, account.token)
+				.post(`/guilds/${guild.id}/channels`)
+				.body({name: 'slooooow', type: ChannelTypes.GUILD_TEXT, rate_limit_per_user: 60})
+				.execute();
+			expect(channel.rate_limit_per_user).toBe(60);
+		});
+		test('should reject invalid slowmode when creating a channel', async () => {
+			const account = await createTestAccount(harness);
+			const guild = await createGuild(harness, account.token, 'Test Guild');
+			await createBuilder(harness, account.token)
+				.post(`/guilds/${guild.id}/channels`)
+				.body({name: 'too-fast-omg', type: ChannelTypes.GUILD_TEXT, rate_limit_per_user: Number.MAX_SAFE_INTEGER})
+				.expect(HTTP_STATUS.BAD_REQUEST)
+				.execute();
+		});
 		test('should set slowmode on text channel', async () => {
 			const account = await createTestAccount(harness);
 			const guild = await createGuild(harness, account.token, 'Test Guild');

--- a/fluxer_api/src/api/openapi/openapi.json
+++ b/fluxer_api/src/api/openapi/openapi.json
@@ -27597,6 +27597,10 @@
 						},
 						"description": "Permission overwrites for roles and members"
 					},
+					"rate_limit_per_user": {
+						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
+						"description": "Slowmode delay in seconds (0-21600)"
+					},
 					"nsfw": {
 						"anyOf": [{"type": "boolean"}, {"type": "null"}],
 						"description": "Legacy: setting true maps to nsfw_override=true; setting false maps to nsfw_override=null (inherit). Prefer nsfw_override."
@@ -27609,10 +27613,6 @@
 					"content_warning_text": {
 						"anyOf": [{"type": "string", "maxLength": 200}, {"type": "null"}],
 						"description": "Custom channel content warning text (max 200 characters); null inherits from parent or guild"
-					},
-					"rate_limit_per_user": {
-						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
-						"description": "Slowmode delay in seconds (0-21600)"
 					},
 					"icon": {
 						"anyOf": [{"$ref": "#/components/schemas/Base64ImageType"}, {"type": "null"}],
@@ -27691,6 +27691,10 @@
 						},
 						"description": "Permission overwrites for roles and members"
 					},
+					"rate_limit_per_user": {
+						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
+						"description": "Slowmode delay in seconds (0-21600)"
+					},
 					"nsfw": {
 						"anyOf": [{"type": "boolean"}, {"type": "null"}],
 						"description": "Legacy: setting true maps to nsfw_override=true; setting false maps to nsfw_override=null (inherit). Prefer nsfw_override."
@@ -27703,10 +27707,6 @@
 					"content_warning_text": {
 						"anyOf": [{"type": "string", "maxLength": 200}, {"type": "null"}],
 						"description": "Custom channel content warning text (max 200 characters); null inherits from parent or guild"
-					},
-					"rate_limit_per_user": {
-						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
-						"description": "Slowmode delay in seconds (0-21600)"
 					},
 					"icon": {
 						"anyOf": [{"$ref": "#/components/schemas/Base64ImageType"}, {"type": "null"}],
@@ -27775,6 +27775,10 @@
 						},
 						"description": "Permission overwrites for roles and members"
 					},
+					"rate_limit_per_user": {
+						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
+						"description": "Slowmode delay in seconds (0-21600)"
+					},
 					"nsfw": {
 						"anyOf": [{"type": "boolean"}, {"type": "null"}],
 						"description": "Legacy: setting true maps to nsfw_override=true; setting false maps to nsfw_override=null (inherit). Prefer nsfw_override."
@@ -27787,10 +27791,6 @@
 					"content_warning_text": {
 						"anyOf": [{"type": "string", "maxLength": 200}, {"type": "null"}],
 						"description": "Custom channel content warning text (max 200 characters); null inherits from parent or guild"
-					},
-					"rate_limit_per_user": {
-						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
-						"description": "Slowmode delay in seconds (0-21600)"
 					},
 					"icon": {
 						"anyOf": [{"$ref": "#/components/schemas/Base64ImageType"}, {"type": "null"}],
@@ -27859,6 +27859,10 @@
 						},
 						"description": "Permission overwrites for roles and members"
 					},
+					"rate_limit_per_user": {
+						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
+						"description": "Slowmode delay in seconds (0-21600)"
+					},
 					"nsfw": {
 						"anyOf": [{"type": "boolean"}, {"type": "null"}],
 						"description": "Legacy: setting true maps to nsfw_override=true; setting false maps to nsfw_override=null (inherit). Prefer nsfw_override."
@@ -27871,10 +27875,6 @@
 					"content_warning_text": {
 						"anyOf": [{"type": "string", "maxLength": 200}, {"type": "null"}],
 						"description": "Custom channel content warning text (max 200 characters); null inherits from parent or guild"
-					},
-					"rate_limit_per_user": {
-						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
-						"description": "Slowmode delay in seconds (0-21600)"
 					},
 					"icon": {
 						"anyOf": [{"$ref": "#/components/schemas/Base64ImageType"}, {"type": "null"}],
@@ -30814,6 +30814,10 @@
 						},
 						"description": "Permission overwrites for roles and members"
 					},
+					"rate_limit_per_user": {
+						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
+						"description": "Slowmode delay in seconds (0-21600)"
+					},
 					"nsfw": {"type": "boolean", "description": "Whether the channel is marked as NSFW"},
 					"nsfw_override": {
 						"anyOf": [{"type": "boolean"}, {"type": "null"}],
@@ -30877,6 +30881,10 @@
 							"required": ["id", "type"]
 						},
 						"description": "Permission overwrites for roles and members"
+					},
+					"rate_limit_per_user": {
+						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
+						"description": "Slowmode delay in seconds (0-21600)"
 					},
 					"nsfw": {"type": "boolean", "description": "Whether the channel is marked as NSFW"},
 					"nsfw_override": {
@@ -30942,6 +30950,10 @@
 						},
 						"description": "Permission overwrites for roles and members"
 					},
+					"rate_limit_per_user": {
+						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
+						"description": "Slowmode delay in seconds (0-21600)"
+					},
 					"nsfw": {"type": "boolean", "description": "Whether the channel is marked as NSFW"},
 					"nsfw_override": {
 						"anyOf": [{"type": "boolean"}, {"type": "null"}],
@@ -31005,6 +31017,10 @@
 							"required": ["id", "type"]
 						},
 						"description": "Permission overwrites for roles and members"
+					},
+					"rate_limit_per_user": {
+						"anyOf": [{"type": "integer", "minimum": 0, "maximum": 21600, "format": "int32"}, {"type": "null"}],
+						"description": "Slowmode delay in seconds (0-21600)"
 					},
 					"nsfw": {"type": "boolean", "description": "Whether the channel is marked as NSFW"},
 					"nsfw_override": {

--- a/packages/schema/src/domains/channel/ChannelRequestSchemas.ts
+++ b/packages/schema/src/domains/channel/ChannelRequestSchemas.ts
@@ -83,6 +83,13 @@ const ChannelCommonBase = z.object({
 		.array(ChannelOverwriteRequest)
 		.optional()
 		.describe('Permission overwrites for roles and members'),
+	rate_limit_per_user: z
+		.number()
+		.int()
+		.min(CHANNEL_RATE_LIMIT_PER_USER_MIN)
+		.max(CHANNEL_RATE_LIMIT_PER_USER_MAX)
+		.nullish()
+		.describe(`Slowmode delay in seconds (${CHANNEL_RATE_LIMIT_PER_USER_MIN}-${CHANNEL_RATE_LIMIT_PER_USER_MAX})`),
 });
 const ChannelContentWarningFields = {
 	nsfw_override: z
@@ -112,13 +119,6 @@ const ChannelUpdateCommon = ChannelCommonBase.extend({
 			'Legacy: setting true maps to nsfw_override=true; setting false maps to nsfw_override=null (inherit). Prefer nsfw_override.',
 		),
 	...ChannelContentWarningFields,
-	rate_limit_per_user: z
-		.number()
-		.int()
-		.min(CHANNEL_RATE_LIMIT_PER_USER_MIN)
-		.max(CHANNEL_RATE_LIMIT_PER_USER_MAX)
-		.nullish()
-		.describe(`Slowmode delay in seconds (${CHANNEL_RATE_LIMIT_PER_USER_MIN}-${CHANNEL_RATE_LIMIT_PER_USER_MAX})`),
 	icon: createBase64StringType(1, Math.ceil(AVATAR_MAX_SIZE * (4 / 3)))
 		.nullish()
 		.describe('Base64-encoded icon image for group DM channels'),


### PR DESCRIPTION
`rate_limit_per_user` was hard-coded to `0` on channel creation. This allows passing `rate_limit_per_user` whilst creating a channel.