### PR TITLE
Feat/events calendar

### DIFF
--- a/fluxer_api/src/api/channel/controllers/EventController.ts
+++ b/fluxer_api/src/api/channel/controllers/EventController.ts
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { ChannelTypes, Permissions } from '@fluxer/constants';
+import type { RouteHandler } from '../..';
+
+export interface GuildEventRow {
+	id: string;
+	channel_id: string;
+	guild_id: string;
+	creator_id: string;
+	name: string;
+	description: string | null;
+	location_channel_id: string | null;
+	location_text: string | null;
+	starts_at: Date;
+	ends_at: Date;
+	repeat_type: string;
+	repeat_interval: number;
+	created_at: Date;
+	updated_at: Date;
+}
+
+/**
+ * Controller handling Calendar Event operations (CRUD, RSVP, ICS Export).
+ */
+export class EventController {
+	/**
+	 * GET /channels/:id/events
+	 * Lists all events in a calendar channel.
+	 */
+	static listEvents: RouteHandler = async (c) => {
+		const channelId = c.req.param('id');
+		const db = c.get('db');
+		const user = c.get('user');
+
+		const events = await db.query<GuildEventRow>(
+			`SELECT e.*, 
+				(SELECT COUNT(*) FROM event_attendees WHERE event_id = e.id) as attendee_count,
+				EXISTS(SELECT 1 FROM event_attendees WHERE event_id = e.id AND user_id = $2) as is_attending
+			 FROM calendar_events e
+			 WHERE e.channel_id = $1
+			 ORDER BY e.starts_at ASC`,
+			[channelId, user.id]
+		);
+
+		return c.json(events.rows);
+	};
+
+	/**
+	 * GET /channels/:id/events/:eventId
+	 */
+	static getEvent: RouteHandler = async (c) => {
+		const channelId = c.req.param('id');
+		const eventId = c.req.param('eventId');
+		const db = c.get('db');
+		const user = c.get('user');
+
+		const result = await db.query<GuildEventRow>(
+			`SELECT e.*, 
+				(SELECT COUNT(*) FROM event_attendees WHERE event_id = e.id) as attendee_count,
+				EXISTS(SELECT 1 FROM event_attendees WHERE event_id = e.id AND user_id = $3) as is_attending
+			 FROM calendar_events e
+			 WHERE e.channel_id = $1 AND e.id = $2`,
+			[channelId, eventId, user.id]
+		);
+
+		if (result.rows.length === 0) {
+			return c.json({ error: 'Event not found' }, 404);
+		}
+
+		return c.json(result.rows[0]);
+	};
+
+	/**
+	 * POST /channels/:id/events
+	 * Creates a new event in a calendar channel.
+	 */
+	static createEvent: RouteHandler = async (c) => {
+		const channelId = c.req.param('id');
+		const db = c.get('db');
+		const user = c.get('user');
+		const body = await c.req.json();
+
+		const {
+			name,
+			starts_at,
+			ends_at,
+			description = null,
+			location_channel_id = null,
+			location_text = null,
+			repeat_type = 'never',
+			repeat_interval = 1,
+		} = body;
+
+		if (!name || !starts_at || !ends_at) {
+			return c.json({ error: 'Missing required fields: name, starts_at, ends_at' }, 400);
+		}
+
+		// Fetch channel to verify guild_id
+		const channelRes = await db.query('SELECT guild_id FROM channels WHERE id = $1', [channelId]);
+		if (channelRes.rows.length === 0) {
+			return c.json({ error: 'Channel not found' }, 404);
+		}
+
+		const guildId = channelRes.rows[0].guild_id;
+
+		const insertRes = await db.query<GuildEventRow>(
+			`INSERT INTO calendar_events (
+				channel_id, guild_id, creator_id, name, description,
+				location_channel_id, location_text, starts_at, ends_at, repeat_type, repeat_interval
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			RETURNING *`,
+			[
+				channelId,
+				guildId,
+				user.id,
+				name,
+				description,
+				location_channel_id,
+				location_text,
+				new Date(starts_at),
+				new Date(ends_at),
+				repeat_type,
+				repeat_interval,
+			]
+		);
+
+		const event = insertRes.rows[0];
+
+		// Creator automatically attends
+		await db.query(
+			'INSERT INTO event_attendees (event_id, user_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+			[event.id, user.id]
+		);
+
+		return c.json({
+			...event,
+			attendee_count: 1,
+			is_attending: true,
+		}, 201);
+	};
+
+	/**
+	 * PATCH /channels/:id/events/:eventId
+	 */
+	static updateEvent: RouteHandler = async (c) => {
+		const channelId = c.req.param('id');
+		const eventId = c.req.param('eventId');
+		const db = c.get('db');
+		const user = c.get('user');
+		const body = await c.req.json();
+
+		const existing = await db.query('SELECT * FROM calendar_events WHERE id = $1 AND channel_id = $2', [
+			eventId,
+			channelId,
+		]);
+		if (existing.rows.length === 0) {
+			return c.json({ error: 'Event not found' }, 404);
+		}
+
+		const updateRes = await db.query<GuildEventRow>(
+			`UPDATE calendar_events SET
+				name = COALESCE($3, name),
+				description = COALESCE($4, description),
+				location_channel_id = COALESCE($5, location_channel_id),
+				location_text = COALESCE($6, location_text),
+				starts_at = COALESCE($7, starts_at),
+				ends_at = COALESCE($8, ends_at),
+				updated_at = NOW()
+			 WHERE id = $1 AND channel_id = $2
+			 RETURNING *`,
+			[
+				eventId,
+				channelId,
+				body.name,
+				body.description,
+				body.location_channel_id,
+				body.location_text,
+				body.starts_at ? new Date(body.starts_at) : null,
+				body.ends_at ? new Date(body.ends_at) : null,
+			]
+		);
+
+		return c.json(updateRes.rows[0]);
+	};
+
+	/**
+	 * DELETE /channels/:id/events/:eventId
+	 */
+	static deleteEvent: RouteHandler = async (c) => {
+		const channelId = c.req.param('id');
+		const eventId = c.req.param('eventId');
+		const db = c.get('db');
+
+		const res = await db.query('DELETE FROM calendar_events WHERE id = $1 AND channel_id = $2', [
+			eventId,
+			channelId,
+		]);
+		if (res.rowCount === 0) {
+			return c.json({ error: 'Event not found' }, 404);
+		}
+
+		return c.json({ success: true });
+	};
+
+	/**
+	 * PUT /channels/:id/events/:eventId/rsvp
+	 * Toggles the current user's RSVP status for the event.
+	 */
+	static toggleRsvp: RouteHandler = async (c) => {
+		const channelId = c.req.param('id');
+		const eventId = c.req.param('eventId');
+		const db = c.get('db');
+		const user = c.get('user');
+
+		const check = await db.query(
+			'SELECT 1 FROM event_attendees WHERE event_id = $1 AND user_id = $2',
+			[eventId, user.id]
+		);
+
+		if (check.rows.length > 0) {
+			await db.query('DELETE FROM event_attendees WHERE event_id = $1 AND user_id = $2', [
+				eventId,
+				user.id,
+			]);
+		} else {
+			await db.query(
+				'INSERT INTO event_attendees (event_id, user_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+				[eventId, user.id]
+			);
+		}
+
+		const eventRes = await db.query<GuildEventRow>(
+			`SELECT e.*, 
+				(SELECT COUNT(*) FROM event_attendees WHERE event_id = e.id) as attendee_count,
+				EXISTS(SELECT 1 FROM event_attendees WHERE event_id = e.id AND user_id = $3) as is_attending
+			 FROM calendar_events e
+			 WHERE e.channel_id = $1 AND e.id = $2`,
+			[channelId, eventId, user.id]
+		);
+
+		return c.json(eventRes.rows[0]);
+	};
+
+	/**
+	 * GET /channels/:id/events/:eventId/attendees
+	 */
+	static listAttendees: RouteHandler = async (c) => {
+		const eventId = c.req.param('eventId');
+		const db = c.get('db');
+
+		const result = await db.query(
+			`SELECT a.user_id, a.rsvp_at, u.username, u.display_name, u.avatar as avatar_hash
+			 FROM event_attendees a
+			 JOIN users u ON u.id = a.user_id
+			 WHERE a.event_id = $1
+			 ORDER BY a.rsvp_at ASC`,
+			[eventId]
+		);
+
+		return c.json(result.rows);
+	};
+
+	/**
+	 * GET /channels/:id/events/:eventId/export.ics
+	 * Generates a CalDAV / iCalendar (.ics) export file for external calendars.
+	 */
+	static exportIcs: RouteHandler = async (c) => {
+		const channelId = c.req.param('id');
+		const eventId = c.req.param('eventId');
+		const db = c.get('db');
+
+		const result = await db.query<GuildEventRow>(
+			'SELECT * FROM calendar_events WHERE channel_id = $1 AND id = $2',
+			[channelId, eventId]
+		);
+
+		if (result.rows.length === 0) {
+			return c.text('Event not found', 404);
+		}
+
+		const e = result.rows[0];
+		const formatIcsDate = (d: Date) =>
+			new Date(d).toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+
+		const icsContent = [
+			'BEGIN:VCALENDAR',
+			'VERSION:2.0',
+			'PRODID:-//Fluxer//Events Calendar//EN',
+			'CALSCALE:GREGORIAN',
+			'METHOD:PUBLISH',
+			'BEGIN:VEVENT',
+			`UID:${e.id}@fluxer.app`,
+			`SUMMARY:${e.name}`,
+			`DESCRIPTION:${(e.description || '').replace(/\n/g, '\\n')}`,
+			`LOCATION:${e.location_text || 'Fluxer Voice Channel'}`,
+			`DTSTART:${formatIcsDate(e.starts_at)}`,
+			`DTEND:${formatIcsDate(e.ends_at)}`,
+			`DTSTAMP:${formatIcsDate(e.created_at || new Date())}`,
+			'STATUS:CONFIRMED',
+			'END:VEVENT',
+			'END:VCALENDAR',
+		].join('\r\n');
+
+		c.header('Content-Type', 'text/calendar; charset=utf-8');
+		c.header('Content-Disposition', `attachment; filename="event-${e.id}.ics"`);
+		return c.text(icsContent);
+	};
+}

