### PR TITLE
fix(sso): trust absent email_verified claim and relax auth code length limit

### DIFF
--- a/fluxer_api/src/api/auth/services/SsoService.ts
+++ b/fluxer_api/src/api/auth/services/SsoService.ts
@@ -224,7 +224,7 @@ function resolveEmailVerified({
 	if (values.includes(false)) {
 		return false;
 	}
-	return values.includes(true);
+	return values.length === 0 || values.includes(true);
 }
 
 function isJsonWebKeySet(value: unknown): value is JSONWebKeySet {

--- a/packages/schema/src/domains/auth/AuthSchemas.ts
+++ b/packages/schema/src/domains/auth/AuthSchemas.ts
@@ -260,8 +260,8 @@ export const SsoStartRequest = z.object({
 export type SsoStartRequest = z.infer<typeof SsoStartRequest>;
 
 export const SsoCompleteRequest = z.object({
-	code: createStringType().describe('Authorization code from the SSO provider'),
-	state: createStringType().describe('State parameter for CSRF protection'),
+	code: createStringType(1, 4096).describe('Authorization code from the SSO provider'),
+	state: createStringType(1, 4096).describe('State parameter for CSRF protection'),
 });
 
 export type SsoCompleteRequest = z.infer<typeof SsoCompleteRequest>;


### PR DESCRIPTION
## Summary

- What changed: Two fixes to the SSO authentication flow. (1) SsoService.ts: resolveEmailVerified now returns true when no email_verified claim is present in the token, instead of false. (2) AuthSchemas.ts: the code and state fields in SsoCompleteRequest now accept up to 4096 characters instead of the default 256.
- Why it is correct: For the schema fix, some SSO providers (e.g. Entra ID, Okta) issue authorization codes longer than 256 characters. Capping at 256 caused a validation failure before the token exchange even began. The OAuth 2.0 spec (RFC 6749) imposes no length limit on authorization codes whatsoever, the new 4096-character cap is a conservative safeguard kept in case an upper bound is needed for security reasons (e.g. DoS protection), not a spec requirement.
Per OIDC Core 1.0 §5.1, email_verified is an optional claim. An absent claim means the IdP chose not to include it, not that the email is unverified. Blocking login when the claim is missing breaks providers like Microsoft Entra ID that omit it by default.
- Risk: Low. The email_verified change only affects the case where no claim is present (previously: treated as unverified → login blocked; now: treated as trusted). An explicit false still blocks login. The schema change is purely permissive, it relaxes a validation constraint with no behavioural side-effects.

## Verification

- Tests run: None
- Manual checks: SSO login tested end-to-end with a Microsoft Entra ID provider that omits email_verified.
- Screenshots or recordings: None

## Checklist

- [X] I understand every change in this PR.
- [X] I can explain what it does and why it is correct.
- [X] I disclosed any LLM coding help below.

## LLM Disclosure

- Claude Sonnet 1M : Researching code parts

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
