### PR TITLE
fix(api): isolate tests from self-hosted environment 1/4

### DIFF
--- a/fluxer_api/src/api/test/Setup.ts
+++ b/fluxer_api/src/api/test/Setup.ts
@@ -32,6 +32,9 @@ function defaultNatsUrl(): string {
 }
 
 function setDefaultTestEnv(): void {
+	// API tests use a non-self-hosted baseline; self-hosted scenarios override the loaded config explicitly.
+	process.env.FLUXER_SELF_HOSTED = 'false';
+
 	const natsUrl = defaultNatsUrl();
 	const defaults: Record<string, string> = {
 		FLUXER_ENV: 'test',
@@ -89,7 +92,6 @@ function setDefaultTestEnv(): void {
 		FLUXER_SEARCH_API_KEY: 'test',
 		FLUXER_CAPTCHA_ENABLED: 'false',
 		FLUXER_CAPTCHA_PROVIDER: 'none',
-		FLUXER_SELF_HOSTED: 'false',
 		FLUXER_DISCOVERY_ENABLED: 'true',
 		FLUXER_RELAX_REGISTRATION_RATE_LIMITS: 'true',
 		FLUXER_DISABLE_RATE_LIMITS: 'true',


### PR DESCRIPTION
> [!NOTE]
> This is part of a 4 stack PR, the next one being #1410

## Summary

- What changed:
API tests now default to non-self-hosted mode regardless of the dev-container environment
- Why it is correct:
Regular tests remain deterministic, while self-hosted tests enable that mode explicitly
- Risk:
This only affects test setup, as it requires the explicit toggle

## Verification

- Tests run:
Previously failing API test group, as well as: pnpm typecheck, pnpm test, Biome check
- Manual checks:
Verified the tests in the standard dev container and confirmed that self-hosted test cases still work as expected
- Screenshots or recordings:

## Custom
A self-hosted test explicitly enables it for that scenario, after which it will then restore the original value

```ts
const config = getConfig();
const original = config.instance.selfHosted;

try {
	config.instance.selfHosted = true;
	await runSelfHostedScenario();
} finally {
	config.instance.selfHosted = original;
}
```
As far as I can tell, existing self-hosted tests already enable that mode explicitly and restore it afterward, so no change is needed in existing tests

## Checklist

- [x] I understand every change in this PR. (To the best of my ability 😄)
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

Using Codex with 5.6 Sol

> [!IMPORTANT]
> I did fill the PR myself, but I used AI to help me be to the point
> Hope that's alright

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