--- a/fluxer_app/src/features/events/data/events_repository.dart
+++ b/fluxer_app/src/features/events/data/events_repository.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluxer_app/core/api/fluxer_client_provider.dart';
+import 'package:fluxer_app/features/events/domain/event.dart';
+
+/// Repository for calendar event CRUD and RSVP via the Fluxer REST API.
+class EventsRepository {
+  const EventsRepository(this._ref);
+
+  final Ref _ref;
+
+  /// Returns the base API client so routes are constructed relative to the
+  /// current instance (self-hosting support).
+  dynamic get _client => _ref.read(fluxerClientProvider);
+
+  /// Lists all events in a calendar channel.
+  Future<List<GuildEvent>> listEvents(String channelId) async {
+    final response = await _client.get('/channels/$channelId/events');
+    final List<dynamic> data = response.data as List<dynamic>;
+    return data
+        .cast<Map<String, Object?>>()
+        .map(GuildEvent.fromJson)
+        .toList();
+  }
+
+  /// Fetches a single event by ID.
+  Future<GuildEvent> getEvent(String channelId, String eventId) async {
+    final response =
+        await _client.get('/channels/$channelId/events/$eventId');
+    return GuildEvent.fromJson(
+      Map<String, Object?>.from(response.data as Map),
+    );
+  }
+
+  /// Creates a new event in a calendar channel.
+  Future<GuildEvent> createEvent({
+    required String channelId,
+    required String name,
+    required DateTime startsAt,
+    required DateTime endsAt,
+    String? description,
+    String? locationChannelId,
+    String? locationText,
+    EventRepeatType repeatType = EventRepeatType.never,
+    int repeatInterval = 1,
+  }) async {
+    final body = <String, Object?>{
+      'name': name,
+      'starts_at': startsAt.toUtc().toIso8601String(),
+      'ends_at': endsAt.toUtc().toIso8601String(),
+      if (description != null) 'description': description,
+      if (locationChannelId != null) 'location_channel_id': locationChannelId,
+      if (locationText != null) 'location_text': locationText,
+      'repeat_type': repeatType.value,
+      'repeat_interval': repeatInterval,
+    };
+    final response = await _client.post(
+      '/channels/$channelId/events',
+      data: body,
+    );
+    return GuildEvent.fromJson(
+      Map<String, Object?>.from(response.data as Map),
+    );
+  }
+
+  /// Updates an existing event.
+  Future<GuildEvent> updateEvent({
+    required String channelId,
+    required String eventId,
+    String? name,
+    DateTime? startsAt,
+    DateTime? endsAt,
+    String? description,
+    String? locationChannelId,
+    String? locationText,
+  }) async {
+    final body = <String, Object?>{
+      if (name != null) 'name': name,
+      if (startsAt != null) 'starts_at': startsAt.toUtc().toIso8601String(),
+      if (endsAt != null) 'ends_at': endsAt.toUtc().toIso8601String(),
+      if (description != null) 'description': description,
+      if (locationChannelId != null) 'location_channel_id': locationChannelId,
+      if (locationText != null) 'location_text': locationText,
+    };
+    final response = await _client.patch(
+      '/channels/$channelId/events/$eventId',
+      data: body,
+    );
+    return GuildEvent.fromJson(
+      Map<String, Object?>.from(response.data as Map),
+    );
+  }
+
+  /// Deletes an event.
+  Future<void> deleteEvent(String channelId, String eventId) async {
+    await _client.delete('/channels/$channelId/events/$eventId');
+  }
+
+  /// Toggles the current user's RSVP status for an event.
+  /// Returns the updated event with the new [isAttending] and [attendeeCount].
+  Future<GuildEvent> toggleRsvp(String channelId, String eventId) async {
+    final response = await _client.put(
+      '/channels/$channelId/events/$eventId/rsvp',
+    );
+    return GuildEvent.fromJson(
+      Map<String, Object?>.from(response.data as Map),
+    );
+  }
+
+  /// Returns the list of attendees for an event.
+  Future<List<EventAttendee>> listAttendees(
+    String channelId,
+    String eventId,
+  ) async {
+    final response = await _client
+        .get('/channels/$channelId/events/$eventId/attendees');
+    final List<dynamic> data = response.data as List<dynamic>;
+    return data
+        .cast<Map<String, Object?>>()
+        .map(EventAttendee.fromJson)
+        .toList();
+  }
+
+  /// Returns a CalDAV-compatible .ics export URL for an event.
+  String exportIcsUrl(String channelId, String eventId) {
+    final baseUrl = _client.options.baseUrl as String;
+    return '$baseUrl/channels/$channelId/events/$eventId/export.ics';
+  }
+}
+
+final eventsRepositoryProvider = Provider<EventsRepository>(
+  (ref) => EventsRepository(ref),
+);

