### PR TITLE
enables native screen capture on X11 on specific app screen sharing only

### DIFF
--- a/fluxer_desktop/native/linux-screen-capture/Cargo.lock
+++ b/fluxer_desktop/native/linux-screen-capture/Cargo.lock
@@ -598,6 +598,7 @@ dependencies = [
  "parking_lot",
  "pipewire",
  "wgpu",
+ "x11rb",
  "zbus",
 ]
 
@@ -720,6 +721,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -2070,6 +2081,23 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "zbus"

--- a/fluxer_desktop/native/linux-screen-capture/Cargo.toml
+++ b/fluxer_desktop/native/linux-screen-capture/Cargo.toml
@@ -29,6 +29,7 @@ dcv-color-primitives = "1.0"
 futures-lite = "2.6.1"
 libc = "0.2"
 pipewire = { version = "0.10.0", features = ["v0_3_33"] }
+x11rb = { version = "0.13", features = ["randr"] }
 zbus = "5.16.0"
 
 [dev-dependencies]

--- a/fluxer_desktop/native/linux-screen-capture/src/lib.rs
+++ b/fluxer_desktop/native/linux-screen-capture/src/lib.rs
@@ -19,6 +19,8 @@ pub mod game_capture;
 pub mod pipewire_stream;
 #[cfg(target_os = "linux")]
 pub mod portal;
+#[cfg(target_os = "linux")]
+pub mod x11_capture;
 
 #[cfg(target_os = "linux")]
 mod napi_surface_linux;

--- a/fluxer_desktop/native/linux-screen-capture/src/napi_surface_linux.rs
+++ b/fluxer_desktop/native/linux-screen-capture/src/napi_surface_linux.rs
@@ -24,9 +24,21 @@ use crate::pipewire_stream::{
     daemon_reachable,
 };
 use crate::portal::{self, LiveSession, PortalError, SOURCE_TYPE_WINDOW, StreamInfo};
