### PR TITLE
fix(guild): stop activity log from rendering ids in channel names

### DIFF
--- a/fluxer_app/src/features/guild/components/modals/guild_tabs/GuildAuditLogTabUtils.tsx
+++ b/fluxer_app/src/features/guild/components/modals/guild_tabs/GuildAuditLogTabUtils.tsx
@@ -539,7 +539,7 @@ export const renderEntrySummary = (args: {
 		findChangeScalar(entry.changes, 'code', i18n) ??
 		getOptionScalar(entry, ['name', 'title', 'code'], i18n) ??
 		null;
-	const namedTarget = changedName ? renderEntityInline(changedName, guildId, i18n) : targetEntity;
+	const namedTarget = changedName ? renderBoldValue(changedName) : targetEntity;
 	const pruneDaysRaw = findChangeNewScalar(entry.changes, 'prune_delete_days', i18n);
 	const pruneDays = pruneDaysRaw ? Number(pruneDaysRaw) : null;
 	const bulkCount = getOptionNumber(entry, ['count', 'delete_count', 'messages', 'message_count'], i18n);


### PR DESCRIPTION
## Summary

- What changed: Replaced renderEntityInline with renderBoldValue so it simply bolds the channel name rather than rendering it as a clickable id.
- Why it is correct: People were able to create a channel with the name of a user id, which rendered the channel name as a username in the activity log. The name was clickable and you could copy the user id. Closes #1426. 
- Risk: None

## Verification

- Tests run: None
- Manual checks: Confirmed to be working in dev container
- Screenshots or recordings:

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- Used AI to find the correct section in the codebase and made the change myself.

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
