### PR TITLE
fix(messaging): strip leading @ from special mentions during autocomplete query filtering

### DIFF
--- a/fluxer_app/src/features/messaging/hooks/useTextareaAutocomplete.ts
+++ b/fluxer_app/src/features/messaging/hooks/useTextareaAutocomplete.ts
@@ -546,7 +546,7 @@ export function useTextareaAutocomplete({
 					const specialMentions = canMentionEveryone
 						? SPECIAL_MENTIONS.filter((mention) => {
 								if (!queryForMatching) return true;
-								return mention.kind.toLowerCase().includes(queryForMatching.toLowerCase());
+								return mention.kind.slice(1).toLowerCase().includes(queryForMatching.toLowerCase());
 							})
 						: [];
 					options = [...members, ...specialMentions, ...roles];


### PR DESCRIPTION
Fixes #1055



## Summary



- What changed:

  Updated `useTextareaAutocomplete.ts` so the filter for `@everyone` and `@here` strips the leading `@` before checking if it matches the user's typed query.



- Why it is correct:

  Currently, if you type `@@`, `@everyone` and `@here` still pop up in the autocomplete menu even though neither contains `@@`. Roles disappear as expected, but special mentions stay because their stored values (`kind: '@everyone' | '@here'`) include the `@` sigil. When you type `@@`, the trigger consumes the first `@`, leaving `@` as the query, so `'@everyone'.includes('@')` returns `true`.



  Since `kind` is used for the dropdown label and the inserted message text, the `@` needs to stay in the data model, but we should strip it (`slice(1)`) while filtering.



  I went with `slice(1)` rather than prepending `@` to the query because prepending `@` would force matching to the start of the word and break substring matching. For example, typing `@one` should match `@everyone` (since `everyone` contains `one`) as well as a role named `someone`. `slice(1)` keeps substring matching consistent across both special mentions and roles.



- Risk:

  Low, it's a single line change in one file. Typing a bare `@` with no query still lists both `@everyone` and `@here`.



## Verification



- Tests run:

  Ran `biome check` on the file (passed).



- Manual checks:

  Tested locally on a devcontainer instance:



  | Input | Before Fix | After Fix |

  | Input | Before Fix | After Fix |
  | :--- | :--- | :--- |
  | `@@` | `@everyone` + `@here` | *Nothing* |
  | `@one` | `@everyone` + role `someone` | Unchanged (both listed) |
  | `@every` | `@everyone` | Unchanged |
 


- Screenshots or recordings:



  **Before fix (typing `@@`):**

  <img width="2940" height="1668" alt="bugged1" src="https://github.com/user-attachments/assets/89906f75-f6e9-4d16-a2d4-f0b10557a499" />



  **After fix (typing `@@`):**

  <img width="2940" height="1654" alt="fix2" src="https://github.com/user-attachments/assets/2d927a98-a211-44d6-9643-026f01c48bac" />



  **No regression check (typing `@one`):**

  <img width="2934" height="1658" alt="fix1" src="https://github.com/user-attachments/assets/36650efc-6c7c-47fd-908b-32fe3ce6866f" />



## Checklist



- [x] I understand every change in this PR.

- [x] I can explain what it does and why it is correct.

- [x] I disclosed any LLM coding help below.



## LLM Disclosure



- None



<!--

Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.



"I have A.I.: actual intelligence."

– Steve Wozniak

-->