### PR TITLE
fix(api): allow cross-instance invite lookups with middleware CORS

### DIFF
--- a/fluxer_api/src/api/app/MiddlewarePipeline.ts
+++ b/fluxer_api/src/api/app/MiddlewarePipeline.ts
@@ -34,6 +34,7 @@ export function configureMiddleware(routes: HonoApp, options: MiddlewarePipeline
 	const resolvedHeader = resolveClientIpHeaderName(clientIpHeaderName);
 	routes.use('/webhooks/:webhook_id/:token', cors({origins: '*'}));
 	routes.use('/webhooks/:webhook_id/:token/messages/:message_id', cors({origins: '*'}));
+	routes.use('/invites/:invite_code', cors({origins: '*'}));
 	applyMiddlewareStack(routes, {
 		requestId: {},
 		cors: {origins: corsOrigins, exposedHeaders: [HttpHeaders.X_FLUXER_VERSION]},


### PR DESCRIPTION
## Summary

- What changed:
  - Added invite route to the middleware with CORS wildcard
- Why it is correct:
  - /invites/:invite_code is already public & without auth like well-known. So this adds a wildcard to CORS so that other fluxer instances can resolve invite metadata from the API
  - I'm working on a PR that will resolve cross-instance invites, at least specifically from self-hosted instances to the official instance as it stands for now, within the app properly that'll make use of it.
- Risk: None

## Verification

- Tests run: None
- Manual checks: None
- Screenshots or recordings: None

## Checklist

- [x] I understand every change in this PR.
- [x] I can explain what it does and why it is correct.
- [x] I disclosed any LLM coding help below.

## LLM Disclosure

- None

<!--
Do not remove this hidden anti-spam marker. For qualifying first-time external contributors, removing it causes automated spam handling, including closing and locking the pull request as spam and blocking the author from the organization.

"I have A.I.: actual intelligence."
– Steve Wozniak
-->
