### PR TITLE
Related to fluxerapp/fluxer-meta#8

### DIFF
--- a/fluxer_app/src/features/platform/types/Electron.ts
+++ b/fluxer_app/src/features/platform/types/Electron.ts
@@ -278,6 +278,24 @@ export interface StreamerModeCaptureAppStatus {
 	processes: Array<StreamerModeCaptureProcess>;
 }
 
+export interface ActivityDetectionProcess {
+	name: string;
+	pid?: number;
+}
+
+export interface DetectedActivity {
+	name: string;
+	aliases?: Array<string>;
+	icon: string;
+	presenceAssets?: Record<string, string>;
+	processes: Array<ActivityDetectionProcess>;
+}
+
+export interface ActivityDetectionStatus {
+	detected: boolean;
+	activities: Array<DetectedActivity>;
+}
+
 export interface CpuInfo {
 	model: string;
 	speed: number;
@@ -369,6 +387,7 @@ export interface ElectronAPI {
 	showNotification: (options: NotificationOptions) => Promise<NotificationResult>;
 	shouldPlayNotificationSound?: () => Promise<boolean>;
 	getStreamerModeCaptureAppStatus?: () => Promise<StreamerModeCaptureAppStatus>;
+	getDetectedActivities?: () => Promise<ActivityDetectionStatus>;
 	closeNotification: (id: string) => void;
 	closeNotifications: (ids: Array<string>) => void;
 	onNotificationClick: (callback: (id: string, url?: string) => void) => () => void;

--- a/fluxer_app/src/types/electron.d.ts
+++ b/fluxer_app/src/types/electron.d.ts
@@ -321,6 +321,24 @@ export interface StreamerModeCaptureAppStatus {
 	processes: Array<StreamerModeCaptureProcess>;
 }
 
+export interface ActivityDetectionProcess {
+	name: string;
+	pid?: number;
+}
+
+export interface DetectedActivity {
+	name: string;
+	aliases?: Array<string>;
+	icon: string;
+	presenceAssets?: Record<string, string>;
+	processes: Array<ActivityDetectionProcess>;
+}
+
+export interface ActivityDetectionStatus {
+	detected: boolean;
+	activities: Array<DetectedActivity>;
+}
+
 export interface CpuInfo {
 	model: string;
 	speed: number;
@@ -392,6 +410,7 @@ export interface ElectronAPI {
 	desktopTroubleshootingReload?(): Promise<void>;
 	desktopTroubleshootingResetAppData?(options?: {confirm?: boolean}): Promise<void>;
 	getStreamerModeCaptureAppStatus?(): Promise<StreamerModeCaptureAppStatus>;
+	getDetectedActivities?(): Promise<ActivityDetectionStatus>;
 	popupHelpMenu?(): Promise<void>;
 	getInitialDeepLink(): Promise<string | null>;
 	onDeepLink(callback: (url: string) => void): () => void;

--- a/fluxer_desktop/src/common/Types.ts
+++ b/fluxer_desktop/src/common/Types.ts
@@ -618,6 +618,24 @@ export interface StreamerModeCaptureAppStatus {
 	processes: Array<StreamerModeCaptureProcess>;
 }
 
+export interface ActivityDetectionProcess {
+	name: string;
+	pid?: number;
+}
+
+export interface DetectedActivity {
+	name: string;
+	aliases?: Array<string>;
+	icon: string;
+	presenceAssets?: Record<string, string>;
+	processes: Array<ActivityDetectionProcess>;
+}
+
+export interface ActivityDetectionStatus {
+	detected: boolean;
+	activities: Array<DetectedActivity>;
+}
+
 export type TrayPresenceStatus = 'online' | 'idle' | 'dnd' | 'invisible';
 
 export interface TrayRuntimeStatePayload {
@@ -718,6 +736,7 @@ export interface ElectronAPI {
 	showNotification: (options: NotificationOptions) => Promise<NotificationResult>;
 	shouldPlayNotificationSound: () => Promise<boolean>;
 	getStreamerModeCaptureAppStatus: () => Promise<StreamerModeCaptureAppStatus>;
+	getDetectedActivities: () => Promise<ActivityDetectionStatus>;
 	closeNotification: (id: string) => void;
 	closeNotifications: (ids: Array<string>) => void;
 	onNotificationClick: (callback: (id: string, url?: string) => void) => () => void;

--- a/fluxer_desktop/src/main/ActivityDetection.test.mjs
+++ b/fluxer_desktop/src/main/ActivityDetection.test.mjs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import {createRequire} from 'node:module';
+import {describe, test} from 'node:test';
+import {fileURLToPath} from 'node:url';
+import vm from 'node:vm';
+
+const require = createRequire(import.meta.url);
+const esbuild = require('esbuild');
+
+const sourcePath = fileURLToPath(new URL('./ActivityDetection.ts', import.meta.url));
+const source = readFileSync(sourcePath, 'utf8');
+const transformedSource = esbuild.transformSync(source, {
+	loader: 'ts',
+	format: 'cjs',
+	platform: 'node',
+	target: 'node20',
+}).code;
+
+const detectablesCatalog = [
+	{
+		name: 'Minecraft',
+		icon: 'minecraft.png',
+		executables: [
+			{name: 'minecraft.windows.exe', os: 'win32'},
+			{name: '>java', os: 'linux', arguments: 'net.minecraft.client.main.Main'},
+		],
+	},
+	{
+		name: 'osu!',
+		icon: 'osu.png',
+		executables: [{name: 'osu!', os: 'linux'}],
+		presence_assets: {mode_0: 'osu/mode_0.png'},
+	},
+];
+
+function plain(value) {
+	return JSON.parse(JSON.stringify(value));
+}
+
+function loadActivityDetection({platform = 'linux'} = {}) {
+	const module = {exports: {}};
+	const context = vm.createContext({
+		module,
+		exports: module.exports,
+		console,
+		process: {platform},
+		require: (specifier) => {
+			if (specifier === './DetectablesCatalog.json') return detectablesCatalog;
+			if (specifier === 'node:child_process') {
+				return {execFile: () => {}};
+			}
+			return require(specifier);
+		},
+	});
+	vm.runInContext(transformedSource, context, {filename: sourcePath});
+	return module.exports.__activityDetectionTest;
+}
+
+describe('ActivityDetection', () => {
+	test('matches shared runtimes only when command-line arguments match', () => {
+		const detector = loadActivityDetection();
+		const activities = detector.detectActivities(detectablesCatalog, [
+			{name: '/usr/bin/java', pid: 123, path: '/usr/bin/java', arguments: '-cp game.jar net.minecraft.client.main.Main'},
+			{name: '/usr/bin/java', pid: 456, path: '/usr/bin/java', arguments: '-jar server.jar'},
+		]);
+
+		assert.deepEqual(plain(activities), [
+			{
+				name: 'Minecraft',
+				icon: 'minecraft.png',
+				processes: [{name: 'java', pid: 123}],
+			},
+		]);
+	});
+
+	test('returns presence assets for matching detectables', () => {
+		const detector = loadActivityDetection();
+		const activities = detector.detectActivities(detectablesCatalog, [
+			{name: '/usr/bin/osu!', pid: 789, path: '/usr/bin/osu!', arguments: 'osu!'},
+		]);
+
+		assert.deepEqual(plain(activities), [
+			{
+				name: 'osu!',
+				icon: 'osu.png',
+				presenceAssets: {mode_0: 'osu/mode_0.png'},
+				processes: [{name: 'osu!', pid: 789}],
+			},
+		]);
+	});
+
+	test('matches Windows executable names case-insensitively', () => {
+		const detector = loadActivityDetection({platform: 'win32'});
+		const activities = detector.detectActivities(detectablesCatalog, [
+			{
+				name: 'Minecraft.Windows.exe',
+				pid: 321,
+				path: 'C:\\Program Files\\WindowsApps\\Minecraft.Windows.exe',
+				arguments: null,
+			},
+		]);
+
+		assert.equal(activities[0]?.name, 'Minecraft');
+		assert.equal(activities[0]?.processes[0]?.name, 'minecraft.windows.exe');
+	});
+
+	test('parses POSIX ps output with command paths and arguments', () => {
+		const detector = loadActivityDetection();
+		const processes = detector.parsePosixProcesses(
+			'  123 /usr/bin/java  /usr/bin/java -cp game.jar net.minecraft.client.main.Main\n',
+		);
+
+		assert.deepEqual(plain(processes), [
+			{
+				name: '/usr/bin/java',
+				pid: 123,
+				path: '/usr/bin/java',
+				arguments: '/usr/bin/java -cp game.jar net.minecraft.client.main.Main',
+			},
+		]);
+	});
+
+	test('parses Windows process JSON from PowerShell', () => {
+		const detector = loadActivityDetection({platform: 'win32'});
+		const processes = detector.parseWindowsProcessJson(
+			JSON.stringify({ProcessId: 42, Name: 'osu!.exe', ExecutablePath: 'C:\\osu!\\osu!.exe', CommandLine: '"osu!.exe"'}),
+		);
+
+		assert.deepEqual(plain(processes), [
+			{name: 'osu!.exe', pid: 42, path: 'C:\\osu!\\osu!.exe', arguments: '"osu!.exe"'},
+		]);
+	});
+});

--- a/fluxer_desktop/src/main/ActivityDetection.ts
+++ b/fluxer_desktop/src/main/ActivityDetection.ts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {execFile} from 'node:child_process';
+import path from 'node:path';
+import {promisify} from 'node:util';
+import type {ActivityDetectionProcess, ActivityDetectionStatus, DetectedActivity} from '@electron/common/Types';
+import detectablesCatalog from './DetectablesCatalog.json';
+
+const execFileAsync = promisify(execFile);
+const PROCESS_QUERY_MAX_BUFFER_BYTES = 2 * 1024 * 1024;
+const MAX_DETECTED_ACTIVITIES = 8;
+const MAX_ACTIVITY_PROCESSES = 4;
+
+interface DetectableExecutable {
+	name: string;
+	os: NodeJS.Platform;
+	arguments?: string;
+}
+
+interface DetectableApplication {
+	name: string;
+	aliases?: Array<string>;
+	icon: string;
+	executables: Array<DetectableExecutable>;
+	presence_assets?: Record<string, string>;
+}
+
+interface ActivityProcessSnapshot extends ActivityDetectionProcess {
+	path?: string | null;
+	arguments?: string | null;
+}
+
+function normalizeProcessName(value: string): string {
+	const normalized = value.trim().replace(/^"|"$/g, '');
+	return path.basename(normalized).toLowerCase();
+}
+
+function normalizeProcessPath(value: string | null | undefined): string {
+	return (value ?? '').trim().replace(/\\/g, '/').replace(/^"|"$/g, '').toLowerCase();
+}
+
+function normalizeArguments(value: string | null | undefined): string {
+	return (value ?? '').toLowerCase();
+}
+
+function executableMatchesProcess(rule: DetectableExecutable, processSnapshot: ActivityProcessSnapshot): boolean {
+	if (rule.os !== process.platform) return false;
+	const rawRuleName = rule.name.trim().toLowerCase();
+	const requiresArguments = rawRuleName.startsWith('>');
+	const ruleName = requiresArguments ? rawRuleName.slice(1) : rawRuleName;
+	if (!ruleName) return false;
+	if (requiresArguments && !rule.arguments) return false;
+	if (rule.arguments && !normalizeArguments(processSnapshot.arguments).includes(rule.arguments.toLowerCase())) {
+		return false;
+	}
+	const processName = normalizeProcessName(processSnapshot.name);
+	const processPath = normalizeProcessPath(processSnapshot.path ?? processSnapshot.name);
+	if (ruleName.includes('/')) {
+		return processPath.endsWith(ruleName);
+	}
+	return processName === ruleName;
+}
+
+function getProcessKey(processSnapshot: ActivityProcessSnapshot): string {
+	return processSnapshot.pid == null ? `name:${processSnapshot.name}` : `pid:${processSnapshot.pid}`;
+}
+
+function detectActivities(
+	catalog: ReadonlyArray<DetectableApplication>,
+	processes: ReadonlyArray<ActivityProcessSnapshot>,
+): Array<DetectedActivity> {
+	const activities: Array<DetectedActivity> = [];
+	for (const application of catalog) {
+		if (activities.length >= MAX_DETECTED_ACTIVITIES) break;
+		const matchedProcesses: Array<ActivityDetectionProcess> = [];
+		const seenProcessKeys = new Set<string>();
+		for (const processSnapshot of processes) {
+			if (matchedProcesses.length >= MAX_ACTIVITY_PROCESSES) break;
+			if (!application.executables.some((rule) => executableMatchesProcess(rule, processSnapshot))) continue;
+			const key = getProcessKey(processSnapshot);
+			if (seenProcessKeys.has(key)) continue;
+			seenProcessKeys.add(key);
+			matchedProcesses.push({
+				name: normalizeProcessName(processSnapshot.name),
+				...(processSnapshot.pid != null ? {pid: processSnapshot.pid} : {}),
+			});
+		}
+		if (matchedProcesses.length === 0) continue;
+		activities.push({
+			name: application.name,
+			...(application.aliases ? {aliases: application.aliases} : {}),
+			icon: application.icon,
+			...(application.presence_assets ? {presenceAssets: application.presence_assets} : {}),
+			processes: matchedProcesses,
+		});
+	}
+	return activities;
+}
+
+function parsePosixProcesses(stdout: string): Array<ActivityProcessSnapshot> {
+	const processes: Array<ActivityProcessSnapshot> = [];
+	for (const line of stdout.split(/\r?\n/)) {
+		const match = line.match(/^\s*(\d+)\s+(.+?)\s{2,}(.*)$/);
+		if (!match) continue;
+		const [, pidRaw, command, args = ''] = match;
+		const pid = Number.parseInt(pidRaw ?? '', 10);
+		if (!command) continue;
+		processes.push({
+			name: command,
+			...(Number.isFinite(pid) ? {pid} : {}),
+			path: command,
+			arguments: args,
+		});
+	}
+	return processes;
+}
+
+function parseWindowsProcessJson(stdout: string): Array<ActivityProcessSnapshot> {
+	const trimmed = stdout.trim();
+	if (!trimmed) return [];
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch {
+		return [];
+	}
+	const rows = Array.isArray(parsed) ? parsed : [parsed];
+	const processes: Array<ActivityProcessSnapshot> = [];
+	for (const row of rows) {
+		if (!row || typeof row !== 'object') continue;
+		const record = row as Record<string, unknown>;
+		const name = typeof record.Name === 'string' ? record.Name : null;
+		if (!name) continue;
+		const pid = typeof record.ProcessId === 'number' ? record.ProcessId : Number.parseInt(String(record.ProcessId), 10);
+		const executablePath = typeof record.ExecutablePath === 'string' ? record.ExecutablePath : null;
+		const commandLine = typeof record.CommandLine === 'string' ? record.CommandLine : null;
+		processes.push({
+			name,
+			...(Number.isFinite(pid) ? {pid} : {}),
+			path: executablePath,
+			arguments: commandLine,
+		});
+	}
+	return processes;
+}
+
+async function getRunningProcesses(): Promise<Array<ActivityProcessSnapshot>> {
+	if (process.platform === 'win32') {
+		const {stdout} = await execFileAsync(
+			'powershell.exe',
+			[
+				'-NoProfile',
+				'-Command',
+				'Get-CimInstance Win32_Process | Select-Object ProcessId,Name,ExecutablePath,CommandLine | ConvertTo-Json -Compress',
+			],
+			{windowsHide: true, maxBuffer: PROCESS_QUERY_MAX_BUFFER_BYTES},
+		);
+		return parseWindowsProcessJson(stdout);
+	}
+	const {stdout} = await execFileAsync('ps', ['-axo', 'pid=,comm=,args='], {
+		maxBuffer: PROCESS_QUERY_MAX_BUFFER_BYTES,
+	});
+	return parsePosixProcesses(stdout);
+}
+
+export async function getDetectedActivities(): Promise<ActivityDetectionStatus> {
+	let activities: Array<DetectedActivity> = [];
+	try {
+		activities = detectActivities(detectablesCatalog as Array<DetectableApplication>, await getRunningProcesses());
+	} catch {
+		activities = [];
+	}
+	return {
+		detected: activities.length > 0,
+		activities,
+	};
+}
+
+export const __activityDetectionTest = {
+	detectActivities,
+	executableMatchesProcess,
+	parsePosixProcesses,
+	parseWindowsProcessJson,
+};

--- a/fluxer_desktop/src/main/DetectablesCatalog.json
+++ b/fluxer_desktop/src/main/DetectablesCatalog.json
@@ -1,0 +1,32 @@
+[
+	{
+		"name": "Minecraft",
+		"aliases": ["Minecraft Launcher", "Minecraft Windows 10 Edition", "Minecraft: Java Edition"],
+		"icon": "minecraft.png",
+		"executables": [
+			{"name": "minecraft.windows.exe", "os": "win32"},
+			{"name": "content/minecraft.exe", "os": "win32"},
+			{"name": ">javaw.exe", "os": "win32", "arguments": "net.minecraft.client.main.Main"},
+			{"name": ">java", "os": "darwin", "arguments": "net.minecraft.client.main.Main"},
+			{"name": ">java", "os": "linux", "arguments": "net.minecraft.client.main.Main"}
+		]
+	},
+	{
+		"name": "osu!",
+		"aliases": ["osu!(lazer)", "osu!(stable)"],
+		"icon": "osu.png",
+		"executables": [
+			{"name": "osu!.exe", "os": "win32"},
+			{"name": "osu!.app", "os": "darwin"},
+			{"name": "osu!", "os": "linux"}
+		],
+		"presence_assets": {
+			"mode_custom": "osu/mode_custom.png",
+			"mode_2": "osu/mode_2.png",
+			"mode_0": "osu/mode_0.png",
+			"mode_3": "osu/mode_3.png",
+			"mode_1": "osu/mode_1.png",
+			"osu_logo_lazer": "osu/osu_logo_lazer.png"
+		}
+	}
+]

--- a/fluxer_desktop/src/main/IpcHandlers.ts
+++ b/fluxer_desktop/src/main/IpcHandlers.ts
@@ -15,6 +15,7 @@ import type {
 	SwitchInstanceUrlOptions,
 	TrayPresenceStatus,
 } from '@electron/common/Types';
+import {getDetectedActivities} from '@electron/main/ActivityDetection';
 import {hasEnabledBlinkFeature, MIDDLE_CLICK_AUTOSCROLL_BLINK_FEATURE} from '@electron/main/ChromiumRuntime';
 import {
 	applyDesktopWindowBehaviorSettings,
@@ -249,6 +250,7 @@ export function registerIpcHandlers(): void {
 	ipcMain.handle('get-openh264-status', () => getOpenH264Status());
 	ipcMain.handle('set-openh264-enabled', (_event, enabled: unknown) => setOpenH264Enabled(Boolean(enabled)));
 	ipcMain.handle('streamer-mode:get-capture-app-status', () => getStreamerModeCaptureAppStatus());
+	ipcMain.handle('activity-detection:get-detected-activities', () => getDetectedActivities());
 	ipcMain.handle('system-idle-time-ms', (): number => {
 		return Math.max(0, powerMonitor.getSystemIdleTime() * 1000);
 	});

--- a/fluxer_desktop/src/preload/index.ts
+++ b/fluxer_desktop/src/preload/index.ts
@@ -4,6 +4,7 @@ import {BUILD_CHANNEL} from '@electron/common/BuildChannel';
 import {DESKTOP_BUILD_VARIANT} from '@electron/common/BuildVariant';
 import type {
 	AppMetricsSnapshot,
+	ActivityDetectionStatus,
 	ClipboardWriteFileOptions,
 	ClipboardWriteFileResult,
 	DesktopInfo,
@@ -524,6 +525,8 @@ const api: ElectronAPI = {
 	shouldPlayNotificationSound: (): Promise<boolean> => ipcRenderer.invoke('notification-sound-allowed'),
 	getStreamerModeCaptureAppStatus: (): Promise<StreamerModeCaptureAppStatus> =>
 		ipcRenderer.invoke('streamer-mode:get-capture-app-status'),
+	getDetectedActivities: (): Promise<ActivityDetectionStatus> =>
+		ipcRenderer.invoke('activity-detection:get-detected-activities'),
 	closeNotification: (id: string): void => {
 		ipcRenderer.send('close-notification', id);
 	},


### PR DESCRIPTION
## Summary

This PR adds a focused desktop activity detection slice related to fluxerapp/fluxer-meta#8.

It introduces local activity detection based on the detectables schema and exposes the result through the Electron IPC/preload layer.

## What changed

- Added desktop activity detection
- Added an initial detectables catalog
- Exposed `getDetectedActivities()` through Electron preload/IPC
- Added related platform types
- Added tests for the detection layer

## Testing

```bash
node --test fluxer_desktop/src/main/ActivityDetection.test.mjs
node --test fluxer_desktop/src/main/StreamerModeProcessDetection.test.mjs
git diff --check