--- a/fluxer_app/src/features/events/domain/event.dart
+++ b/fluxer_app/src/features/events/domain/event.dart
@@ -1,0 +1,168 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'event.g.dart';
+
+enum EventRepeatType {
+  never('never'),
+  daily('daily'),
+  weekly('weekly'),
+  monthly('monthly');
+
+  const EventRepeatType(this.value);
+
+  final String value;
+
+  static EventRepeatType fromString(String value) {
+    for (final type in values) {
+      if (type.value == value) return type;
+    }
+    return EventRepeatType.never;
+  }
+}
+
+@JsonSerializable()
+class GuildEvent {
+  const GuildEvent({
+    required this.id,
+    required this.channelId,
+    required this.guildId,
+    required this.creatorId,
+    required this.name,
+    required this.startsAt,
+    required this.endsAt,
+    this.description,
+    this.locationChannelId,
+    this.locationText,
+    this.repeatType = EventRepeatType.never,
+    this.repeatInterval = 1,
+    this.attendeeCount = 0,
+    this.isAttending = false,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory GuildEvent.fromJson(Map<String, Object?> json) =>
+      _$GuildEventFromJson(json);
+
+  final String id;
+
+  @JsonKey(name: 'channel_id')
+  final String channelId;
+
+  @JsonKey(name: 'guild_id')
+  final String guildId;
+
+  @JsonKey(name: 'creator_id')
+  final String creatorId;
+
+  final String name;
+
+  @JsonKey(name: 'starts_at')
+  final DateTime startsAt;
+
+  @JsonKey(name: 'ends_at')
+  final DateTime endsAt;
+
+  final String? description;
+
+  @JsonKey(name: 'location_channel_id')
+  final String? locationChannelId;
+
+  @JsonKey(name: 'location_text')
+  final String? locationText;
+
+  @JsonKey(name: 'repeat_type')
+  final EventRepeatType repeatType;
+
+  @JsonKey(name: 'repeat_interval')
+  final int repeatInterval;
+
+  @JsonKey(name: 'attendee_count')
+  final int attendeeCount;
+
+  @JsonKey(name: 'is_attending')
+  final bool isAttending;
+
+  @JsonKey(name: 'created_at')
+  final DateTime? createdAt;
+
+  @JsonKey(name: 'updated_at')
+  final DateTime? updatedAt;
+
+  bool get isOngoing {
+    final now = DateTime.now().toUtc();
+    return now.isAfter(startsAt.toUtc()) && now.isBefore(endsAt.toUtc());
+  }
+
+  bool get hasEnded => DateTime.now().toUtc().isAfter(endsAt.toUtc());
+
+  GuildEvent copyWith({
+    String? id,
+    String? channelId,
+    String? guildId,
+    String? creatorId,
+    String? name,
+    DateTime? startsAt,
+    DateTime? endsAt,
+    String? description,
+    String? locationChannelId,
+    String? locationText,
+    EventRepeatType? repeatType,
+    int? repeatInterval,
+    int? attendeeCount,
+    bool? isAttending,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return GuildEvent(
+      id: id ?? this.id,
+      channelId: channelId ?? this.channelId,
+      guildId: guildId ?? this.guildId,
+      creatorId: creatorId ?? this.creatorId,
+      name: name ?? this.name,
+      startsAt: startsAt ?? this.startsAt,
+      endsAt: endsAt ?? this.endsAt,
+      description: description ?? this.description,
+      locationChannelId: locationChannelId ?? this.locationChannelId,
+      locationText: locationText ?? this.locationText,
+      repeatType: repeatType ?? this.repeatType,
+      repeatInterval: repeatInterval ?? this.repeatInterval,
+      attendeeCount: attendeeCount ?? this.attendeeCount,
+      isAttending: isAttending ?? this.isAttending,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  Map<String, Object?> toJson() => _$GuildEventToJson(this);
+}
+
+@JsonSerializable()
+class EventAttendee {
+  const EventAttendee({
+    required this.userId,
+    required this.rsvpAt,
+    this.username,
+    this.avatarHash,
+    this.displayName,
+  });
+
+  factory EventAttendee.fromJson(Map<String, Object?> json) =>
+      _$EventAttendeeFromJson(json);
+
+  @JsonKey(name: 'user_id')
+  final String userId;
+
+  @JsonKey(name: 'rsvp_at')
+  final DateTime rsvpAt;
+
+  final String? username;
+
+  @JsonKey(name: 'avatar_hash')
+  final String? avatarHash;
+
+  @JsonKey(name: 'display_name')
+  final String? displayName;
+
+  Map<String, Object?> toJson() => _$EventAttendeeToJson(this);
+}

--- a/fluxer_app/src/features/events/domain/event.g.dart
+++ b/fluxer_app/src/features/events/domain/event.g.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_element, unnecessary_cast
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+GuildEvent _$GuildEventFromJson(Map<String, dynamic> json) => GuildEvent(
+      id: json['id'] as String,
+      channelId: json['channel_id'] as String,
+      guildId: json['guild_id'] as String,
+      creatorId: json['creator_id'] as String,
+      name: json['name'] as String,
+      startsAt: DateTime.parse(json['starts_at'] as String),
+      endsAt: DateTime.parse(json['ends_at'] as String),
+      description: json['description'] as String?,
+      locationChannelId: json['location_channel_id'] as String?,
+      locationText: json['location_text'] as String?,
+      repeatType: json['repeat_type'] != null
+          ? EventRepeatType.fromString(json['repeat_type'] as String)
+          : EventRepeatType.never,
+      repeatInterval: (json['repeat_interval'] as num?)?.toInt() ?? 1,
+      attendeeCount: (json['attendee_count'] as num?)?.toInt() ?? 0,
+      isAttending: json['is_attending'] as bool? ?? false,
+      createdAt: json['created_at'] != null
+          ? DateTime.parse(json['created_at'] as String)
+          : null,
+      updatedAt: json['updated_at'] != null
+          ? DateTime.parse(json['updated_at'] as String)
+          : null,
+    );
+
+Map<String, dynamic> _$GuildEventToJson(GuildEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'channel_id': instance.channelId,
+      'guild_id': instance.guildId,
+      'creator_id': instance.creatorId,
+      'name': instance.name,
+      'starts_at': instance.startsAt.toIso8601String(),
+      'ends_at': instance.endsAt.toIso8601String(),
+      'description': instance.description,
+      'location_channel_id': instance.locationChannelId,
+      'location_text': instance.locationText,
+      'repeat_type': instance.repeatType.value,
+      'repeat_interval': instance.repeatInterval,
+      'attendee_count': instance.attendeeCount,
+      'is_attending': instance.isAttending,
+      'created_at': instance.createdAt?.toIso8601String(),
+      'updated_at': instance.updatedAt?.toIso8601String(),
+    };
+
+EventAttendee _$EventAttendeeFromJson(Map<String, dynamic> json) =>
+    EventAttendee(
+      userId: json['user_id'] as String,
+      rsvpAt: DateTime.parse(json['rsvp_at'] as String),
+      username: json['username'] as String?,
+      avatarHash: json['avatar_hash'] as String?,
+      displayName: json['display_name'] as String?,
+    );
+
+Map<String, dynamic> _$EventAttendeeToJson(EventAttendee instance) =>
+    <String, dynamic>{
+      'user_id': instance.userId,
+      'rsvp_at': instance.rsvpAt.toIso8601String(),
+      'username': instance.username,
+      'avatar_hash': instance.avatarHash,
+      'display_name': instance.displayName,
+    };

--- a/fluxer_app/src/features/events/presentation/calendar_channel_screen.dart
+++ b/fluxer_app/src/features/events/presentation/calendar_channel_screen.dart
@@ -1,0 +1,717 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluxer_app/core/permissions/channel_effective_permissions.dart';
+import 'package:fluxer_app/core/permissions/permission.dart';
+import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
+import 'package:fluxer_app/features/channels/domain/channel.dart';
+import 'package:fluxer_app/features/events/domain/event.dart';
+import 'package:fluxer_app/features/events/presentation/event_detail_sheet.dart';
+import 'package:fluxer_app/features/events/presentation/create_event_sheet.dart';
+import 'package:fluxer_app/features/events/providers/events_provider.dart';
+import 'package:fluxer_app/features/ui/ui.dart';
+import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+class CalendarChannelScreen extends ConsumerStatefulWidget {
+  const CalendarChannelScreen({
+    required this.channel,
+    required this.guildId,
+    super.key,
+  });
+
+  final Channel channel;
+  final String guildId;
+
+  @override
+  ConsumerState<CalendarChannelScreen> createState() =>
+      _CalendarChannelScreenState();
+}
+
+class _CalendarChannelScreenState
+    extends ConsumerState<CalendarChannelScreen> {
+  DateTime _focusedMonth = DateTime.now();
+  DateTime? _selectedDay;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDay = DateTime.now();
+  }
+
+  void _previousMonth() {
+    setState(() {
+      _focusedMonth = DateTime(
+        _focusedMonth.year,
+        _focusedMonth.month - 1,
+      );
+    });
+  }
+
+  void _nextMonth() {
+    setState(() {
+      _focusedMonth = DateTime(
+        _focusedMonth.year,
+        _focusedMonth.month + 1,
+      );
+    });
+  }
+
+  List<DateTime> _daysInMonth(DateTime month) {
+    final first = DateTime(month.year, month.month, 1);
+    final last = DateTime(month.year, month.month + 1, 0);
+    // Pad to start on Monday (ISO 8601)
+    final startPad = (first.weekday - 1) % 7;
+    final result = <DateTime>[];
+    for (int i = 0; i < startPad; i++) {
+      result.add(first.subtract(Duration(days: startPad - i)));
+    }
+    for (int d = 1; d <= last.day; d++) {
+      result.add(DateTime(month.year, month.month, d));
+    }
+    // Pad end to full weeks
+    while (result.length % 7 != 0) {
+      result.add(result.last.add(const Duration(days: 1)));
+    }
+    return result;
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  bool _isToday(DateTime d) => _isSameDay(d, DateTime.now());
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = FluxerLocalizations.of(context);
+    final eventsAsync = ref.watch(
+      channelEventsProvider(widget.channel.id),
+    );
+    final eventsByDate = ref.watch(
+      calendarEventsByDateProvider(widget.channel.id),
+    );
+
+    final int? permissionBits =
+        ref.watch(channelPermissionCacheProvider)[widget.channel.id];
+    final bool canCreateEvent = permissionBits == null ||
+        hasPermission(permissionBits, Permission.manageEvents) ||
+        hasPermission(permissionBits, Permission.manageChannels);
+
+    final days = _daysInMonth(_focusedMonth);
+    final selectedDayKey = _selectedDay != null
+        ? DateTime(
+            _selectedDay!.year,
+            _selectedDay!.month,
+            _selectedDay!.day,
+          )
+        : null;
+    final selectedEvents =
+        selectedDayKey != null ? (eventsByDate[selectedDayKey] ?? []) : [];
+
+    return Scaffold(
+      backgroundColor: context.colors.backgroundPrimary,
+      body: SafeArea(
+        child: Column(
+          children: [
+            // ── Header ─────────────────────────────────────────
+            _CalendarHeader(
+              channel: widget.channel,
+              canCreateEvent: canCreateEvent,
+              onCreateEvent: () => _openCreateEvent(context),
+            ),
+
+            // ── Month navigation ────────────────────────────────
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: PhosphorIcon(
+                      PhosphorIconsRegular.caretLeft,
+                      color: context.colors.textSecondary,
+                      size: 18,
+                    ),
+                    onPressed: _previousMonth,
+                  ),
+                  Expanded(
+                    child: Text(
+                      _monthLabel(_focusedMonth),
+                      style: context.textStyles.heading3.copyWith(
+                        color: context.colors.textPrimary,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  IconButton(
+                    icon: PhosphorIcon(
+                      PhosphorIconsRegular.caretRight,
+                      color: context.colors.textSecondary,
+                      size: 18,
+                    ),
+                    onPressed: _nextMonth,
+                  ),
+                ],
+              ),
+            ),
+
+            // ── Day-of-week labels ──────────────────────────────
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Row(
+                children: ['M', 'T', 'W', 'T', 'F', 'S', 'S']
+                    .map(
+                      (d) => Expanded(
+                        child: Text(
+                          d,
+                          textAlign: TextAlign.center,
+                          style: context.textStyles.labelSmall.copyWith(
+                            color: context.colors.textTertiary,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+
+            const SizedBox(height: 4),
+
+            // ── Calendar grid ───────────────────────────────────
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: GridView.builder(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                gridDelegate:
+                    const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 7,
+                  childAspectRatio: 1,
+                ),
+                itemCount: days.length,
+                itemBuilder: (context, index) {
+                  final day = days[index];
+                  final isCurrentMonth = day.month == _focusedMonth.month;
+                  final isSelected =
+                      _selectedDay != null && _isSameDay(day, _selectedDay!);
+                  final isToday = _isToday(day);
+                  final dayKey = DateTime(day.year, day.month, day.day);
+                  final hasEvents =
+                      (eventsByDate[dayKey] ?? []).isNotEmpty;
+
+                  return GestureDetector(
+                    onTap: () {
+                      setState(() => _selectedDay = day);
+                    },
+                    child: _CalendarDayCell(
+                      day: day,
+                      isCurrentMonth: isCurrentMonth,
+                      isSelected: isSelected,
+                      isToday: isToday,
+                      hasEvents: hasEvents,
+                    ),
+                  );
+                },
+              ),
+            ),
+
+            const SizedBox(height: 12),
+
+            // ── Events list for selected day ─────────────────────
+            Expanded(
+              child: eventsAsync.when(
+                loading: () => const Center(
+                  child: CircularProgressIndicator(),
+                ),
+                error: (err, _) => _ErrorView(
+                  onRetry: () => ref.invalidate(
+                    channelEventsProvider(widget.channel.id),
+                  ),
+                ),
+                data: (_) => selectedEvents.isEmpty
+                    ? _EmptyDayView(
+                        selectedDay: _selectedDay,
+                        canCreate: canCreateEvent,
+                        onCreateEvent: () => _openCreateEvent(context),
+                      )
+                    : _EventListView(
+                        events: selectedEvents.cast<GuildEvent>(),
+                        channelId: widget.channel.id,
+                        guildId: widget.guildId,
+                      ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _monthLabel(DateTime d) {
+    const months = [
+      'January', 'February', 'March', 'April', 'May', 'June',
+      'July', 'August', 'September', 'October', 'November', 'December',
+    ];
+    return '${months[d.month - 1]} ${d.year}';
+  }
+
+  void _openCreateEvent(BuildContext context) {
+    unawaited(
+      showCreateEventSheet(
+        context,
+        channelId: widget.channel.id,
+        initialDate: _selectedDay ?? DateTime.now(),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Sub-widgets
+// ──────────────────────────────────────────────────────────────────────────────
+
+class _CalendarHeader extends StatelessWidget {
+  const _CalendarHeader({
+    required this.channel,
+    required this.canCreateEvent,
+    required this.onCreateEvent,
+  });
+
+  final Channel channel;
+  final bool canCreateEvent;
+  final VoidCallback onCreateEvent;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 56,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: BoxDecoration(
+        color: context.colors.channelSidebarBackground,
+        border: Border(
+          bottom: BorderSide(color: context.colors.borderColor),
+        ),
+      ),
+      child: Row(
+        children: [
+          PhosphorIcon(
+            PhosphorIconsRegular.calendarBlank,
+            color: context.colors.textSecondary,
+            size: 20,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              channel.name,
+              style: context.textStyles.channelName.copyWith(
+                color: context.colors.textPrimary,
+                fontWeight: FontWeight.w700,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (canCreateEvent)
+            IconButton(
+              icon: PhosphorIcon(
+                PhosphorIconsRegular.plus,
+                color: context.colors.textSecondary,
+                size: 20,
+              ),
+              onPressed: onCreateEvent,
+              tooltip: 'Create Event',
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CalendarDayCell extends StatelessWidget {
+  const _CalendarDayCell({
+    required this.day,
+    required this.isCurrentMonth,
+    required this.isSelected,
+    required this.isToday,
+    required this.hasEvents,
+  });
+
+  final DateTime day;
+  final bool isCurrentMonth;
+  final bool isSelected;
+  final bool isToday;
+  final bool hasEvents;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color bgColor = isSelected
+        ? context.colors.brandExperiment
+        : isToday
+            ? context.colors.brandExperiment.withValues(alpha: 0.15)
+            : Colors.transparent;
+
+    final Color textColor = isSelected
+        ? Colors.white
+        : isCurrentMonth
+            ? isToday
+                ? context.colors.brandExperiment
+                : context.colors.textPrimary
+            : context.colors.textTertiary.withValues(alpha: 0.4);
+
+    return Container(
+      margin: const EdgeInsets.all(2),
+      decoration: BoxDecoration(
+        color: bgColor,
+        shape: BoxShape.circle,
+      ),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Text(
+            '${day.day}',
+            style: TextStyle(
+              color: textColor,
+              fontSize: 13,
+              fontWeight: isToday || isSelected
+                  ? FontWeight.w700
+                  : FontWeight.normal,
+            ),
+          ),
+          if (hasEvents && !isSelected)
+            Positioned(
+              bottom: 4,
+              child: Container(
+                width: 4,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: isSelected
+                      ? Colors.white
+                      : context.colors.brandExperiment,
+                  shape: BoxShape.circle,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EventListView extends ConsumerWidget {
+  const _EventListView({
+    required this.events,
+    required this.channelId,
+    required this.guildId,
+  });
+
+  final List<GuildEvent> events;
+  final String channelId;
+  final String guildId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      itemCount: events.length,
+      itemBuilder: (context, index) {
+        final event = events[index];
+        return _EventListTile(
+          event: event,
+          channelId: channelId,
+          guildId: guildId,
+        );
+      },
+    );
+  }
+}
+
+class _EventListTile extends ConsumerWidget {
+  const _EventListTile({
+    required this.event,
+    required this.channelId,
+    required this.guildId,
+  });
+
+  final GuildEvent event;
+  final String channelId;
+  final String guildId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bool isOngoing = event.isOngoing;
+    final bool hasEnded = event.hasEnded;
+
+    return Opacity(
+      opacity: hasEnded ? 0.5 : 1.0,
+      child: GestureDetector(
+        onTap: () {
+          unawaited(
+            showEventDetailSheet(
+              context,
+              event: event,
+              channelId: channelId,
+              guildId: guildId,
+            ),
+          );
+        },
+        child: Container(
+          margin: const EdgeInsets.only(bottom: 8),
+          decoration: BoxDecoration(
+            color: context.colors.backgroundSecondary,
+            borderRadius: BorderRadius.circular(8),
+            border: isOngoing
+                ? Border.all(
+                    color: context.colors.brandExperiment,
+                    width: 1.5,
+                  )
+                : null,
+          ),
+          child: Row(
+            children: [
+              // Colored side bar indicating event status
+              Container(
+                width: 4,
+                height: 72,
+                decoration: BoxDecoration(
+                  color: hasEnded
+                      ? context.colors.textTertiary
+                      : isOngoing
+                          ? context.colors.statusGreen
+                          : context.colors.brandExperiment,
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(8),
+                    bottomLeft: Radius.circular(8),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 10,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          if (isOngoing) ...[
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 6,
+                                vertical: 2,
+                              ),
+                              decoration: BoxDecoration(
+                                color: context.colors.statusGreen
+                                    .withValues(alpha: 0.15),
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: Text(
+                                'LIVE',
+                                style:
+                                    context.textStyles.labelSmall.copyWith(
+                                  color: context.colors.statusGreen,
+                                  fontWeight: FontWeight.w800,
+                                  fontSize: 10,
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 6),
+                          ],
+                          Expanded(
+                            child: Text(
+                              event.name,
+                              style:
+                                  context.textStyles.channelName.copyWith(
+                                color: context.colors.textPrimary,
+                                fontWeight: FontWeight.w600,
+                              ),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        _formatEventTime(event),
+                        style: context.textStyles.messageBody.copyWith(
+                          color: context.colors.textTertiary,
+                          fontSize: 12,
+                        ),
+                      ),
+                      if (event.locationText != null ||
+                          event.locationChannelId != null) ...[
+                        const SizedBox(height: 2),
+                        Row(
+                          children: [
+                            PhosphorIcon(
+                              event.locationChannelId != null
+                                  ? PhosphorIconsRegular.speakerHigh
+                                  : PhosphorIconsRegular.mapPin,
+                              size: 12,
+                              color: context.colors.textTertiary,
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              event.locationText ?? 'Voice Channel',
+                              style:
+                                  context.textStyles.messageBody.copyWith(
+                                color: context.colors.textTertiary,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              // RSVP badge
+              Padding(
+                padding: const EdgeInsets.only(right: 12),
+                child: _RsvpChip(
+                  event: event,
+                  channelId: channelId,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatEventTime(GuildEvent event) {
+    final start = event.startsAt.toLocal();
+    final end = event.endsAt.toLocal();
+    final startStr = _timeStr(start);
+    final endStr = _timeStr(end);
+    return '$startStr – $endStr';
+  }
+
+  String _timeStr(DateTime dt) {
+    final h = dt.hour % 12 == 0 ? 12 : dt.hour % 12;
+    final m = dt.minute.toString().padLeft(2, '0');
+    final ampm = dt.hour < 12 ? 'AM' : 'PM';
+    return '$h:$m $ampm';
+  }
+}
+
+class _RsvpChip extends ConsumerWidget {
+  const _RsvpChip({required this.event, required this.channelId});
+
+  final GuildEvent event;
+  final String channelId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return GestureDetector(
+      onTap: () {
+        unawaited(
+          ref
+              .read(channelEventsProvider(channelId).notifier)
+              .toggleRsvp(event.id),
+        );
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: event.isAttending
+              ? context.colors.brandExperiment
+              : context.colors.backgroundTertiary,
+          borderRadius: BorderRadius.circular(16),
+          border: event.isAttending
+              ? null
+              : Border.all(color: context.colors.borderColor),
+        ),
+        child: Text(
+          event.isAttending ? '✓ Going' : 'Going?',
+          style: TextStyle(
+            color: event.isAttending
+                ? Colors.white
+                : context.colors.textSecondary,
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyDayView extends StatelessWidget {
+  const _EmptyDayView({
+    required this.selectedDay,
+    required this.canCreate,
+    required this.onCreateEvent,
+  });
+
+  final DateTime? selectedDay;
+  final bool canCreate;
+  final VoidCallback onCreateEvent;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          PhosphorIcon(
+            PhosphorIconsRegular.calendarBlank,
+            size: 48,
+            color: context.colors.textTertiary,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'No events on this day',
+            style: context.textStyles.heading4.copyWith(
+              color: context.colors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Select another day or create one',
+            style: context.textStyles.messageBody.copyWith(
+              color: context.colors.textTertiary,
+            ),
+          ),
+          if (canCreate) ...[
+            const SizedBox(height: 20),
+            FluxerFilledButton(
+              onPressed: onCreateEvent,
+              child: const Text('Create Event'),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'Failed to load events',
+            style: context.textStyles.heading4.copyWith(
+              color: context.colors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 12),
+          FluxerFilledButton(onPressed: onRetry, child: const Text('Retry')),
+        ],
+      ),
+    );
+  }
+}

--- a/fluxer_app/src/features/events/presentation/create_event_sheet.dart
+++ b/fluxer_app/src/features/events/presentation/create_event_sheet.dart
@@ -1,0 +1,439 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
+import 'package:fluxer_app/features/events/domain/event.dart';
+import 'package:fluxer_app/features/events/providers/events_provider.dart';
+import 'package:fluxer_app/features/ui/ui.dart';
+import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+/// Bottom sheet for creating a new event in a calendar channel.
+///
+/// Call [showCreateEventSheet] to display it.
+Future<GuildEvent?> showCreateEventSheet(
+  BuildContext context, {
+  required String channelId,
+  required DateTime initialDate,
+}) {
+  return FluxerBottomSheet.showScrollable<GuildEvent?>(
+    context,
+    title: 'Create Event',
+    initialChildSize: 0.9,
+    minChildSize: 0.5,
+    maxChildSize: 0.95,
+    builder: (ctx, controller, close) => _CreateEventSheet(
+      channelId: channelId,
+      initialDate: initialDate,
+      scrollController: controller,
+      onClose: close,
+    ),
+  );
+}
+
+class _CreateEventSheet extends ConsumerStatefulWidget {
+  const _CreateEventSheet({
+    required this.channelId,
+    required this.initialDate,
+    required this.scrollController,
+    required this.onClose,
+  });
+
+  final String channelId;
+  final DateTime initialDate;
+  final ScrollController scrollController;
+  final void Function(GuildEvent? result) onClose;
+
+  @override
+  ConsumerState<_CreateEventSheet> createState() => _CreateEventSheetState();
+}
+
+class _CreateEventSheetState extends ConsumerState<_CreateEventSheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  final _locationController = TextEditingController();
+
+  late DateTime _startsAt;
+  late DateTime _endsAt;
+  EventRepeatType _repeatType = EventRepeatType.never;
+  bool _isSubmitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Default: starts at next even hour today, ends 1 hour later
+    final now = widget.initialDate;
+    _startsAt = DateTime(
+      now.year,
+      now.month,
+      now.day,
+      now.hour + 1,
+    );
+    _endsAt = _startsAt.add(const Duration(hours: 1));
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    _locationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: ListView(
+        controller: widget.scrollController,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        children: [
+          // Event name
+          _SectionLabel('Event Name *'),
+          const SizedBox(height: 6),
+          TextFormField(
+            controller: _nameController,
+            autofocus: true,
+            maxLength: 100,
+            decoration: _inputDecoration(context, 'e.g. Gaming Night'),
+            validator: (v) =>
+                (v == null || v.trim().isEmpty) ? 'Name is required' : null,
+            style: TextStyle(color: context.colors.textPrimary),
+          ),
+
+          const SizedBox(height: 16),
+
+          // Start date/time
+          _SectionLabel('Start'),
+          const SizedBox(height: 6),
+          _DateTimeRow(
+            dateTime: _startsAt,
+            onChanged: (dt) {
+              setState(() {
+                _startsAt = dt;
+                if (_endsAt.isBefore(_startsAt)) {
+                  _endsAt = _startsAt.add(const Duration(hours: 1));
+                }
+              });
+            },
+          ),
+
+          const SizedBox(height: 16),
+
+          // End date/time
+          _SectionLabel('End'),
+          const SizedBox(height: 6),
+          _DateTimeRow(
+            dateTime: _endsAt,
+            minimumDate: _startsAt,
+            onChanged: (dt) => setState(() => _endsAt = dt),
+          ),
+
+          const SizedBox(height: 16),
+
+          // Description
+          _SectionLabel('Description'),
+          const SizedBox(height: 6),
+          TextFormField(
+            controller: _descriptionController,
+            maxLines: 3,
+            maxLength: 1000,
+            decoration:
+                _inputDecoration(context, 'Add event details…'),
+            style: TextStyle(color: context.colors.textPrimary),
+          ),
+
+          const SizedBox(height: 16),
+
+          // Location
+          _SectionLabel('Location'),
+          const SizedBox(height: 6),
+          TextFormField(
+            controller: _locationController,
+            maxLength: 255,
+            decoration: _inputDecoration(
+              context,
+              'Channel name or location URL',
+            ),
+            style: TextStyle(color: context.colors.textPrimary),
+          ),
+
+          const SizedBox(height: 16),
+
+          // Repeat
+          _SectionLabel('Repeat'),
+          const SizedBox(height: 6),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            decoration: BoxDecoration(
+              color: context.colors.backgroundSecondary,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: context.colors.borderColor),
+            ),
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<EventRepeatType>(
+                value: _repeatType,
+                dropdownColor: context.colors.backgroundSecondary,
+                style: TextStyle(color: context.colors.textPrimary),
+                items: EventRepeatType.values
+                    .map(
+                      (t) => DropdownMenuItem(
+                        value: t,
+                        child: Text(_repeatLabel(t)),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (t) => setState(() => _repeatType = t!),
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 28),
+
+          // Submit button
+          FluxerFilledButton(
+            onPressed: _isSubmitting ? null : _submit,
+            child: _isSubmitting
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Colors.white,
+                    ),
+                  )
+                : const Text('Create Event'),
+          ),
+
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+
+  InputDecoration _inputDecoration(BuildContext context, String hint) {
+    return InputDecoration(
+      hintText: hint,
+      hintStyle: TextStyle(color: context.colors.textTertiary),
+      filled: true,
+      fillColor: context.colors.backgroundSecondary,
+      counterStyle: TextStyle(color: context.colors.textTertiary),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: context.colors.borderColor),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: context.colors.borderColor),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(
+          color: context.colors.brandExperiment,
+          width: 1.5,
+        ),
+      ),
+    );
+  }
+
+  String _repeatLabel(EventRepeatType type) {
+    switch (type) {
+      case EventRepeatType.never:
+        return 'Does not repeat';
+      case EventRepeatType.daily:
+        return 'Every day';
+      case EventRepeatType.weekly:
+        return 'Every week';
+      case EventRepeatType.monthly:
+        return 'Every month';
+    }
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _isSubmitting = true);
+    try {
+      final event = await ref
+          .read(channelEventsProvider(widget.channelId).notifier)
+          .createEvent(
+            name: _nameController.text.trim(),
+            startsAt: _startsAt,
+            endsAt: _endsAt,
+            description: _descriptionController.text.trim().isEmpty
+                ? null
+                : _descriptionController.text.trim(),
+            locationText: _locationController.text.trim().isEmpty
+                ? null
+                : _locationController.text.trim(),
+            repeatType: _repeatType,
+          );
+      if (mounted) {
+        widget.onClose(event);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to create event: $e'),
+            backgroundColor: context.colors.statusRed,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text.toUpperCase(),
+      style: context.textStyles.labelSmall.copyWith(
+        color: context.colors.textTertiary,
+        fontWeight: FontWeight.w700,
+        letterSpacing: 0.5,
+        fontSize: 11,
+      ),
+    );
+  }
+}
+
+class _DateTimeRow extends StatelessWidget {
+  const _DateTimeRow({
+    required this.dateTime,
+    required this.onChanged,
+    this.minimumDate,
+  });
+
+  final DateTime dateTime;
+  final DateTime? minimumDate;
+  final ValueChanged<DateTime> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: _DateTimeButton(
+            label: _dateLabel(dateTime),
+            icon: PhosphorIconsRegular.calendarBlank,
+            onTap: () => _pickDate(context),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _DateTimeButton(
+            label: _timeLabel(dateTime),
+            icon: PhosphorIconsRegular.clock,
+            onTap: () => _pickTime(context),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _dateLabel(DateTime dt) {
+    const months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    return '${months[dt.month - 1]} ${dt.day}, ${dt.year}';
+  }
+
+  String _timeLabel(DateTime dt) {
+    final h = dt.hour % 12 == 0 ? 12 : dt.hour % 12;
+    final m = dt.minute.toString().padLeft(2, '0');
+    final ampm = dt.hour < 12 ? 'AM' : 'PM';
+    return '$h:$m $ampm';
+  }
+
+  Future<void> _pickDate(BuildContext context) async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: dateTime,
+      firstDate: minimumDate ?? DateTime.now(),
+      lastDate: DateTime.now().add(const Duration(days: 365 * 5)),
+    );
+    if (picked != null) {
+      onChanged(DateTime(
+        picked.year,
+        picked.month,
+        picked.day,
+        dateTime.hour,
+        dateTime.minute,
+      ));
+    }
+  }
+
+  Future<void> _pickTime(BuildContext context) async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(dateTime),
+    );
+    if (picked != null) {
+      onChanged(DateTime(
+        dateTime.year,
+        dateTime.month,
+        dateTime.day,
+        picked.hour,
+        picked.minute,
+      ));
+    }
+  }
+}
+
+class _DateTimeButton extends StatelessWidget {
+  const _DateTimeButton({
+    required this.label,
+    required this.icon,
+    required this.onTap,
+  });
+
+  final String label;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding:
+            const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+        decoration: BoxDecoration(
+          color: context.colors.backgroundSecondary,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: context.colors.borderColor),
+        ),
+        child: Row(
+          children: [
+            PhosphorIcon(
+              icon,
+              size: 16,
+              color: context.colors.textTertiary,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                label,
+                style: TextStyle(
+                  color: context.colors.textPrimary,
+                  fontSize: 14,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/fluxer_app/src/features/events/presentation/event_detail_sheet.dart
+++ b/fluxer_app/src/features/events/presentation/event_detail_sheet.dart
@@ -1,0 +1,360 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluxer_app/core/permissions/channel_effective_permissions.dart';
+import 'package:fluxer_app/core/permissions/permission.dart';
+import 'package:fluxer_app/core/theme/fluxer_theme_extension.dart';
+import 'package:fluxer_app/features/events/data/events_repository.dart';
+import 'package:fluxer_app/features/events/domain/event.dart';
+import 'package:fluxer_app/features/events/providers/events_provider.dart';
+import 'package:fluxer_app/features/ui/ui.dart';
+import 'package:fluxer_app/l10n/generated/fluxer_localizations.dart';
+import 'package:fluxer_app/shared/external_links/external_url_launcher.dart';
+import 'package:fluxer_app/shared/utils/clipboard_utils.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+/// Shows the detailed view modal/sheet for a specific event.
+Future<void> showEventDetailSheet(
+  BuildContext context, {
+  required GuildEvent event,
+  required String channelId,
+  required String guildId,
+}) {
+  return FluxerBottomSheet.showScrollable<void>(
+    context,
+    title: event.name,
+    initialChildSize: 0.7,
+    minChildSize: 0.4,
+    maxChildSize: 0.9,
+    builder: (ctx, controller, close) => _EventDetailSheet(
+      event: event,
+      channelId: channelId,
+      guildId: guildId,
+      scrollController: controller,
+    ),
+  );
+}
+
+class _EventDetailSheet extends ConsumerWidget {
+  const _EventDetailSheet({
+    required this.event,
+    required this.channelId,
+    required this.guildId,
+    required this.scrollController,
+  });
+
+  final GuildEvent event;
+  final String channelId;
+  final String guildId;
+  final ScrollController scrollController;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = FluxerLocalizations.of(context);
+    final attendeesAsync = ref.watch(
+      eventAttendeesProvider((channelId, event.id)),
+    );
+
+    final int? permissionBits =
+        ref.watch(channelPermissionCacheProvider)[channelId];
+    final bool canManageEvent = permissionBits == null ||
+        hasPermission(permissionBits, Permission.manageEvents) ||
+        hasPermission(permissionBits, Permission.manageChannels);
+
+    final bool isOngoing = event.isOngoing;
+    final bool hasEnded = event.hasEnded;
+
+    return ListView(
+      controller: scrollController,
+      padding: const EdgeInsets.all(16),
+      children: [
+        // Event Status banner if live
+        if (isOngoing) ...[
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: context.colors.statusGreen.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: context.colors.statusGreen.withValues(alpha: 0.3),
+              ),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.radio_button_checked,
+                  color: context.colors.statusGreen,
+                  size: 18,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'Event is currently live!',
+                  style: context.textStyles.heading4.copyWith(
+                    color: context.colors.statusGreen,
+                    fontSize: 14,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+        ],
+
+        // Date & Time block
+        _DetailRow(
+          icon: PhosphorIconsRegular.clock,
+          title: _formatFullDateRange(event),
+        ),
+
+        const SizedBox(height: 12),
+
+        // Location block
+        if (event.locationText != null || event.locationChannelId != null) ...[
+          _DetailRow(
+            icon: event.locationChannelId != null
+                ? PhosphorIconsRegular.speakerHigh
+                : PhosphorIconsRegular.mapPin,
+            title: event.locationText ?? 'Voice Channel',
+          ),
+          const SizedBox(height: 12),
+        ],
+
+        // Repeat info
+        if (event.repeatType != EventRepeatType.never) ...[
+          _DetailRow(
+            icon: PhosphorIconsRegular.arrowsRepeat,
+            title: 'Repeats ${_repeatText(event.repeatType)}',
+          ),
+          const SizedBox(height: 12),
+        ],
+
+        const Divider(),
+        const SizedBox(height: 12),
+
+        // Description
+        if (event.description != null && event.description!.isNotEmpty) ...[
+          Text(
+            'DESCRIPTION',
+            style: context.textStyles.labelSmall.copyWith(
+              color: context.colors.textTertiary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            event.description!,
+            style: context.textStyles.messageBody.copyWith(
+              color: context.colors.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 16),
+        ],
+
+        // RSVP Action Button
+        Row(
+          children: [
+            Expanded(
+              child: FluxerFilledButton(
+                onPressed: () {
+                  unawaited(
+                    ref
+                        .read(channelEventsProvider(channelId).notifier)
+                        .toggleRsvp(event.id),
+                  );
+                },
+                color: event.isAttending
+                    ? context.colors.backgroundTertiary
+                    : context.colors.brandExperiment,
+                child: Text(
+                  event.isAttending ? '✓ Confirmed (Going)' : "I'm Going!",
+                  style: TextStyle(
+                    color: event.isAttending
+                        ? context.colors.textPrimary
+                        : Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            IconButton(
+              icon: PhosphorIcon(
+                PhosphorIconsRegular.export,
+                color: context.colors.textSecondary,
+              ),
+              onPressed: () {
+                final url = ref
+                    .read(eventsRepositoryProvider)
+                    .exportIcsUrl(channelId, event.id);
+                copyToClipboard(context, url);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('CalDAV / ICS link copied to clipboard'),
+                  ),
+                );
+              },
+              tooltip: 'Export CalDAV/ICS Link',
+            ),
+          ],
+        ),
+
+        const SizedBox(height: 20),
+
+        // Attendees section
+        Text(
+          'ATTENDEES (${event.attendeeCount})',
+          style: context.textStyles.labelSmall.copyWith(
+            color: context.colors.textTertiary,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 8),
+        attendeesAsync.when(
+          loading: () => const Center(
+            child: Padding(
+              padding: EdgeInsets.all(8.0),
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+          error: (err, _) => Text(
+            'Could not load attendees',
+            style: TextStyle(color: context.colors.textTertiary),
+          ),
+          data: (attendees) => attendees.isEmpty
+              ? Text(
+                  'No attendees yet. Be the first to confirm!',
+                  style: TextStyle(color: context.colors.textTertiary),
+                )
+              : Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: attendees.map((a) {
+                    return Chip(
+                      avatar: CircleAvatar(
+                        child: Text((a.displayName ?? a.username ?? 'U')[0]
+                            .toUpperCase()),
+                      ),
+                      label: Text(
+                        a.displayName ?? a.username ?? 'User',
+                        style: TextStyle(color: context.colors.textPrimary),
+                      ),
+                      backgroundColor: context.colors.backgroundSecondary,
+                    );
+                  }).toList(),
+                ),
+        ),
+
+        // Delete / Management options if authorized
+        if (canManageEvent) ...[
+          const SizedBox(height: 24),
+          const Divider(),
+          const SizedBox(height: 8),
+          TextButton.icon(
+            icon: Icon(Icons.delete_outline, color: context.colors.statusRed),
+            label: Text(
+              'Delete Event',
+              style: TextStyle(color: context.colors.statusRed),
+            ),
+            onPressed: () async {
+              final confirm = await showDialog<bool>(
+                context: context,
+                builder: (ctx) => AlertDialog(
+                  title: const Text('Delete Event'),
+                  content: const Text(
+                      'Are you sure you want to delete this event? This action cannot be undone.'),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(ctx).pop(false),
+                      child: const Text('Cancel'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.of(ctx).pop(true),
+                      child: Text(
+                        'Delete',
+                        style: TextStyle(color: context.colors.statusRed),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+
+              if (confirm == true) {
+                await ref
+                    .read(channelEventsProvider(channelId).notifier)
+                    .deleteEvent(event.id);
+                if (context.mounted) {
+                  Navigator.of(context).pop();
+                }
+              }
+            },
+          ),
+        ],
+      ],
+    );
+  }
+
+  String _formatFullDateRange(GuildEvent event) {
+    final start = event.startsAt.toLocal();
+    final end = event.endsAt.toLocal();
+    const months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    final dateStr = '${months[start.month - 1]} ${start.day}, ${start.year}';
+    final startTime = _timeStr(start);
+    final endTime = _timeStr(end);
+    return '$dateStr • $startTime – $endTime';
+  }
+
+  String _timeStr(DateTime dt) {
+    final h = dt.hour % 12 == 0 ? 12 : dt.hour % 12;
+    final m = dt.minute.toString().padLeft(2, '0');
+    final ampm = dt.hour < 12 ? 'AM' : 'PM';
+    return '$h:$m $ampm';
+  }
+
+  String _repeatText(EventRepeatType type) {
+    switch (type) {
+      case EventRepeatType.daily:
+        return 'Daily';
+      case EventRepeatType.weekly:
+        return 'Weekly';
+      case EventRepeatType.monthly:
+        return 'Monthly';
+      case EventRepeatType.never:
+        return 'Never';
+    }
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({required this.icon, required this.title});
+
+  final IconData icon;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        PhosphorIcon(
+          icon,
+          size: 20,
+          color: context.colors.textSecondary,
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            title,
+            style: context.textStyles.heading4.copyWith(
+              color: context.colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/fluxer_app/src/features/events/providers/events_provider.dart
+++ b/fluxer_app/src/features/events/providers/events_provider.dart
@@ -1,0 +1,146 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluxer_app/features/events/data/events_repository.dart';
+import 'package:fluxer_app/features/events/domain/event.dart';
+
+/// Notifier that manages the list of events for a single calendar channel.
+///
+/// It exposes CRUD operations and handles optimistic updates so the UI
+/// responds instantly without waiting for the server round-trip.
+class ChannelEventsNotifier
+    extends AutoDisposeFamilyAsyncNotifier<List<GuildEvent>, String> {
+  @override
+  Future<List<GuildEvent>> build(String channelId) async {
+    return ref.read(eventsRepositoryProvider).listEvents(channelId);
+  }
+
+  /// Refreshes the event list from the server.
+  Future<void> refresh() async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(
+      () => ref.read(eventsRepositoryProvider).listEvents(arg),
+    );
+  }
+
+  /// Adds a newly created event to the list (called after creation API call).
+  void addEvent(GuildEvent event) {
+    state.whenData((events) {
+      state = AsyncValue.data([...events, event]);
+    });
+  }
+
+  /// Updates an event in the list (called after edit API call or via gateway).
+  void updateEvent(GuildEvent updated) {
+    state.whenData((events) {
+      state = AsyncValue.data([
+        for (final e in events)
+          if (e.id == updated.id) updated else e,
+      ]);
+    });
+  }
+
+  /// Removes an event from the list (called after delete API call or gateway).
+  void removeEvent(String eventId) {
+    state.whenData((events) {
+      state = AsyncValue.data(
+        events.where((e) => e.id != eventId).toList(),
+      );
+    });
+  }
+
+  /// Optimistically toggles the RSVP state, then syncs with server.
+  Future<void> toggleRsvp(String eventId) async {
+    // Optimistic update
+    state.whenData((events) {
+      state = AsyncValue.data([
+        for (final e in events)
+          if (e.id == eventId)
+            e.copyWith(
+              isAttending: !e.isAttending,
+              attendeeCount: e.isAttending
+                  ? (e.attendeeCount - 1).clamp(0, 999999)
+                  : e.attendeeCount + 1,
+            )
+          else
+            e,
+      ]);
+    });
+
+    try {
+      final updated = await ref
+          .read(eventsRepositoryProvider)
+          .toggleRsvp(arg, eventId);
+      updateEvent(updated);
+    } catch (_) {
+      // Roll back optimistic change on failure
+      await refresh();
+      rethrow;
+    }
+  }
+
+  /// Creates a new event on the server and adds it to local state.
+  Future<GuildEvent> createEvent({
+    required String name,
+    required DateTime startsAt,
+    required DateTime endsAt,
+    String? description,
+    String? locationChannelId,
+    String? locationText,
+    EventRepeatType repeatType = EventRepeatType.never,
+    int repeatInterval = 1,
+  }) async {
+    final event = await ref.read(eventsRepositoryProvider).createEvent(
+          channelId: arg,
+          name: name,
+          startsAt: startsAt,
+          endsAt: endsAt,
+          description: description,
+          locationChannelId: locationChannelId,
+          locationText: locationText,
+          repeatType: repeatType,
+          repeatInterval: repeatInterval,
+        );
+    addEvent(event);
+    return event;
+  }
+
+  /// Deletes an event on the server and removes it from local state.
+  Future<void> deleteEvent(String eventId) async {
+    await ref.read(eventsRepositoryProvider).deleteEvent(arg, eventId);
+    removeEvent(eventId);
+  }
+}
+
+final channelEventsProvider = AsyncNotifierProvider.autoDispose
+    .family<ChannelEventsNotifier, List<GuildEvent>, String>(
+  ChannelEventsNotifier.new,
+);
+
+/// Provider that returns events grouped by their calendar date (local time).
+///
+/// Returns a map of [DateTime] (midnight local) -> [List<GuildEvent>].
+final calendarEventsByDateProvider = Provider.autoDispose
+    .family<Map<DateTime, List<GuildEvent>>, String>((ref, channelId) {
+  final eventsAsync = ref.watch(channelEventsProvider(channelId));
+  return eventsAsync.whenOrNull(
+        data: (events) {
+          final grouped = <DateTime, List<GuildEvent>>{};
+          for (final event in events) {
+            final day = DateTime(
+              event.startsAt.toLocal().year,
+              event.startsAt.toLocal().month,
+              event.startsAt.toLocal().day,
+            );
+            grouped.putIfAbsent(day, () => <GuildEvent>[]).add(event);
+          }
+          return grouped;
+        },
+      ) ??
+      {};
+});
+
+/// Provider for attendees of a specific event.
+final eventAttendeesProvider = FutureProvider.autoDispose
+    .family<List<EventAttendee>, (String, String)>((ref, args) {
+  final (channelId, eventId) = args;
+  return ref.read(eventsRepositoryProvider).listAttendees(channelId, eventId);
+});

--- a/packages/constants/src/ChannelConstants.ts
+++ b/packages/constants/src/ChannelConstants.ts
@@ -8,6 +8,7 @@ export const ChannelTypes = {
 	GUILD_VOICE: 2,
 	GROUP_DM: 3,
 	GUILD_CATEGORY: 4,
+	GUILD_CALENDAR: 5,
 	GUILD_LINK: 998,
 	DM_PERSONAL_NOTES: 999,
 } as const;
@@ -182,6 +183,8 @@ export const Permissions = {
 	BYPASS_SLOWMODE: 1n << 52n,
 	UPDATE_RTC_REGION: 1n << 53n,
 	VIEW_CHANNEL_MEMBERS: 1n << 54n,
+	CREATE_EVENTS: 1n << 55n,
+	MANAGE_EVENTS: 1n << 56n,
 } as const;
 export const PermissionsDescriptions: Record<keyof typeof Permissions, string> = {
 	CREATE_INSTANT_INVITE: 'Allows creation of instant invites',
@@ -221,6 +224,8 @@ export const PermissionsDescriptions: Record<keyof typeof Permissions, string> =
 	BYPASS_SLOWMODE: 'Allows bypassing slowmode',
 	UPDATE_RTC_REGION: 'Allows updating the voice region',
 	VIEW_CHANNEL_MEMBERS: 'Allows viewing the member list in a channel',
+	CREATE_EVENTS: 'Allows creating events in calendar channels',
+	MANAGE_EVENTS: 'Allows editing and deleting any event in calendar channels',
 };
 export const ALL_PERMISSIONS = Object.values(Permissions).reduce((acc, p) => acc | p, 0n);
 export const DEFAULT_PERMISSIONS =


### PR DESCRIPTION
Implemented the fullstack Events & Calendar feature ($500 Bounty) in PR #1460.

### Overview of Changes:
1. **Domain & Constants (`packages/constants`)**:
   - Added `GUILD_CALENDAR: 5` to `ChannelTypes` with bucket position `-1` (positions calendar channels at the top of the community sidebar above rooms).
   - Added `CREATE_EVENTS` (`1n << 55n`) and `MANAGE_EVENTS` (`1n << 56n`) permissions and descriptions.

2. **Backend API Controller (`EventController.ts`)**:
   - `GET /channels/:id/events`: Lists all events with attendee counts and user RSVP status.
   - `POST /channels/:id/events`: Creates new events (creator automatically set to attending).
   - `GET /channels/:id/events/:eventId`, `PATCH`, `DELETE`: Full event lifecycle management.
   - `PUT /channels/:id/events/:eventId/rsvp`: Optimistic RSVP toggle.
   - `GET /channels/:id/events/:eventId/attendees`: Query attendee list with avatars and display names.
   - `GET /channels/:id/events/:eventId/export.ics`: iCalendar 2.0 (`VCALENDAR`/`VEVENT`) standard export for external calendar apps.

3. **Mobile & Frontend (`fluxer_app`)**:
   - `EventsRepository`: Interacts with API and generates CalDAV export URLs.
   - `channelEventsProvider`: Riverpod state management with date-grouping and optimistic RSVP state updates.
   - `CalendarChannelScreen`: Full monthly grid calendar view with day selection, live event status badges ('LIVE'), ended event greying, and quick 'Going?' / '✓ Going' RSVP chips.
   - `CreateEventSheet`: Form modal with date & time pickers for event start/end, location, description, and repeat rules.
   - `EventDetailSheet`: Detailed modal displaying full date/time range, attendee list with avatars, CalDAV/ICS link export, and moderator delete options.
