### PR TITLE
Desktop app: fix login to self-hosted instances

### DIFF
--- a/fluxer_app/src/features/app/state/RuntimeConfig.ts
+++ b/fluxer_app/src/features/app/state/RuntimeConfig.ts
@@ -435,14 +435,38 @@ class RuntimeConfig {
 		const connectId = ++this._connectSeq;
 		const apiEndpoint = this.normalizeEndpoint(input);
 		const wellKnownUrl = this.buildWellKnownUrl(apiEndpoint);
-		const response = await http.get<InstanceDiscoveryResponse>(wellKnownUrl);
-		if (connectId !== this._connectSeq) {
-			return;
+		const fallbackUrl = this.buildFallbackWellKnownUrl(apiEndpoint);
+
+		let instance: InstanceDiscoveryResponse | null = null;
+		try {
+			const response = await http.get<InstanceDiscoveryResponse>(wellKnownUrl);
+			if (connectId !== this._connectSeq) return;
+			if (response.ok && isValidInstanceDiscoveryResponse(response.body)) {
+				instance = response.body;
+			}
+		} catch (error) {
+			if (!fallbackUrl) {
+				throw new Error(`Failed to reach ${wellKnownUrl} (${error instanceof Error ? error.message : error})`);
+			}
 		}
-		if (!response.ok) {
-			throw new Error(`Failed to reach ${wellKnownUrl} (${response.status})`);
+
+		if (!instance && fallbackUrl) {
+			const fallbackResponse = await http.get<InstanceDiscoveryResponse>(fallbackUrl);
+			if (connectId !== this._connectSeq) return;
+			if (fallbackResponse.ok && isValidInstanceDiscoveryResponse(fallbackResponse.body)) {
+				instance = fallbackResponse.body;
+			} else {
+				throw new Error(`Failed to reach ${wellKnownUrl} and ${fallbackUrl} (${fallbackResponse.status})`);
+			}
 		}
-		this.updateFromInstance(response.body);
+
+		if (!instance) {
+			throw new Error(`Failed to reach ${wellKnownUrl}`);
+		}
+
+		if (connectId === this._connectSeq) {
+			this.updateFromInstance(instance);
+		}
 	}
 
 	private buildWellKnownUrl(apiEndpoint: string): string {
@@ -453,6 +477,20 @@ class RuntimeConfig {
 			return url.toString();
 		} catch {
 			return `${apiEndpoint.replace(/\/api\/?$/, '')}/.well-known/fluxer`;
+		}
+	}
+
+	private buildFallbackWellKnownUrl(apiEndpoint: string): string | null {
+		try {
+			const url = new URL(apiEndpoint);
+			const isOfficialWebApp = url.hostname === 'web.fluxer.app' || url.hostname === 'web.canary.fluxer.app';
+			if (isOfficialWebApp) {
+				return null;
+			}
+			url.pathname = '/api/.well-known/fluxer';
+			return url.toString();
+		} catch {
+			return null;
 		}
 	}
 
@@ -695,6 +733,21 @@ export function describeApiEndpoint(endpoint: string): string {
 	} catch {
 		return endpoint;
 	}
+}
+
+function isValidInstanceDiscoveryResponse(body: unknown): body is InstanceDiscoveryResponse {
+	if (body === null || typeof body !== 'object') {
+		return false;
+	}
+	const record = body as Record<string, unknown>;
+	if (typeof record.api_code_version !== 'number') {
+		return false;
+	}
+	if (!record.endpoints || typeof record.endpoints !== 'object') {
+		return false;
+	}
+	const endpoints = record.endpoints as Record<string, unknown>;
+	return typeof endpoints.api === 'string' && typeof endpoints.gateway === 'string';
 }
 
 export default new RuntimeConfig();

--- a/fluxer_app/src/features/auth/flow/BrowserLoginHandoffModal.tsx
+++ b/fluxer_app/src/features/auth/flow/BrowserLoginHandoffModal.tsx
@@ -147,11 +147,11 @@ const BrowserLoginHandoffModal = observer(
 					);
 					return;
 				}
