### PR TITLE
fix(devcontainer): wait for documentation server readiness 4/4

### DIFF
--- a/fluxer_docs/serve.sh
+++ b/fluxer_docs/serve.sh
@@ -5,7 +5,15 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV="$HERE/.venv"
 ADDR="${ZENSICAL_DEV_ADDR:-0.0.0.0:8000}"
 LOG="${ZENSICAL_LOG:-/tmp/zensical-serve.log}"
+HOST="${ADDR%:*}"
 PORT="${ADDR##*:}"
+
+case "$HOST" in
+	0.0.0.0) READY_HOST="127.0.0.1" ;;
+	"[::]") READY_HOST="[::1]" ;;
+	*) READY_HOST="$HOST" ;;
+esac
+READY_URL="http://${READY_HOST}:${PORT}/"
 
 cd "$HERE"
 
@@ -17,19 +25,56 @@ ensure_env() {
 	"$VENV/bin/python" -m pip install --quiet --require-virtualenv -r "$HERE/requirements.txt"
 }
 
+is_ready() {
+	curl --fail --silent --output /dev/null --noproxy '*' --connect-timeout 1 --max-time 2 "$READY_URL"
+}
+
+stop_daemon() {
+	local pid="$1"
+	kill "$pid" 2>/dev/null || true
+	for _ in {1..50}; do
+		if ! kill -0 "$pid" 2>/dev/null; then
+			wait "$pid" 2>/dev/null || true
+			return
+		fi
+		sleep 0.1
+	done
+	kill -KILL "$pid" 2>/dev/null || true
+	wait "$pid" 2>/dev/null || true
+}
+
 case "${1:-serve}" in
 	--bootstrap)
 		ensure_env
 		;;
 	--daemon)
 		ensure_env
-		if curl -sf -o /dev/null "http://127.0.0.1:${PORT}/" 2>/dev/null; then
+		if is_ready; then
 			echo "zensical already serving on ${ADDR}"
 			exit 0
 		fi
-		setsid "$VENV/bin/zensical" serve -a "$ADDR" >"$LOG" 2>&1 &
-		disown 2>/dev/null || true
-		echo "zensical serving on ${ADDR} (logs: ${LOG})"
+		setsid "$VENV/bin/zensical" serve -a "$ADDR" </dev/null >"$LOG" 2>&1 &
+		pid=$!
+		deadline=$((SECONDS + 30))
+		while ((SECONDS < deadline)); do
+			if is_ready; then
+				disown "$pid" 2>/dev/null || true
+				echo "zensical serving on ${ADDR} (logs: ${LOG})"
+				exit 0
+			fi
+			if ! kill -0 "$pid" 2>/dev/null; then
+				status=0
+				wait "$pid" || status=$?
+				echo "zensical exited during startup with status ${status} (logs: ${LOG})" >&2
+				tail -n 20 "$LOG" >&2 || true
+				exit 1
+			fi
+			sleep 0.25
+		done
+		stop_daemon "$pid"
+		echo "timed out waiting for zensical on ${ADDR} (logs: ${LOG})" >&2
+		tail -n 20 "$LOG" >&2 || true
+		exit 1
 		;;
 	serve)
 		ensure_env


### PR DESCRIPTION
## Summary

- What changed:
The documentation startup waits for Zensical to become ready and cleans up failed starts
- Why it is correct:
Success is reported only when the server responds, while the existing healthy servers are being reused
- Risk:
It only affects local documentation startup, so genuine startup failures now correctly fail the hook

## Verification

- Tests run:
Shell syntax check, documentation build, Rust formatting, Clippy, workspace tests, typecheck, and the full test suite
- Manual checks:
Verified normal startup, repeated startup without duplicate processes, IPv4 and IPv6 addresses, timeout cleanup, and port-conflict handling (through the guidance of the AI)
- Screenshots or recordings:

## Custom

I did that because when I was looking at the clean environment errors, the assistant noticed that too

Previously, the script reported success immediately after starting Zensical, but the dev container could finish while the documentation was not ready

> [!TIP]
> [Isolated diff](https://github.com/Neonsy/fluxer/commit/28987ba54cb7d4d275c2db2b3a3523d223f7ead7)

## Checklist

- [x] I understand every change in this PR. (To the best of my ability 😄)
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

Using Codex with 5.6 Sol

> [!IMPORTANT]
> I did fill the PR myself, but I used AI to help me be to the point
> Hope that's alright

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
