### PR TITLE
fix(devcontainer): respect selected database backend 3/4

### DIFF
--- a/fluxer_api/src/api/test/Setup.ts
+++ b/fluxer_api/src/api/test/Setup.ts
@@ -32,6 +32,9 @@ function defaultNatsUrl(): string {
 }
 
 function setDefaultTestEnv(): void {
+	// API tests use a non-self-hosted baseline; self-hosted scenarios override the loaded config explicitly.
+	process.env.FLUXER_SELF_HOSTED = 'false';
+
 	const natsUrl = defaultNatsUrl();
 	const defaults: Record<string, string> = {
 		FLUXER_ENV: 'test',
@@ -89,7 +92,6 @@ function setDefaultTestEnv(): void {
 		FLUXER_SEARCH_API_KEY: 'test',
 		FLUXER_CAPTCHA_ENABLED: 'false',
 		FLUXER_CAPTCHA_PROVIDER: 'none',
-		FLUXER_SELF_HOSTED: 'false',
 		FLUXER_DISCOVERY_ENABLED: 'true',
 		FLUXER_RELAX_REGISTRATION_RATE_LIMITS: 'true',
 		FLUXER_DISABLE_RATE_LIMITS: 'true',

--- a/tools/dev/src/bootstrap.rs
+++ b/tools/dev/src/bootstrap.rs
@@ -39,6 +39,7 @@ pub async fn post_start() -> Result<()> {
     ensure_state_dirs()?;
     ensure_writable_dev_paths()?;
     setup_gateway_config()?;
+    crate::media_proxy::ensure_dev_object_store(true, 120).await?;
     run_smoke(true, false).await
 }
 

--- a/tools/dev/src/smoke.rs
+++ b/tools/dev/src/smoke.rs
@@ -24,6 +24,25 @@ pub const S3_BUCKETS: &[&str] = &[
     "fluxer-static",
 ];
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DatabaseBackend {
+    Postgres,
+    Cassandra,
+}
+
+fn parse_database_backend(value: Option<&str>) -> Result<DatabaseBackend> {
+    match value.unwrap_or("postgres") {
+        "postgres" => Ok(DatabaseBackend::Postgres),
+        "cassandra" => Ok(DatabaseBackend::Cassandra),
+        other => bail!("unsupported FLUXER_DATABASE_BACKEND: {other}"),
+    }
+}
+
+fn database_backend() -> Result<DatabaseBackend> {
+    let value = env::var("FLUXER_DATABASE_BACKEND").ok();
+    parse_database_backend(value.as_deref())
+}
+
 pub async fn run_smoke(quick: bool, public: bool) -> Result<()> {
     let timeout = if quick { 5 } else { 120 };
     wait_tcp(
@@ -80,7 +99,9 @@ pub async fn run_smoke(quick: bool, public: bool) -> Result<()> {
     .await?;
     wait_s3_api(timeout).await?;
     if !quick {
-        verify_schema(None, None).await?;
+        if database_backend()? == DatabaseBackend::Cassandra {
+            verify_schema(None, None).await?;
+        }
         check_s3_buckets()?;
         check_config_load()?;
     }
@@ -385,7 +406,9 @@ async fn check_gateway_internal_rpc() -> Result<()> {
 }
 
 pub async fn bootstrap_schema_and_object_store() -> Result<()> {
-    apply_schema(Some(config_from_env()?)).await?;
+    if database_backend()? == DatabaseBackend::Cassandra {
+        apply_schema(Some(config_from_env()?)).await?;
+    }
     ensure_s3_buckets()
 }
 
@@ -402,6 +425,37 @@ pub async fn http_ok(url: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn database_backend_defaults_to_postgres() {
+        assert_eq!(
+            parse_database_backend(None).unwrap(),
+            DatabaseBackend::Postgres
+        );
+    }
+
+    #[test]
+    fn database_backend_accepts_canonical_values() {
+        assert_eq!(
+            parse_database_backend(Some("postgres")).unwrap(),
+            DatabaseBackend::Postgres
+        );
+        assert_eq!(
+            parse_database_backend(Some("cassandra")).unwrap(),
+            DatabaseBackend::Cassandra
+        );
+    }
+
+    #[test]
+    fn database_backend_rejects_unsupported_values() {
+        for value in ["postgresql", "pg", "scylla", "scylladb", "sqlite"] {
+            let error = parse_database_backend(Some(value)).unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                format!("unsupported FLUXER_DATABASE_BACKEND: {value}")
+            );
+        }
+    }
 
     #[test]
     fn s3_env_uses_fluxer_defaults() {


### PR DESCRIPTION
> [!NOTE]
> This is part of a 4 stack PR, the next one being #1412

## Summary

- What changed:
Dev bootstrap now runs Cassandra setup only when Cassandra is selected
- Why it is correct:
PostgreSQL environments no longer require Cassandra, while Cassandra environments keep the existing schema checks
- Risk:
Changes dev bootstrap behavior based on the configured backend, but it's intended and not really a risk IMO

## Verification

- Tests run:
Rust formatting, Clippy, workspace tests, typecheck, and full test suite
- Manual checks:
Verified PostgreSQL startup with Cassandra stopped, then verified full Cassandra schema setup with Cassandra selected
- Screenshots or recordings:

## Custom

> [!TIP]
> [Isolated diff](https://github.com/Neonsy/fluxer/commit/9dd0e5eff99d9efd45b7305618097cedac61e9c4)

## Checklist

- [x] I understand every change in this PR. (To the best of my ability 😄)
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

Using Codex with 5.6 Sol

> [!IMPORTANT]
> I did fill the PR myself, but I used AI to help me be to the point
> Hope that's alright

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
