### PR TITLE
fix(devcontainer): restore SeaweedFS on restart 2/4

### DIFF
--- a/fluxer_api/src/api/test/Setup.ts
+++ b/fluxer_api/src/api/test/Setup.ts
@@ -32,6 +32,9 @@ function defaultNatsUrl(): string {
 }
 
 function setDefaultTestEnv(): void {
+	// API tests use a non-self-hosted baseline; self-hosted scenarios override the loaded config explicitly.
+	process.env.FLUXER_SELF_HOSTED = 'false';
+
 	const natsUrl = defaultNatsUrl();
 	const defaults: Record<string, string> = {
 		FLUXER_ENV: 'test',
@@ -89,7 +92,6 @@ function setDefaultTestEnv(): void {
 		FLUXER_SEARCH_API_KEY: 'test',
 		FLUXER_CAPTCHA_ENABLED: 'false',
 		FLUXER_CAPTCHA_PROVIDER: 'none',
-		FLUXER_SELF_HOSTED: 'false',
 		FLUXER_DISCOVERY_ENABLED: 'true',
 		FLUXER_RELAX_REGISTRATION_RATE_LIMITS: 'true',
 		FLUXER_DISABLE_RATE_LIMITS: 'true',

--- a/tools/dev/src/bootstrap.rs
+++ b/tools/dev/src/bootstrap.rs
@@ -39,6 +39,7 @@ pub async fn post_start() -> Result<()> {
     ensure_state_dirs()?;
     ensure_writable_dev_paths()?;
     setup_gateway_config()?;
+    crate::media_proxy::ensure_dev_object_store(true, 120).await?;
     run_smoke(true, false).await
 }
 


### PR DESCRIPTION
> [!NOTE]
> This is part of a 4 stack PR, the next one being #1411

## Summary

- What changed:
The dev container now restarts SeaweedFS before checking whether it is ready
- Why it is correct:
It uses the existing recovery function, preserving stored data and buckets
- Risk:
Only affects dev-container startup, but I don't see any risks with the change, as it's a very minor one

## Verification

- Tests run:
Rust formatting, Clippy, and workspace tests
- Manual checks:
Restarted the dev container from a stopped state, confirmed SeaweedFS recovered with all buckets intact, and verified a second start did not create another process
- Screenshots or recordings:

## Custom

> [!TIP]
> [Isolated diff](https://github.com/Neonsy/fluxer/commit/74b6320f9139e37dfa485f6e83a160e2db7551dd)

## Checklist

- [x] I understand every change in this PR. (To the best of my ability 😄)
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

Using Codex with 5.6 Sol

> [!IMPORTANT]
> I did fill the PR myself, but I used AI to help me be to the point
> Hope that's alright

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
