### PR TITLE
fix(desktop): open external browser when will-navigate blocks an untrusted origin

### DIFF
--- a/fluxer_desktop/src/main/Window.ts
+++ b/fluxer_desktop/src/main/Window.ts
@@ -1034,6 +1034,9 @@ export function createWindow(options: CreateWindowOptions = {}): BrowserWindow {
 	webContents.on('will-navigate', (event, url) => {
 		if (!isTrustedOrigin(url)) {
 			event.preventDefault();
+			openExternalDeduped(url).catch((error) => {
+				log.warn('Failed to open external URL from will-navigate:', error);
+			});
 		}
 	});
 	webContents.on('did-create-window', (window, details) => {


### PR DESCRIPTION
## Summary

- What changed: `will-navigate` in the desktop app's main window now opens blocked (untrusted-origin) navigations in the system's default browser via `openExternalDeduped()`, instead of only calling `event.preventDefault()` and leaving the window on a blank page.
- Why it is correct: `setWindowOpenHandler` already falls back to `openExternalDeduped()` for popup windows that target an untrusted origin. `will-navigate` had no equivalent fallback, so any full-page (non-popup) redirect away from the trusted origin was silently cancelled with no way for the user to continue. This is hit by the standard OIDC/SSO authorization-code redirect flow (e.g. a self-hosted instance with Google SSO enabled): clicking "Continue with SSO" makes the main window try to navigate to the identity provider's authorization URL, which gets blocked, leaving the window black/stuck indefinitely with no error shown.
- Risk: Low. The change only affects the branch that was already discarding the navigation (`!isTrustedOrigin(url)`); it adds an external-open call in that branch, mirroring the existing, already-shipped behavior in `setWindowOpenHandler` just above it in the same file.

## Verification

- Tests run: existing test suite unaffected (no test currently covers `will-navigate`); ran `pnpm typecheck` for `fluxer_desktop`.
- Manual checks: Reproduced on a self-hosted instance with SSO (OIDC, Google as provider) enabled and enforced. Before the fix: clicking "Continue with SSO" in the desktop app leaves the window blank/black forever; confirmed via `--remote-debugging-port` that the client receives `200` from `POST /api/v1/auth/sso/start` and then attempts a top-level navigation to `accounts.google.com`, which fires `will-navigate` -> `isTrustedOrigin` is false -> `preventDefault()` with no fallback, observed as `net::ERR_ABORTED` on that navigation. After the fix: the same click opens the identity provider's login in the system browser and the main window remains on the login screen instead of going blank.
- Screenshots or recordings: none included.

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

Diagnosed and authored with the help of Claude (Anthropic), used interactively as a coding assistant: it traced the bug from a live repro (an Electron `--remote-debugging-port` session) down to this exact code path, and drafted this one-line fix mirroring the existing `setWindowOpenHandler` fallback. I reviewed the change and the diagnosis myself before opening this PR.

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