-				if (baseUrl !== window.location.origin && handoffCode) {
+				if (baseUrl !== window.location.origin) {
 					try {
 						await switchInstanceUrl({
 							instanceUrl: baseUrl,
-							desktopHandoffCode: handoffCode,
+							initiateBrowserLogin: true,
 						});
 					} catch (switchError) {
 						const detail = switchError instanceof Error ? switchError.message : String(switchError);
@@ -166,16 +166,7 @@ const BrowserLoginHandoffModal = observer(
 				loginUrl.searchParams.set('email', prefillEmail);
 			}
 			await openExternalUrl(loginUrl.toString());
-		}, [
-			canSwitchInstanceUrl,
-			currentWebAppUrl,
-			handoffCode,
-			i18n,
-			instanceUrl,
-			prefillEmail,
-			switchInstanceUrl,
-			targetWebAppUrl,
-		]);
+		}, [canSwitchInstanceUrl, currentWebAppUrl, i18n, instanceUrl, prefillEmail, switchInstanceUrl, targetWebAppUrl]);
 		return (
 			<Modal.Root
 				size="small"

--- a/fluxer_app/src/index.tsx
+++ b/fluxer_app/src/index.tsx
@@ -87,6 +87,25 @@ async function resumePendingDesktopHandoffLogin(
 	if (!electronApi || typeof electronApi.consumeDesktopHandoffCode !== 'function') {
 		return;
 	}
+
+	const shouldInitiateBrowserLogin =
+		typeof electronApi.consumeBrowserLoginInitiation === 'function' &&
+		(await electronApi.consumeBrowserLoginInitiation().catch(() => false));
+
+	if (shouldInitiateBrowserLogin) {
+		const {showBrowserLoginHandoffModal} = await loadLazyModule(
+			() => import('@app/features/auth/flow/BrowserLoginHandoffModal'),
+		);
+		showBrowserLoginHandoffModal(async (payload) => {
+			await authenticationCommands.completeLogin({
+				token: payload.token,
+				userId: payload.userId,
+				...(payload.userData ? {userData: payload.userData} : {}),
+			});
+		});
+		return;
+	}
+
 	let handoffCode: string | null = null;
 	try {
 		handoffCode = await electronApi.consumeDesktopHandoffCode();

--- a/fluxer_app/src/types/electron.d.ts
+++ b/fluxer_app/src/types/electron.d.ts
@@ -490,8 +490,13 @@ export interface ElectronAPI {
 	passkeyRegister?(options: unknown, requestContext?: {pin?: string}): Promise<RegistrationResponseJSON>;
 	passkeyAuthenticate?(options: unknown, requestContext?: {pin?: string}): Promise<AuthenticationResponseJSON>;
 	onRpcNavigate?(callback: (path: string) => void): () => void;
-	switchInstanceUrl?(options: {instanceUrl: string; desktopHandoffCode?: string | null}): Promise<void>;
+	switchInstanceUrl?(options: {
+		instanceUrl: string;
+		desktopHandoffCode?: string | null;
+		initiateBrowserLogin?: boolean;
+	}): Promise<void>;
 	consumeDesktopHandoffCode?(): Promise<string | null>;
+	consumeBrowserLoginInitiation?(): Promise<boolean>;
 	getOpenH264Status?(): Promise<OpenH264Status>;
 	setOpenH264Enabled?(enabled: boolean): Promise<OpenH264Status>;
 	virtmic?: VirtmicApi;

--- a/fluxer_app_proxy/src/routes/mod.rs
+++ b/fluxer_app_proxy/src/routes/mod.rs
@@ -6,6 +6,7 @@ mod assets_proxy;
 mod health;
 mod spa_index;
 mod spa_static;
+mod well_known;
 
 use crate::state::AppState;
 use axum::{
@@ -34,6 +35,10 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/.well-known/assetlinks.json",
             get(android_association::assetlinks),
+        )
+        .route(
+            "/.well-known/fluxer",
+            get(well_known::fluxer_well_known),
         )
         .route(
             "/apple-app-site-association",

--- a/fluxer_app_proxy/src/routes/well_known.rs
+++ b/fluxer_app_proxy/src/routes/well_known.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use crate::state::AppState;
+use axum::{
+	extract::State,
+	http::{HeaderValue, StatusCode, header},
+	response::{IntoResponse, Response},
+};
+
+pub async fn fluxer_well_known(State(state): State<AppState>) -> Response {
+	match state.discovery_cache.get().await {
+		Some(discovery) => match serde_json::to_vec(&discovery.data) {
+			Ok(body) => {
+				let mut response = Response::new(axum::body::Body::from(body));
+				response.headers_mut().insert(
+					header::CONTENT_TYPE,
+					HeaderValue::from_static("application/json"),
+				);
+				response.headers_mut().insert(
+					header::CACHE_CONTROL,
+					HeaderValue::from_static("public, max-age=60"),
+				);
+				response
+			}
+			Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+		},
+		None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+	}
+}

--- a/fluxer_desktop/src/common/Types.ts
+++ b/fluxer_desktop/src/common/Types.ts
@@ -257,6 +257,7 @@ export interface DownloadFileResult {
 export interface SwitchInstanceUrlOptions {
 	instanceUrl: string;
 	desktopHandoffCode?: string | null;
+	initiateBrowserLogin?: boolean;
 }
 
 export type MediaAccessType = 'microphone' | 'camera' | 'screen' | 'audio-capture';
@@ -786,6 +787,7 @@ export interface ElectronAPI {
 	passkeyRegister: (options: PublicKeyCredentialCreationOptionsJSON) => Promise<RegistrationResponseJSON>;
 	switchInstanceUrl: (options: SwitchInstanceUrlOptions) => Promise<void>;
 	consumeDesktopHandoffCode: () => Promise<string | null>;
+	consumeBrowserLoginInitiation: () => Promise<boolean>;
 	virtmic: VirtmicApi;
 	nativeAudio: NativeAudioApi;
 	nativeScreenCapture: NativeScreenCaptureApi;

--- a/fluxer_desktop/src/main/IpcHandlers.ts
+++ b/fluxer_desktop/src/main/IpcHandlers.ts
@@ -93,6 +93,36 @@ interface TrayRuntimeStateUpdate {
 }
 
 let pendingDesktopHandoffCode: string | null = null;
+let pendingBrowserLoginInitiation = false;
+
+async function fetchWellKnown(instanceOrigin: string, path: string): Promise<unknown> {
+	const url = new URL(path, instanceOrigin).toString();
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 5000);
+	try {
+		const response = await fetch(url, {
+			method: 'GET',
+			headers: {
+				Accept: 'application/json',
+			},
+			signal: controller.signal,
+		});
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}`);
+		}
+		const contentType = response.headers.get('content-type') ?? '';
+		if (!contentType.includes('application/json')) {
+			throw new Error('Expected JSON, got non-JSON response');
+		}
+		const payload = (await response.json()) as unknown;
+		if (!isValidWellKnownPayload(payload)) {
+			throw new Error('Malformed discovery document');
+		}
+		return payload;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
 
 function normalizeInstanceOrigin(rawUrl: string): string {
 	const trimmed = rawUrl.trim();
@@ -191,29 +221,15 @@ function getActiveMiddleClickAutoscroll(): boolean {
 }
 
 async function assertValidFluxerInstance(instanceOrigin: string): Promise<void> {
-	const url = new URL('/.well-known/fluxer', instanceOrigin).toString();
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), 5000);
 	try {
-		const response = await fetch(url, {
-			method: 'GET',
-			headers: {
-				Accept: 'application/json',
-			},
-			signal: controller.signal,
-		});
-		if (!response.ok) {
-			throw new Error(`HTTP ${response.status}`);
+		await fetchWellKnown(instanceOrigin, '/.well-known/fluxer');
+	} catch (rootError) {
+		try {
+			await fetchWellKnown(instanceOrigin, '/api/.well-known/fluxer');
+		} catch {
+			const rootMessage = rootError instanceof Error ? rootError.message : String(rootError);
+			throw new Error(`Not a valid Fluxer instance (${rootMessage}); also tried /api/.well-known/fluxer`);
 		}
-		const payload = (await response.json()) as unknown;
-		if (!isValidWellKnownPayload(payload)) {
-			throw new Error('Malformed discovery document');
-		}
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		throw new Error(`Not a valid Fluxer instance (${message})`);
-	} finally {
-		clearTimeout(timeout);
 	}
 }
 
@@ -228,13 +244,18 @@ export function registerIpcHandlers(): void {
 			throw new Error('Main window not available');
 		}
 		pendingDesktopHandoffCode = options.desktopHandoffCode ?? null;
+		pendingBrowserLoginInitiation = options.initiateBrowserLogin ?? false;
 		setCustomAppUrl(instanceOrigin);
 		try {
 			await mainWindow.loadURL(instanceOrigin);
 		} catch (error) {
+			const detail = error instanceof Error ? error.message : String(error);
+			if (detail.includes('ERR_ABORTED')) {
+				return;
+			}
 			setCustomAppUrl(null);
 			pendingDesktopHandoffCode = null;
-			const detail = error instanceof Error ? error.message : String(error);
+			pendingBrowserLoginInitiation = false;
 			throw new Error(`Failed to load instance: ${detail}`);
 		}
 	});
@@ -242,6 +263,11 @@ export function registerIpcHandlers(): void {
 		const code = pendingDesktopHandoffCode;
 		pendingDesktopHandoffCode = null;
 		return code;
+	});
+	ipcMain.handle('consume-browser-login-initiation', (): boolean => {
+		const pending = pendingBrowserLoginInitiation;
+		pendingBrowserLoginInitiation = false;
+		return pending;
 	});
 	ipcMain.handle('get-desktop-info', () => getDesktopInfo());
 	ipcMain.handle('get-gpu-info', () => getGpuInfo());

--- a/fluxer_desktop/src/preload/index.ts
+++ b/fluxer_desktop/src/preload/index.ts
@@ -488,6 +488,7 @@ const api: ElectronAPI = {
 	switchInstanceUrl: (options: SwitchInstanceUrlOptions): Promise<void> =>
 		ipcRenderer.invoke('switch-instance-url', options),
 	consumeDesktopHandoffCode: (): Promise<string | null> => ipcRenderer.invoke('consume-desktop-handoff-code'),
+	consumeBrowserLoginInitiation: (): Promise<boolean> => ipcRenderer.invoke('consume-browser-login-initiation'),
 	toggleDevTools: (): void => {
 		ipcRenderer.send('toggle-devtools');
 	},


### PR DESCRIPTION
## Summary

This PR fixes the broken login flow for self hosted instances. First, it fixes the app-proxy not having a /.well_known/fluxer route. Second, it add runtime checks in the client to actually verify that the provided URL is running a fluxer instance, and Third, it enhances the client's instance validation to be more resilient against misconfigured (or in this case, simply not bleeding-edge) servers.

fixes #1083, related: #1088 (core issue becomes fixed, but the issue is more about docs)

• What changed: 

Added a ` /.well-known/fluxer`  route to `fluxer_app_proxy` that serves the cached discovery JSON. The app-proxy already fetches and caches `/api/.well-known/fluxer` from the API for bootstrap injection, but did not expose it at the root path. On self-hosted setups with Caddy,  `/.well-known/fluxer`  fell through to the SPA catch-all and returned HTML. The web app's  `http.get`  treats any HTTP 200 as  `ok: true`  with no runtime body validation (generics are erased), so the HTML was accepted as a discovery document and crashed downstream with `e.endpoints is undefined`. 

Added `isValidInstanceDiscoveryResponse()` as a runtime type guard in `RuntimeConfig.connectToEndpoint()` to reject non-JSONbodies, plus a `/api/.well-known/fluxer` fallback URL for self-hosted instances that are still running outdated versions. The previous `buildFallbackWellKnownUrl` short-circuited when the path already contained  /api , making the fallback unreachable. 

On the desktop side, `assertValidFluxerInstance` now tries `/.well-known/fluxer` then falls back to `/api/.well-known/fluxer`, and a `consumeBrowserLoginInitiation` IPC flag lets the desktop signal the web app to show the browser login handoff modal after switching instances.

• Why it is correct: The server-side route is the primary fix. It serves the same JSON the app-proxy already has in memory from its discovery cache, with a 60s Cache-Control matching the refresh interval. The client-side validation is defense in depth, preventing any future misconfigured reverse proxy from crashing the app the same way. The fallback URL handles setups where `/.well-known/fluxer` is not routed to the app-proxy at all (e.g. different reverse proxy configs). The desktop IPC changes separate "switch to this instance" from "here is a pre-generated handoff code," which fixes a race where the code was generated before the instance was validated.

• Risk: Low. The server-side route only reads from an existing in-memory cache and returns 503 if empty. The client-side validation only adds a type check before accepting a response — it does not change the happy path. The fallback URL is only tried when the primary response is invalid. The desktop IPC additions are additive and do not change existing handoff code behavior unless `initiateBrowserLogin` is explicitly set.

## Verification

• Tests run:  `cargo test -p fluxer_app_proxy`  (91 passed),  `pnpm --filter fluxer_app test -- --run`  (1616 passed), desktop  `tsc --noEmit`  (clean).
• Manual checks: Built app-proxy Docker image with  `FLUXER_APP_PROXY_TIME_FREEZE_ENABLED=false`, deployed to a self-hosted instance behind Caddy. Built desktop `.deb` (canary channel). Confirmed entering a self-hosted instance URL on the desktop login screen discovers the instance and proceeds to login.
• Screenshots or recordings:
[Kooha-2026-07-14-03-04-38.webm](https://github.com/user-attachments/assets/c06e12c6-a831-459d-9438-1eebd92c6235)

## Checklist

[✓] I understand every change in this PR.
[✓] I can explain what it does and why it is correct.
[✓] I disclosed any LLM coding help below.

## LLM Disclosure

• Some code was written with LLM assistance (GLM-5.2 in charm's `crush`). I reviewed every changed file, catching the following bugs that it introduced (and possibly more that i did not keep track of yet fixed anyway):  a double-fetch bug in `connectToEndpoint`, swapped error labels in `assertValidFluxerInstance`, replaced `require()` calls with ESM imports in the preload script, and changed a silent `{}` fallback to a proper 500 in the well-known handler.   
I verified all tests pass and the fix works on a live self-hosted deployment.