### PR TITLE
fix: address issue #1463

### DIFF
--- a/fluxer_gateway/src/presence/presence.erl
+++ b/fluxer_gateway/src/presence/presence.erl
@@ -90,6 +90,10 @@ handle_call({session_connect, Request}, {Pid, _}, State) when is_map(Request), i
     ),
     presence_broadcast:send_cached_presences_to_session(Pid, FinalState),
     {reply, Reply, FinalState};
+handle_call({has_session, SessionId, SessionPid}, _From, State) when
+    is_binary(SessionId), is_pid(SessionPid)
+->
+    {reply, presence_session:has_session(SessionId, SessionPid, State), State};
 handle_call(get_current_visible_presence, _From, State) ->
     {reply, presence_broadcast:current_visible_presence(State), State};
 handle_call({terminate_session, SessionIdHashes}, _From, State) when is_list(SessionIdHashes) ->

--- a/fluxer_gateway/src/presence/presence_session.erl
+++ b/fluxer_gateway/src/presence/presence_session.erl
@@ -6,6 +6,7 @@
 -export([
     handle_session_connect/3,
     handle_presence_update/2,
+    has_session/3,
     dispatch_sessions_replace/1,
     notify_sessions_guild_join/2,
     notify_sessions_guild_leave/2,
@@ -30,6 +31,13 @@
 -type connect_request() :: map().
 -type update_request() :: map().
 -type session_ref_map() :: #{session_id() => map()}.
+
+-spec has_session(session_id(), pid(), state()) -> boolean().
+has_session(SessionId, Pid, State) when is_binary(SessionId), is_pid(Pid) ->
+    case maps:get(SessionId, maps:get(sessions, State, #{}), undefined) of
+        #{pid := Pid} -> true;
+        _ -> false
+    end.
 
 -spec handle_session_connect(connect_request(), pid(), state()) ->
     {reply, {ok, [map()]}, state()}.

--- a/fluxer_gateway/src/session/session_connection_presence.erl
+++ b/fluxer_gateway/src/session/session_connection_presence.erl
@@ -13,6 +13,7 @@
 -export_type([session_state/0, attempt/0]).
 
 -define(MAX_RETRY_ATTEMPTS, 25).
+-define(PRESENCE_MEMBERSHIP_TIMEOUT, 1000).
 
 -type session_state() :: session:session_state().
 -type attempt() :: non_neg_integer().
@@ -173,10 +174,23 @@ repair_presence_connection(State) ->
 presence_attachment_healthy(State) ->
     case maps:get(presence_pid, State, undefined) of
         Pid when is_pid(Pid) ->
-            presence_pid_alive(Pid) andalso presence_owner_matches(State, Pid);
+            presence_pid_alive(Pid) andalso
+                presence_owner_matches(State, Pid) andalso
+                presence_has_session(State, Pid);
         _ ->
             false
     end.
+
+-spec presence_has_session(session_state(), pid()) -> boolean().
+presence_has_session(#{id := SessionId}, Pid) when is_binary(SessionId) ->
+    try gen_server:call(Pid, {has_session, SessionId, self()}, ?PRESENCE_MEMBERSHIP_TIMEOUT) of
+        true -> true;
+        _ -> false
+    catch
+        exit:_Reason -> false
+    end;
+presence_has_session(_State, _Pid) ->
+    true.
 
 -spec presence_pid_alive(pid()) -> boolean().
 presence_pid_alive(Pid) ->
@@ -262,6 +276,35 @@ presence_attachment_healthy_false_when_unattached_test() ->
 presence_attachment_healthy_true_for_live_local_pid_without_user_id_test() ->
     ?assert(presence_attachment_healthy(#{presence_pid => self()})).
 
+presence_attachment_healthy_true_when_session_is_registered_test() ->
+    Pid = start_presence_membership_probe(<<"registered">>, self()),
+    ?assert(
+        presence_attachment_healthy(#{
+            presence_pid => Pid, id => <<"registered">>
+        })
+    ),
+    Pid ! stop.
+
+presence_attachment_healthy_false_when_session_is_missing_test() ->
+    Pid = start_presence_membership_probe(<<"other">>, self()),
+    ?assertNot(
+        presence_attachment_healthy(#{
+            presence_pid => Pid, id => <<"missing">>
+        })
+    ),
+    Pid ! stop.
+
+presence_attachment_healthy_false_when_session_pid_was_replaced_test() ->
+    OtherPid = spawn(fun presence_target_loop/0),
+    Pid = start_presence_membership_probe(<<"registered">>, OtherPid),
+    ?assertNot(
+        presence_attachment_healthy(#{
+            presence_pid => Pid, id => <<"registered">>
+        })
+    ),
+    Pid ! stop,
+    OtherPid ! stop.
+
 presence_attachment_healthy_false_for_dead_local_pid_test() ->
     ?assertNot(presence_attachment_healthy(#{presence_pid => dead_pid()})).
 
@@ -324,6 +367,21 @@ presence_target_loop() ->
     receive
         stop -> ok
     after 5000 -> ok
+    end.
+
+start_presence_membership_probe(SessionId, SessionPid) ->
+    spawn(fun() -> presence_membership_probe_loop(SessionId, SessionPid) end).
+
+presence_membership_probe_loop(SessionId, SessionPid) ->
+    receive
+        {'$gen_call', From, {has_session, RequestedId, RequestedPid}} ->
+            gen_server:reply(
+                From,
+                RequestedId =:= SessionId andalso RequestedPid =:= SessionPid
+            ),
+            presence_membership_probe_loop(SessionId, SessionPid);
+        stop ->
+            ok
     end.
 
 received_presence_connect() ->

--- a/fluxer_gateway/test/presence_connect_tests.erl
+++ b/fluxer_gateway/test/presence_connect_tests.erl
@@ -28,6 +28,26 @@ session_connect_sends_cached_friend_presence_to_new_session_test() ->
     SessionPid ! stop,
     ok = gen_server:stop(PresencePid).
 
+dispatch_reaches_all_sessions_for_same_user_test() ->
+    maybe_start_presence_bus(),
+    maybe_start_presence_cache(),
+    {ok, PresencePid} = presence:start_link(presence_data([])),
+    BrowserPid = start_session_probe(PresencePid, connect_req(<<"browser-session">>)),
+    UserbotPid = start_session_probe(PresencePid, connect_req(<<"userbot-session">>)),
+    assert_session_connected(BrowserPid),
+    assert_session_connected(UserbotPid),
+    Event = #{
+        <<"id">> => <<"100">>,
+        <<"channel_id">> => <<"200">>,
+        <<"content">> => <<"inbound dm">>
+    },
+    gen_server:cast(PresencePid, {dispatch, message_create, Event}),
+    assert_probe_dispatch(BrowserPid, message_create, Event),
+    assert_probe_dispatch(UserbotPid, message_create, Event),
+    BrowserPid ! stop,
+    UserbotPid ! stop,
+    ok = gen_server:stop(PresencePid).
+
 session_connect_sends_live_friend_presence_when_cache_missing_test() ->
     maybe_start_presence_bus(),
     maybe_start_presence_cache(),

--- a/fluxer_gateway/test/session_lifecycle_tests.erl
+++ b/fluxer_gateway/test/session_lifecycle_tests.erl
@@ -219,23 +219,24 @@ handle_resume_replaces_existing_socket_test() ->
     end.
 
 handle_resume_restores_resume_status_after_offline_timer_test() ->
+    PresencePid = start_resume_presence_probe(self()),
     State0 = resume_test_state(#{
         seq => 1,
         buffer => [#{seq => 1, event => message_create, data => #{}}],
         status => offline,
         resume_status => dnd,
-        presence_pid => self()
+        presence_pid => PresencePid
     }),
     {reply, {ok, _Missed, 1}, State1} = session_lifecycle:handle_resume(0, self(), State0),
     ?assertEqual(dnd, maps:get(status, State1)),
     ?assertEqual(dnd, maps:get(resume_status, State1)),
     receive
-        {'$gen_call', {Worker, Tag}, {session_connect, PresenceUpdate}} ->
-            Worker ! {Tag, ok},
+        {presence_session_connect, PresenceUpdate} ->
             ?assertEqual(dnd, maps:get(status, PresenceUpdate))
     after 200 ->
         ?assert(false)
-    end.
+    end,
+    PresencePid ! stop.
 
 handle_resume_cancels_pending_offline_timer_test() ->
     Token = make_ref(),
@@ -283,21 +284,39 @@ handle_resume_reconnects_presence_when_owner_moved_test() ->
 
 handle_resume_refreshes_healthy_presence_attachment_test() ->
     SocketPid = spawn(fun resume_loop/0),
+    PresencePid = start_resume_presence_probe(self()),
     State0 = resume_test_state(#{
         seq => 1,
-        presence_pid => self(),
+        presence_pid => PresencePid,
         buffer => [#{seq => 1, event => message_create, data => #{}}]
     }),
     {reply, {ok, _Missed, 1}, State1} = session_lifecycle:handle_resume(0, SocketPid, State0),
-    ?assertEqual(self(), maps:get(presence_pid, State1)),
+    ?assertEqual(PresencePid, maps:get(presence_pid, State1)),
     receive
-        {'$gen_call', {Worker, Tag}, {session_connect, Req}} ->
-            Worker ! {Tag, ok},
+        {presence_session_connect, Req} ->
             ?assertEqual(<<"session-resume-test">>, maps:get(session_id, Req))
     after 1000 ->
         ?assert(false, healthy_resume_did_not_refresh_presence)
     end,
+    PresencePid ! stop,
     SocketPid ! stop.
+
+start_resume_presence_probe(SessionPid) ->
+    TestPid = self(),
+    spawn(fun() -> resume_presence_probe_loop(TestPid, SessionPid) end).
+
+resume_presence_probe_loop(TestPid, SessionPid) ->
+    receive
+        {'$gen_call', From, {has_session, <<"session-resume-test">>, SessionPid}} ->
+            gen_server:reply(From, true),
+            resume_presence_probe_loop(TestPid, SessionPid);
+        {'$gen_call', From, {session_connect, Req}} ->
+            TestPid ! {presence_session_connect, Req},
+            gen_server:reply(From, ok),
+            resume_presence_probe_loop(TestPid, SessionPid);
+        stop ->
+            ok
+    end.
 
 resume_loop() ->
     receive


### PR DESCRIPTION
## Summary

Potential fix #1463.  I did not replicate the bug so this is a defensive fix but I am fairly confident that this is a good fix.

- What changed: fluxer_gateway/src/presence/presence.erl, fluxer_gateway/src/presence/presence_session.erl, fluxer_gateway/src/session/session_connection_presence.erl, fluxer_gateway/test/presence_connect_tests.erl 
- Why it is correct: My change makes each gateway session verify that it is still registered with the user’s Presence process.
- Risk: Medium

## Verification

- Tests run:  cd /workspaces/fluxer/fluxer_gateway

  rebar3 as test eunit --module=presence_connect_tests
  rebar3 as test eunit --module=session_connection_presence

  Results:

  - presence_connect_tests: 4 tests, 0 failures
  - session_connection_presence: 14 tests, 0 failures
  - Total: 18 tests, 0 failures
  - The gateway also compiled successfully during that run.
- Manual checks: None
- Screenshots or recordings: Didn't get any

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
