### PR TITLE
fix: OpenAPI spec does not require nullable description in rich embeds

### DIFF
--- a/fluxer_api/src/api/openapi/openapi.json
+++ b/fluxer_api/src/api/openapi/openapi.json
@@ -28596,8 +28596,7 @@
 						],
 						"description": "Array of field objects (max 25)"
 					}
-				},
-				"required": ["description"]
+				}
 			},
 			"RichEmbedAuthorRequest": {
 				"anyOf": [

--- a/packages/schema/src/domains/message/MessageRequestSchemas.ts
+++ b/packages/schema/src/domains/message/MessageRequestSchemas.ts
@@ -101,6 +101,7 @@ export const RichEmbedRequest = z.object({
 	timestamp: DateTimeType.nullish().describe('ISO8601 timestamp for the embed'),
 	description: z
 		.preprocess(omitEmptyString, createStringType(1, RICH_EMBED_DESCRIPTION_MAX_LENGTH).nullish())
+		.optional()
 		.describe(`Description of the embed (1-${RICH_EMBED_DESCRIPTION_MAX_LENGTH} characters)`),
 	author: RichEmbedAuthorRequest.nullish().describe('Author information'),
 	image: RichEmbedMediaRequest.nullish().describe('Image to display in the embed'),


### PR DESCRIPTION
## Summary

- What changed:
Per https://github.com/fluxerapp/fluxer/issues/1518, have altered the OpenAPI spec to conform to observed behaviour. It is entirely possible this is deleterious as I cannot get a dev environment working and I have not tested everything yet.
- Why it is correct:
Unknown if it is as of yet, this PR is just to demonstrate what the change should be. See outline of what I know to be true in original issue.
- Risk:
There could be an endpoint that uses the `RichEmbedRequest` type that does not handle for the missing value. I would expect this to not be the case.

## Verification

- Tests run:
- Manual checks:
Sent data without the relevant field to the endpoints mentioned in the original issue.
- Screenshots or recordings:

## Checklist

- [x] I understand every change in this PR.
- [ ] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

None, I would sooner put a bullet in my head.

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
