### PR TITLE
feat(app): Flatpak options and fixes with updater

### DIFF
--- a/fluxer_app/src/features/app/state/Updater.ts
+++ b/fluxer_app/src/features/app/state/Updater.ts
@@ -560,7 +560,7 @@ class Updater {
 			pushUnsupportedUpdateModal('managed-package');
 			return;
 		}
-		if (this.isNative && this.nativeManualUpdateAvailable) {
+		if (this.isNative && this.nativeManualUpdateAvailable && !this.nativeUnsupported) {
 			this.showManualNativeUpdateModal();
 			return;
 		}

--- a/fluxer_app/src/features/app/state/Updater.ts
+++ b/fluxer_app/src/features/app/state/Updater.ts
@@ -556,7 +556,7 @@ class Updater {
 		if (this.isNative && this.nativeDownloadInFlight) {
 			return;
 		}
-		if (this.isNative && this.nativeUnsupported?.reason === 'managed-package') {
+		if (this.isNative && this.nativeUnsupported?.reason === 'managed-package' && !this.updateInfo.web.available) {
 			pushUnsupportedUpdateModal('managed-package');
 			return;
 		}

--- a/fluxer_app/src/features/updater/commands/UpdaterModalCommands.tsx
+++ b/fluxer_app/src/features/updater/commands/UpdaterModalCommands.tsx
@@ -7,7 +7,7 @@ import type {UpdaterDownloadOption} from '@app/features/platform/types/Electron'
 import * as ModalCommands from '@app/features/ui/commands/ModalCommands';
 import {modal} from '@app/features/ui/commands/ModalCommands';
 import {Combobox} from '@app/features/ui/components/form/FormCombobox';
-import {openExternalUrl} from '@app/features/ui/utils/NativeUtils';
+import {openExternalUrl, isCanaryDesktop} from '@app/features/ui/utils/NativeUtils';
 import styles from '@app/features/updater/commands/UpdaterModalCommands.module.css';
 import {i18n} from '@lingui/core';
 import {msg} from '@lingui/core/macro';
@@ -75,6 +75,10 @@ const MANUAL_UPDATE_BODY_DESCRIPTOR = msg({
 const SYSTEM_MANAGED_UPDATE_BODY_DESCRIPTOR = msg({
 	message: 'This install is managed by your system. Update {productName} from your software center or package manager.',
 	comment: 'Desktop updater modal body for managed package builds such as Flatpak. productName is the app name.',
+});
+const OPEN_SOFTWARE_CENTER_DESCRIPTOR = msg({
+	message: 'Open software center',
+	comment: 'Button label that opens the software center via appstream protocol.',
 });
 const OPEN_DESKTOP_DOWNLOADS_DESCRIPTOR = msg({
 	message: 'Open desktop downloads',
@@ -291,7 +295,15 @@ export function pushUnsupportedUpdateModal(
 					<ConfirmModal
 						title={i18n._(SYSTEM_MANAGED_INSTALL_DESCRIPTOR)}
 						description={i18n._(SYSTEM_MANAGED_UPDATE_BODY_DESCRIPTOR, {productName: PRODUCT_NAME})}
+						primaryText={i18n._(OPEN_SOFTWARE_CENTER_DESCRIPTOR)}
 						secondaryText={i18n._(CLOSE_DESCRIPTOR)}
+						onPrimary={() => {
+							const appstreamUrl = isCanaryDesktop()
+								? 'appstream://app.fluxer.FluxerCanary'
+								: 'appstream://app.fluxer.Fluxer';
+
+							void openExternalUrl(appstreamUrl);
+						}}
 						data-flx="updater.updater-modal-commands.push-unsupported-update-modal.confirm-modal"
 					/>
 				);

--- a/fluxer_desktop/src/main/OpenExternal.ts
+++ b/fluxer_desktop/src/main/OpenExternal.ts
@@ -4,7 +4,14 @@ import {APP_PROTOCOL} from '@electron/common/Constants';
 import {shell} from 'electron';
 
 const DEDUPE_WINDOW_MS = 500;
-const ALLOWED_EXTERNAL_URL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:', `${APP_PROTOCOL}:`]);
+const ALLOWED_EXTERNAL_URL_PROTOCOLS = new Set([
+	'http:',
+	'https:',
+	'mailto:',
+	'tel:',
+	'appstream:',
+	`${APP_PROTOCOL}:`,
+]);
 const recentOpens = new Map<string, number>();
 
 function getSafeExternalUrl(url: string): string | null {


### PR DESCRIPTION
## Summary

- What changed: 
  - Now reloads if web update instead of tellling user to download from app center
  - Added option to open app center if managed flatpak package
- Why it is correct:
   Because web updates requite only reload and almost all software centers which support flatpak also supports the appstream url 
- Risk: 
   Added new safe protocol `appstream:` which can used to software links but they are curated mostly so quite safe 

## Verification

- Tests run: 
  `pnpm test`  and all the files I edited passed 
- Manual checks:
   `openExternalUrl` opens the software center atleast via console 
- Screenshots or recordings:

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

None

<!--
"I am A.I.: Actually Indian."
– Me
-->

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