+use crate::x11_capture::{X11Target, X11VideoStream};
 
 fn generic_error(reason: impl Into<String>) -> napi::Error {
     napi::Error::new(Status::GenericFailure, reason.into())
+}
+
+/// Native screen capture uses xdg-desktop-portal ScreenCast, which is only
+/// usable on Wayland (KDE's portal refuses ScreenCast on X11). On X11 we capture
+/// directly from the X server instead. Treat the session as Wayland only when a
+/// Wayland display is actually present.
+fn is_wayland_session() -> bool {
+    if std::env::var_os("WAYLAND_DISPLAY").is_some_and(|value| !value.is_empty()) {
+        return true;
+    }
+    std::env::var("XDG_SESSION_TYPE").is_ok_and(|value| value.eq_ignore_ascii_case("wayland"))
 }
 
 fn invalid_arg(reason: impl Into<String>) -> napi::Error {
@@ -456,6 +468,7 @@ struct CaptureState {
     session: Option<LiveSession>,
     stream: Option<PipeWireVideoStream>,
     game_stream: Option<GameCaptureVideoStream>,
+    x11_stream: Option<X11VideoStream>,
 }
 
 struct CaptureInner {
@@ -486,6 +499,7 @@ impl ScreenCapture {
                     session: None,
                     stream: None,
                     game_stream: None,
+                    x11_stream: None,
                 }),
                 running: Arc::new(AtomicBool::new(false)),
                 capture_id: Arc::new(Mutex::new(None)),
@@ -636,11 +650,51 @@ impl ScreenCapture {
                 state.session = None;
                 state.stream = None;
                 state.game_stream = Some(game_stream);
+                state.x11_stream = None;
             }
             self.inner.running.store(true, Ordering::Release);
             return Ok(ScreenCaptureStartResult {
                 width,
                 height,
+                frame_rate: effective_fps,
+                pixel_format: "nv12".to_string(),
+            });
+        }
+
+        if !is_wayland_session() {
+            let target = if source_kind == "window" {
+                let xid = parse_source_id(&source_id).ok_or_else(|| {
+                    invalid_arg("ScreenCapture.start window sourceId must be a positive X11 window id")
+                })?;
+                X11Target::Window(xid)
+            } else if let Some(rect) = start_options.capture_rect {
+                // A caller-supplied rectangle (e.g. a single monitor resolved from
+                // its display id) captures exactly that region of the desktop.
+                X11Target::Region {
+                    x: rect.x.round().clamp(i16::MIN as f64, i16::MAX as f64) as i16,
+                    y: rect.y.round().clamp(i16::MIN as f64, i16::MAX as f64) as i16,
+                    width: rect.width,
+                    height: rect.height,
+                }
+            } else {
+                // A monitor index selects a specific display; anything else captures
+                // the whole root window.
+                X11Target::Screen(source_id.parse::<usize>().ok())
+            };
+            let (x11_stream, cap_width, cap_height) =
+                X11VideoStream::open(target, effective_fps, frame_cb, lifecycle_cb)
+                    .map_err(|e| generic_error(format!("X11 screen capture failed: {e}")))?;
+            {
+                let mut state = lock_state(&self.inner)?;
+                state.session = None;
+                state.stream = None;
+                state.game_stream = None;
+                state.x11_stream = Some(x11_stream);
+            }
+            self.inner.running.store(true, Ordering::Release);
+            return Ok(ScreenCaptureStartResult {
+                width: cap_width,
+                height: cap_height,
                 frame_rate: effective_fps,
                 pixel_format: "nv12".to_string(),
             });
@@ -687,6 +741,7 @@ impl ScreenCapture {
             state.session = Some(session);
             state.stream = Some(stream);
             state.game_stream = None;
+            state.x11_stream = None;
         }
         self.inner.running.store(true, Ordering::Release);
 
@@ -717,16 +772,18 @@ impl ScreenCapture {
         if let Ok(mut guard) = self.inner.native_frame_sink.lock() {
             guard.take();
         }
-        let (stream, game_stream, session) = {
+        let (stream, game_stream, x11_stream, session) = {
             let mut state = lock_state(&self.inner)?;
             (
                 state.stream.take(),
                 state.game_stream.take(),
+                state.x11_stream.take(),
                 state.session.take(),
             )
         };
         drop(stream);
         drop(game_stream);
+        drop(x11_stream);
         if let Some(s) = session {
             s.close();
         }
@@ -773,12 +830,18 @@ impl Drop for ScreenCapture {
         if let Ok(mut guard) = self.inner.native_frame_sink.lock() {
             guard.take();
         }
-        let (stream, game_stream, session) = match self.inner.state.lock() {
-            Ok(mut s) => (s.stream.take(), s.game_stream.take(), s.session.take()),
-            Err(_) => (None, None, None),
+        let (stream, game_stream, x11_stream, session) = match self.inner.state.lock() {
+            Ok(mut s) => (
+                s.stream.take(),
+                s.game_stream.take(),
+                s.x11_stream.take(),
+                s.session.take(),
+            ),
+            Err(_) => (None, None, None, None),
         };
         drop(stream);
         drop(game_stream);
+        drop(x11_stream);
         if let Some(s) = session {
             s.close();
         }

--- a/fluxer_desktop/native/linux-screen-capture/src/x11_capture.rs
+++ b/fluxer_desktop/native/linux-screen-capture/src/x11_capture.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// X11 screen/window capture backend.
+//
+// The portal (xdg-desktop-portal ScreenCast) backend only works on Wayland;
+// xdg-desktop-portal-kde refuses ScreenCast on X11 outright. This backend
+// captures directly from the X server via GetImage and feeds NV12 frames into
+// the same pipeline the PipeWire path uses, so native screen share works on X11.
+//
+// v1 uses core-protocol GetImage (no MIT-SHM); this is simple and correct.
+// A shared-memory fast path can be layered on later if throughput needs it.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::sync_channel;
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use x11rb::connection::Connection;
+use x11rb::protocol::randr::ConnectionExt as _;
+use x11rb::protocol::xproto::{ConnectionExt as _, Drawable, ImageFormat, Window};
+
+use crate::frame_buffer_pool::LINUX_FRAME_DIM_MAX;
+use crate::nv12_packing::{bgra_to_nv12, Nv12Layout};
+use crate::pipewire_stream::{FrameCallback, LifecycleCallback, VideoFrame, VideoFrameData};
+
+const DIM_MAX: u32 = LINUX_FRAME_DIM_MAX as u32;
+
+/// What to capture.
+pub enum X11Target {
+    /// A single toplevel window, by X11 window id (XID).
+    Window(u32),
+    /// An explicit rectangle on the root window, in root pixel coordinates.
+    /// Used to capture a single monitor of a multi-monitor desktop.
+    Region {
+        x: i16,
+        y: i16,
+        width: u32,
+        height: u32,
+    },
+    /// A display. `Some(index)` selects a RandR monitor by index; `None` (or an
+    /// out-of-range index) captures the whole root window (all monitors).
+    Screen(Option<usize>),
+}
+
+pub struct X11VideoStream {
+    running: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl X11VideoStream {
+    /// Opens the capture and starts delivering frames on a background thread.
+    /// Returns the stream plus the initial capture dimensions.
+    pub fn open(
+        target: X11Target,
+        frame_rate: u32,
+        on_frame: FrameCallback,
+        on_lifecycle: LifecycleCallback,
+    ) -> Result<(Self, u32, u32), String> {
+        let running = Arc::new(AtomicBool::new(true));
+        let running_thread = Arc::clone(&running);
+        let fps = frame_rate.clamp(1, 240);
+        let (ready_tx, ready_rx) = sync_channel::<Result<(u32, u32), String>>(1);
+        let handle = std::thread::Builder::new()
+            .name("fluxer-x11-capture".into())
+            .spawn(move || {
+                run_capture(target, fps, on_frame, on_lifecycle, running_thread, ready_tx);
+            })
+            .map_err(|e| format!("failed to spawn X11 capture thread: {e}"))?;
+        match ready_rx.recv() {
+            Ok(Ok((w, h))) => Ok((
+                Self {
+                    running,
+                    handle: Some(handle),
+                },
+                w,
+                h,
+            )),
+            Ok(Err(e)) => {
+                let _ = handle.join();
+                Err(e)
+            }
+            Err(_) => {
+                let _ = handle.join();
+                Err("X11 capture thread exited before signalling readiness".into())
+            }
+        }
+    }
+}
+
+impl Drop for X11VideoStream {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Release);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+struct CaptureRect {
+    drawable: Drawable,
+    x: i16,
+    y: i16,
+    width: u32,
+    height: u32,
+}
+
+/// Resolves the current capture rectangle. Returns `Err` when the target is
+/// permanently gone (e.g. window destroyed), `Ok(None)` when it is momentarily
+/// uncapturable (e.g. zero-sized), so the loop can keep polling.
+fn resolve_rect<C: Connection>(
+    conn: &C,
+    target: &X11Target,
+    root: Window,
+) -> Result<Option<CaptureRect>, ()> {
+    let (drawable, x, y, mut width, mut height) = match target {
+        X11Target::Window(xid) => {
+            let geo = conn
+                .get_geometry(*xid)
+                .map_err(|_| ())?
+                .reply()
+                .map_err(|_| ())?;
+            (*xid as Drawable, 0i16, 0i16, geo.width as u32, geo.height as u32)
+        }
+        X11Target::Region {
+            x,
+            y,
+            width,
+            height,
+        } => (root as Drawable, *x, *y, *width, *height),
+        X11Target::Screen(index) => {
+            if let Some(rect) = index.and_then(|i| monitor_rect(conn, root, i)) {
+                rect
+            } else {
+                let geo = conn
+                    .get_geometry(root)
+                    .map_err(|_| ())?
+                    .reply()
+                    .map_err(|_| ())?;
+                (root as Drawable, 0i16, 0i16, geo.width as u32, geo.height as u32)
+            }
+        }
+    };
+    // NV12 requires even dimensions; clamp to the pipeline's max frame size.
+    width = (width & !1).min(DIM_MAX);
+    height = (height & !1).min(DIM_MAX);
+    if width < 2 || height < 2 {
+        return Ok(None);
+    }
+    Ok(Some(CaptureRect {
+        drawable,
+        x,
+        y,
+        width,
+        height,
+    }))
+}
+
+fn monitor_rect<C: Connection>(
+    conn: &C,
+    root: Window,
+    index: usize,
+) -> Option<(Drawable, i16, i16, u32, u32)> {
+    let monitors = conn.randr_get_monitors(root, true).ok()?.reply().ok()?;
+    let monitor = monitors.monitors.get(index)?;
+    Some((
+        root as Drawable,
+        monitor.x,
+        monitor.y,
+        monitor.width as u32,
+        monitor.height as u32,
+    ))
+}
+
+fn run_capture(
+    target: X11Target,
+    fps: u32,
+    on_frame: FrameCallback,
+    on_lifecycle: LifecycleCallback,
+    running: Arc<AtomicBool>,
+    ready_tx: std::sync::mpsc::SyncSender<Result<(u32, u32), String>>,
+) {
+    let (conn, screen_num) = match x11rb::connect(None) {
+        Ok(pair) => pair,
+        Err(err) => {
+            let _ = ready_tx.send(Err(format!("X11 connect failed: {err}")));
+            return;
+        }
+    };
+    let root = conn.setup().roots[screen_num].root;
+
+    let initial = match resolve_rect(&conn, &target, root) {
+        Ok(Some(rect)) => rect,
+        Ok(None) => {
+            let _ = ready_tx.send(Err("X11 capture target has no capturable area".into()));
+            return;
+        }
+        Err(()) => {
+            let _ = ready_tx.send(Err("X11 capture target is not available".into()));
+            return;
+        }
+    };
+    let _ = ready_tx.send(Ok((initial.width, initial.height)));
+
+    let base = Instant::now();
+    let frame_interval = Duration::from_secs_f64(1.0 / fps as f64);
+    let mut scratch: Vec<u8> = Vec::new();
+
+    while running.load(Ordering::Acquire) {
+        let loop_start = Instant::now();
+
+        let rect = match resolve_rect(&conn, &target, root) {
+            Ok(Some(rect)) => rect,
+            Ok(None) => {
+                std::thread::sleep(frame_interval);
+                continue;
+            }
+            Err(()) => break, // target destroyed
+        };
+
+        let image = match conn.get_image(
+            ImageFormat::Z_PIXMAP,
+            rect.drawable,
+            rect.x,
+            rect.y,
+            rect.width as u16,
+            rect.height as u16,
+            !0u32,
+        ) {
+            Ok(cookie) => match cookie.reply() {
+                Ok(reply) => reply,
+                Err(_) => {
+                    // Momentary failure (e.g. window unmapped); keep polling.
+                    std::thread::sleep(frame_interval);
+                    continue;
+                }
+            },
+            Err(_) => {
+                std::thread::sleep(frame_interval);
+                continue;
+            }
+        };
+
+        let bgra = &image.data;
+        let pixels = (rect.width as usize) * (rect.height as usize);
+        if pixels == 0 || bgra.len() < pixels * 4 {
+            // Only 32-bpp Z_PIXMAP data is supported (depth 24 is padded to 32).
+            std::thread::sleep(frame_interval);
+            continue;
+        }
+        let bgra_stride = rect.width * 4;
+
+        let layout = Nv12Layout {
+            width: rect.width,
+            height: rect.height,
+            stride_y: rect.width,
+            stride_uv: rect.width,
+        };
+        let Some(total) = layout.packed_size() else {
+            std::thread::sleep(frame_interval);
+            continue;
+        };
+        if scratch.len() != total {
+            scratch.resize(total, 0);
+        }
+        if !bgra_to_nv12(layout, bgra, bgra_stride, &mut scratch, false) {
+            std::thread::sleep(frame_interval);
+            continue;
+        }
+
+        let frame = VideoFrame {
+            width: rect.width,
+            height: rect.height,
+            stride_y: layout.packed_stride_y(),
+            stride_uv: layout.packed_stride_uv(),
+            timestamp_us: base.elapsed().as_micros().min(i64::MAX as u128) as i64,
+            data: VideoFrameData::from_vec(std::mem::take(&mut scratch)),
+            dmabuf: None,
+        };
+        on_frame(frame);
+
+        let elapsed = loop_start.elapsed();
+        if elapsed < frame_interval {
+            std::thread::sleep(frame_interval - elapsed);
+        }
+    }
+
+    on_lifecycle("closed-clean", "X11 capture stopped");
+}

--- a/fluxer_desktop/native/webrtc-sender/src/engine.rs
+++ b/fluxer_desktop/native/webrtc-sender/src/engine.rs
@@ -1390,7 +1390,19 @@ impl ScreenFrameSink for BusSenderSink {
     fn enqueue(&self, frame: BusScreenFrame) -> EnqueueOutcome {
         let timestamp_us = frame.timestamp_us();
         let pending = match frame {
-            BusScreenFrame::Nv12(_) | BusScreenFrame::Bgra(_) => return EnqueueOutcome::Rejected,
+            // CPU NV12 frames come from the X11 screen-capture backend (the portal
+            // backend delivers DMABUF/GPU frames instead). Feed them through the
+            // existing software NV12 encode path.
+            BusScreenFrame::Nv12(nv12) => PendingVideoFrame::Nv12 {
+                data: nv12.data.as_slice().to_vec(),
+                width: nv12.width,
+                height: nv12.height,
+                stride_y: nv12.stride_y,
+                stride_uv: nv12.stride_uv,
+                timestamp_us,
+                enqueued_at: Instant::now(),
+            },
+            BusScreenFrame::Bgra(_) => return EnqueueOutcome::Rejected,
             #[cfg(target_os = "macos")]
             BusScreenFrame::MacCvPixelBuffer(mac_frame) => {
                 let raw = mac_frame.into_raw_pixel_buffer();
@@ -1559,6 +1571,35 @@ unsafe extern "C" fn enqueue_native_mac_cv_pixel_buffer(
     )
 }
 
+unsafe extern "C" fn enqueue_native_nv12(
+    context: *const c_void,
+    data: *const u8,
+    data_len: usize,
+    width: u32,
+    height: u32,
+    stride_y: u32,
+    stride_uv: u32,
+    timestamp_us: i64,
+) -> u32 {
+    let Some(sink) = bus_sender_sink_from_context(context) else {
+        return frame_bus::NATIVE_SCREEN_FRAME_SINK_REJECTED;
+    };
+    if data.is_null() || data_len == 0 || data_len > frame_bus::FRAME_DATA_BYTES_CAP {
+        return frame_bus::NATIVE_SCREEN_FRAME_SINK_REJECTED;
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec();
+    NativeScreenFrameSinkHandle::native_outcome(sink.enqueue(BusScreenFrame::Nv12(
+        frame_bus::Nv12Frame {
+            data: frame_bus::FrameData::from_owned(bytes),
+            width,
+            height,
+            stride_y,
+            stride_uv,
+            timestamp_us,
+        },
+    )))
+}
+
 #[cfg(target_os = "linux")]
 unsafe extern "C" fn enqueue_native_dmabuf(
     context: *const c_void,
@@ -1672,7 +1713,7 @@ fn create_native_screen_frame_sink_handle(sink: Arc<BusSenderSink>) -> NativeScr
         retain: retain_bus_sender_sink,
         release: release_bus_sender_sink,
         enqueue_screen_audio: None,
-        enqueue_nv12: None,
+        enqueue_nv12: Some(enqueue_native_nv12),
         enqueue_bgra: None,
         #[cfg(target_os = "macos")]
         enqueue_mac_cv_pixel_buffer: Some(enqueue_native_mac_cv_pixel_buffer),
@@ -6193,7 +6234,9 @@ mod tests {
     }
 
     #[test]
-    fn bus_sender_sink_rejects_copied_nv12_frames() {
+    fn bus_sender_sink_accepts_copied_nv12_frames() {
+        // The X11 screen-capture backend delivers CPU NV12 frames; they must be
+        // accepted and routed through the software NV12 encode path.
         let (sender, _stats) = sender_for_tests();
         let sink = BusSenderSink {
             sender: sender.clone(),
@@ -6209,8 +6252,8 @@ mod tests {
             stride_uv: 8,
             timestamp_us: 1234,
         });
-        assert_eq!(sink.enqueue(frame), EnqueueOutcome::Rejected);
-        assert_eq!(sender.pending.len(), 0);
+        assert_eq!(sink.enqueue(frame), EnqueueOutcome::Accepted);
+        assert_eq!(sender.pending.len(), 1);
     }
 
     #[test]
@@ -6234,7 +6277,7 @@ mod tests {
     }
 
     #[test]
-    fn native_screen_frame_sink_handle_omits_copied_frame_callbacks() {
+    fn native_screen_frame_sink_handle_exposes_nv12_callback() {
         let (sender, _stats) = sender_for_tests();
         let sink = BusSenderSink {
             sender: sender.clone(),
@@ -6244,7 +6287,8 @@ mod tests {
         };
         let handle = create_native_screen_frame_sink_handle(Arc::new(sink));
         assert!(handle.is_valid());
-        assert!(handle.enqueue_nv12.is_none());
+        // CPU NV12 ingestion is wired for the X11 backend; BGRA remains unused.
+        assert!(handle.enqueue_nv12.is_some());
         assert!(handle.enqueue_bgra.is_none());
         assert!(handle.enqueue_screen_audio.is_none());
         unsafe { (handle.release)(handle.context) };

--- a/fluxer_desktop/src/main/NativeScreenCapture.ts
+++ b/fluxer_desktop/src/main/NativeScreenCapture.ts
@@ -16,7 +16,7 @@ import type {
 	NativeScreenCaptureStartResult,
 	WindowsHagsState,
 } from '@electron/common/Types';
-import {ipcMain} from 'electron';
+import {ipcMain, screen} from 'electron';
 import {getTccStatus} from './MacTcc';
 import {isValidStartOptions, normalizeScreenCaptureDimension} from './NativeScreenCaptureValidation';
 import {createNativeVoiceEngineScreenFrameSinkHandle} from './NativeVoiceEngine';
@@ -815,6 +815,70 @@ async function makeRoomForSenderSession(senderId: number): Promise<void> {
 	}
 }
 
+// On Linux/X11 the native backend captures from the X server. A whole-desktop
+// ("screen") capture would otherwise grab the entire root window spanning every
+// monitor (e.g. 5120x1440 across two displays), which exceeds the encoder's max
+// dimensions and produces a green stream. The renderer passes the Chromium
+// display id as sourceId; resolve it to that monitor's pixel rectangle so the
+// backend captures just the selected monitor. Returns the existing captureRect
+// unchanged on other platforms/source kinds.
+function resolveNativeCaptureRect(
+	options: NativeScreenCaptureStartOptions,
+): NativeScreenCaptureStartOptions['captureRect'] {
+	if (process.platform !== 'linux' || options.sourceKind !== 'screen') {
+		return options.captureRect;
+	}
+	if (options.captureRect) {
+		return options.captureRect;
+	}
+	try {
+		const displays = screen.getAllDisplays();
+		const physical = (display: Electron.Display) => {
+			const scale = display.scaleFactor > 0 ? display.scaleFactor : 1;
+			return {
+				x: Math.round(display.bounds.x * scale),
+				y: Math.round(display.bounds.y * scale),
+				width: Math.round(display.bounds.width * scale),
+				height: Math.round(display.bounds.height * scale),
+			};
+		};
+		// The renderer's sourceId is Chromium's display id, which does not match
+		// Electron's Display.id. Try the id first, then match by the requested
+		// dimensions, and finally fall back to a single monitor so we never capture
+		// the whole (multi-monitor) root, which would exceed the encoder's limits.
+		let match = displays.find((display) => String(display.id) === String(options.sourceId));
+		let how = 'id';
+		if (!match && options.width && options.height) {
+			match = displays.find((display) => {
+				const rect = physical(display);
+				return rect.width === options.width && rect.height === options.height;
+			});
+			how = 'size';
+		}
+		if (!match) {
+			match = displays.find((display) => display.id === screen.getPrimaryDisplay().id) ?? displays[0];
+			how = 'primary-fallback';
+			logger.warn('screen-share sourceId did not map to a display; capturing a single monitor', {
+				sourceId: options.sourceId,
+				requested: {width: options.width, height: options.height},
+				displays: displays.map((display) => ({id: display.id, rect: physical(display)})),
+			});
+		}
+		if (!match) {
+			return options.captureRect;
+		}
+		const rect = physical(match);
+		logger.info('Resolved Linux screen capture rect', {sourceId: options.sourceId, how, rect});
+		return rect;
+	} catch (error) {
+		logger.warn('Failed to resolve Linux screen capture rect from display id', {
+			error,
+			sourceId: options.sourceId,
+		});
+		return options.captureRect;
+	}
+}
+
 async function startNativeScreenCapture(
 	sender: Electron.WebContents,
 	options: NativeScreenCaptureStartOptions,
@@ -857,6 +921,7 @@ async function startNativeScreenCapture(
 	if (!frameSinkHandle) {
 		throw new Error('Native screen capture requires a native frame sink handle, but none is active');
 	}
+	const captureRect = resolveNativeCaptureRect(options);
 	const capture = new loadResult.addon.ScreenCapture({
 		sourceId: options.sourceId,
 		sourceKind: options.sourceKind,
@@ -868,7 +933,7 @@ async function startNativeScreenCapture(
 		colorRange: options.colorRange,
 		colorSpace: options.colorSpace,
 		showCursorClicks: options.showCursorClicks === true,
-		captureRect: options.captureRect,
+		captureRect,
 		nativeFrameSinkRequired: true,
 		frameSinkHandle,
 	});


### PR DESCRIPTION
This PR enables native screen capture on X11; window sharing is verified end-to-end; whole-display sharing is implemented and works when the client path is used, but a known renderer-side path-selection issue on X11 can currently prevent it

- What: native Linux screen capture only had the xdg-desktop-portal/DMABUF backend, which doesn't work on X11 (KDE refuses ScreenCast there) this adds an X11 GetImage→NV12 backend and wires the previously-unused CPU-NV12 path in the frame sink.
- Why it's safe: Wayland stays on the portal path (gated by session type); Windows/macOS unaffected; the NV12 sink change is additive.
- What you tested: e.g. "Tested on KDE Plasma X11: window and single-display share with audio, viewed by multiple participants." Wayland/Windows wasn't re-tested.

## Summary

- What changed: new X11 GetImage→NV12 capture backend used on non-Wayland Linux and wiring the previously-unused CPU-NV12 path in the webrtc-sender frame sink which fixed an issue where streams were just a green screen instead of the actual screen content.
- Why it is correct: Wayland gated out (portal path unchanged), Windows/macOS untouched, NV12 sink change is additive (handles a frame type previously rejected).
- Risk: low for existing platforms (they're unchanged); the X11 path is new code. Note the GetImage (no shared-memory) perf limitation as a known follow-up.

## Verification

- Tests run: 
    - cargo test on native/linux-screen-capture — 110 passed
    - cargo test on native/webrtc-sender — 330 passed (includes two tests updated to reflect the new NV12-accepted behavior)
    - pnpm typecheck — clean
    - full pnpm build — succeeds
- Manual checks: Your actual results: on KDE Plasma (X11) — window/app share verified end-to-end with video and audio, viewed by multiple participants; start/stop works. Wayland and Windows were not re-tested
- Screenshots or recordings:

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- Used LLM to write code
- I understand if you don't want to accept the PR due to LLM usage, but I hope it at least inspires the fix for this issue that was bugging me for a while even if the PR is not ultimately accepted.

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
