### PR TITLE
fix(api): make PostgreSQL job ledger durable and bounded

### DIFF
--- a/fluxer_admin/src/api/jobs.rs
+++ b/fluxer_admin/src/api/jobs.rs
@@ -3,7 +3,9 @@
 use crate::api::generated::types as generated_types;
 
 use super::client::{AdminApiClient, ApiError, ApiResult};
-use super::types::{ActiveJobsResponse, CancelJobResponse, GetJobResponse, ListJobsResponse};
+use super::types::{
+    ActiveJobsRequest, ActiveJobsResponse, CancelJobResponse, GetJobResponse, ListJobsResponse,
+};
 
 pub struct ListJobsParams {
     pub limit: u32,
@@ -78,12 +80,16 @@ impl AdminApiClient {
             .await
     }
 
-    pub async fn list_active_jobs(&self) -> ApiResult<ActiveJobsResponse> {
-        let response = self
-            .generated()
-            .list_active_jobs()
+    pub async fn list_active_jobs_page(
+        &self,
+        page_state: Option<String>,
+    ) -> ApiResult<ActiveJobsResponse> {
+        let body = ActiveJobsRequest {
+            limit: 200,
+            page_state,
+            task_type: None,
+        };
+        self.post_typed_with_reason("/admin/jobs/active", &body, None)
             .await
-            .map_err(|e| self.generated_error(e))?;
-        self.generated_value(response.into_inner())
     }
 }

--- a/fluxer_admin/src/api/types/jobs.rs
+++ b/fluxer_admin/src/api/types/jobs.rs
@@ -25,4 +25,13 @@ pub struct CancelJobResponse {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ActiveJobsResponse {
     pub jobs: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub next_page_state: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ActiveJobsRequest {
+    pub limit: u16,
+    pub page_state: Option<String>,
+    pub task_type: Option<String>,
 }

--- a/fluxer_admin/src/routes/jobs.rs
+++ b/fluxer_admin/src/routes/jobs.rs
@@ -38,6 +38,11 @@ struct JobActionQuery {
 }
 
 #[derive(Deserialize)]
+struct ActiveJobsQuery {
+    page_state: Option<String>,
+}
+
+#[derive(Deserialize)]
 struct JobActionForm {
     audit_log_reason: Option<String>,
     #[serde(default)]
@@ -132,14 +137,15 @@ async fn jobs_list(
 async fn jobs_active_json(
     State(state): State<AppState>,
     auth: axum::Extension<AuthContext>,
+    Query(query): Query<ActiveJobsQuery>,
 ) -> Response {
     let config = state.config();
     let client = AdminApiClient::new(state.http_client(), config, &auth.0.session);
-    match client.list_active_jobs().await {
-        Ok(data) => Json(serde_json::json!(data)).into_response(),
+    match client.list_active_jobs_page(query.page_state).await {
+        Ok(data) => Json(data).into_response(),
         Err(error) => {
             tracing::warn!(%error, "admin API request failed: list active jobs");
-            Json(serde_json::json!({ "jobs": [] })).into_response()
+            Json(serde_json::json!({"jobs": [], "next_page_state": null})).into_response()
         }
     }
 }

--- a/fluxer_api/src/api/Tables.ts
+++ b/fluxer_api/src/api/Tables.ts
@@ -188,9 +188,11 @@ import {
 import {INSTANCE_CONFIGURATION_COLUMNS, type InstanceConfigurationRow} from './database/types/InstanceConfigTypes';
 import {
 	JOB_ACTIVE_COLUMNS,
+	JOB_ACTIVE_V2_COLUMNS,
 	JOB_BY_DAY_BUCKET_COLUMNS,
 	JOB_BY_ID_COLUMNS,
 	type JobActiveRow,
+	type JobActiveV2Row,
 	type JobByDayBucketRow,
 	type JobByIdRow,
 } from './database/types/JobLedgerTypes';
@@ -1154,10 +1156,16 @@ export const JobsByDayBucket = defineTable<JobByDayBucketRow, 'bucket_day' | 'cr
 	primaryKey: ['bucket_day', 'created_at', 'job_id'],
 	partitionKey: ['bucket_day'],
 });
-export const JobsActive = defineTable<JobActiveRow, 'job_id'>({
+export const JobsActiveLegacy = defineTable<JobActiveRow, 'job_id'>({
 	name: 'jobs_active',
 	columns: JOB_ACTIVE_COLUMNS,
 	primaryKey: ['job_id'],
+});
+export const JobsActive = defineTable<JobActiveV2Row, 'shard' | 'job_id', 'shard'>({
+	name: 'jobs_active_v2',
+	columns: JOB_ACTIVE_V2_COLUMNS,
+	primaryKey: ['shard', 'job_id'],
+	partitionKey: ['shard'],
 });
 export const AttachmentUploadTracesByKey = defineTable<AttachmentUploadTraceByKeyRow, 'upload_key'>({
 	name: 'attachment_upload_traces_by_key',

--- a/fluxer_api/src/api/admin/controllers/JobsAdminController.ts
+++ b/fluxer_api/src/api/admin/controllers/JobsAdminController.ts
@@ -2,6 +2,7 @@
 
 import {AdminACLs} from '@fluxer/constants/src/AdminACLs';
 import {
+	ActiveJobsRequest,
 	ActiveJobsResponseSchema,
 	CancelJobRequest,
 	CancelJobResponseSchema,
@@ -83,6 +84,7 @@ export function JobsAdminController(app: HonoApp) {
 		'/admin/jobs/active',
 		RateLimitMiddleware(RateLimitConfigs.ADMIN_JOBS_VIEW),
 		requireAdminACL(AdminACLs.JOBS_VIEW),
+		Validator('json', ActiveJobsRequest),
 		OpenAPI({
 			operationId: 'list_active_jobs',
 			summary: 'List active (queued + running) jobs',
@@ -95,7 +97,7 @@ export function JobsAdminController(app: HonoApp) {
 		}),
 		async (ctx) => {
 			const adminService = ctx.get('adminService');
-			return ctx.json(await adminService.jobAdminService.listActiveJobs());
+			return ctx.json(await adminService.jobAdminService.listActiveJobs(ctx.req.valid('json')));
 		},
 	);
 }

--- a/fluxer_api/src/api/billing/repositories/BillingChargeRepository.ts
+++ b/fluxer_api/src/api/billing/repositories/BillingChargeRepository.ts
@@ -5,7 +5,7 @@ import {fetchMany, fetchOne, fetchPage, type PagedQueryResult, upsertOne} from '
 import type {BillingChargeRow} from '../../database/types/BillingTypes';
 import {BillingCharges, BillingChargesByCustomer} from '../../Tables';
 import {mapStripeChargeToRow} from '../mappers/StripeToBillingMapper';
-import {isExistingNewer} from './BillingRepoHelpers';
+import {BILLING_REVERSE_CHRONOLOGICAL_ORDER, isExistingNewer, restoreReferenceOrder} from './BillingRepoHelpers';
 
 const FETCH_BY_ID = BillingCharges.selectCql({
 	where: BillingCharges.where.eq('provider_id'),
@@ -13,6 +13,7 @@ const FETCH_BY_ID = BillingCharges.selectCql({
 });
 const FETCH_BY_CUSTOMER = BillingChargesByCustomer.selectCql({
 	where: BillingChargesByCustomer.where.eq('customer_id'),
+	orderBy: BILLING_REVERSE_CHRONOLOGICAL_ORDER,
 });
 const FETCH_BY_PROVIDER_IDS = BillingCharges.selectCql({
 	where: BillingCharges.where.in('provider_id', 'provider_ids'),
@@ -42,7 +43,7 @@ export class BillingChargeRepository {
 		}
 		const ids = refsPage.rows.map((r) => r.provider_id);
 		const rows = await fetchMany<BillingChargeRow>(FETCH_BY_PROVIDER_IDS, {provider_ids: ids});
-		return {rows, pageState: refsPage.pageState};
+		return {rows: restoreReferenceOrder(refsPage.rows, rows), pageState: refsPage.pageState};
 	}
 
 	async upsertFromStripe(c: Stripe.Charge): Promise<{

--- a/fluxer_api/src/api/billing/repositories/BillingCheckoutSessionRepository.ts
+++ b/fluxer_api/src/api/billing/repositories/BillingCheckoutSessionRepository.ts
@@ -5,7 +5,7 @@ import {fetchMany, fetchOne, fetchPage, type PagedQueryResult, upsertOne} from '
 import type {BillingCheckoutSessionRow} from '../../database/types/BillingTypes';
 import {BillingCheckoutSessions, BillingCheckoutSessionsByCustomer} from '../../Tables';
 import {mapStripeCheckoutSessionToRow} from '../mappers/StripeToBillingMapper';
-import {isExistingNewer} from './BillingRepoHelpers';
+import {BILLING_REVERSE_CHRONOLOGICAL_ORDER, isExistingNewer, restoreReferenceOrder} from './BillingRepoHelpers';
 
 const FETCH_BY_ID = BillingCheckoutSessions.selectCql({
 	where: BillingCheckoutSessions.where.eq('provider_id'),
@@ -13,6 +13,7 @@ const FETCH_BY_ID = BillingCheckoutSessions.selectCql({
 });
 const FETCH_BY_CUSTOMER = BillingCheckoutSessionsByCustomer.selectCql({
 	where: BillingCheckoutSessionsByCustomer.where.eq('customer_id'),
+	orderBy: BILLING_REVERSE_CHRONOLOGICAL_ORDER,
 });
 const FETCH_BY_PROVIDER_IDS = BillingCheckoutSessions.selectCql({
 	where: BillingCheckoutSessions.where.in('provider_id', 'provider_ids'),
@@ -42,7 +43,7 @@ export class BillingCheckoutSessionRepository {
 		}
 		const ids = refsPage.rows.map((r) => r.provider_id);
 		const rows = await fetchMany<BillingCheckoutSessionRow>(FETCH_BY_PROVIDER_IDS, {provider_ids: ids});
-		return {rows, pageState: refsPage.pageState};
+		return {rows: restoreReferenceOrder(refsPage.rows, rows), pageState: refsPage.pageState};
 	}
 
 	async upsertFromStripe(

--- a/fluxer_api/src/api/billing/repositories/BillingInvoiceRepository.ts
+++ b/fluxer_api/src/api/billing/repositories/BillingInvoiceRepository.ts
@@ -12,7 +12,14 @@ import {
 } from '../../Tables';
 import {mapStripeInvoiceToRow} from '../mappers/StripeToBillingMapper';
 import type {BillingPaymentRepository} from './BillingPaymentRepository';
-import {buildPatchFromRow, executeBillingVersionedUpdate, isExistingNewer, rowsEquivalent} from './BillingRepoHelpers';
+import {
+	BILLING_REVERSE_CHRONOLOGICAL_ORDER,
+	buildPatchFromRow,
+	executeBillingVersionedUpdate,
+	isExistingNewer,
+	restoreReferenceOrder,
+	rowsEquivalent,
+} from './BillingRepoHelpers';
 
 const FETCH_BY_ID = BillingInvoices.selectCql({
 	where: BillingInvoices.where.eq('provider_id'),
@@ -20,9 +27,11 @@ const FETCH_BY_ID = BillingInvoices.selectCql({
 });
 const FETCH_BY_CUSTOMER_PARTITION = BillingInvoicesByCustomer.selectCql({
 	where: BillingInvoicesByCustomer.where.eq('customer_id'),
+	orderBy: BILLING_REVERSE_CHRONOLOGICAL_ORDER,
 });
 const FETCH_BY_SUBSCRIPTION_PARTITION = BillingInvoicesBySubscription.selectCql({
 	where: BillingInvoicesBySubscription.where.eq('subscription_id'),
+	orderBy: BILLING_REVERSE_CHRONOLOGICAL_ORDER,
 });
 const FETCH_BY_PROVIDER_IDS = BillingInvoices.selectCql({
 	where: BillingInvoices.where.in('provider_id', 'provider_ids'),
@@ -30,6 +39,48 @@ const FETCH_BY_PROVIDER_IDS = BillingInvoices.selectCql({
 const FETCH_CUSTOMERS_BY_USER = BillingCustomersByUserId.selectCql({
 	where: BillingCustomersByUserId.where.eq('user_id'),
 });
+
+interface InvoiceRef {
+	provider_id: string;
+	stripe_created_at: Date;
+}
+
+interface UserInvoicePartitionState {
+	customerId: string;
+	nextPageState: string | null;
+	exhausted: boolean;
+	buffer: Array<{providerId: string; stripeCreatedAt: string}>;
+}
+
+interface UserInvoicePageState {
+	version: 1;
+	partitions: Array<UserInvoicePartitionState>;
+}
+
+function decodeUserInvoicePageState(value: string): UserInvoicePageState {
+	const decoded = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as UserInvoicePageState;
+	const validPartitions =
+		Array.isArray(decoded.partitions) &&
+		decoded.partitions.every((partition) => {
+			if (typeof partition.customerId !== 'string') return false;
+			if (partition.nextPageState !== null && typeof partition.nextPageState !== 'string') return false;
+			if (typeof partition.exhausted !== 'boolean' || !Array.isArray(partition.buffer)) return false;
+			return partition.buffer.every(
+				(ref) =>
+					typeof ref.providerId === 'string' &&
+					typeof ref.stripeCreatedAt === 'string' &&
+					Number.isFinite(new Date(ref.stripeCreatedAt).getTime()),
+			);
+		});
+	if (decoded.version !== 1 || !validPartitions) {
+		throw new Error('Invalid billing invoice user page state');
+	}
+	return decoded;
+}
+
+function encodeUserInvoicePageState(state: UserInvoicePageState): string {
+	return Buffer.from(JSON.stringify(state)).toString('base64url');
+}
 
 export class BillingInvoiceRepository {
 	constructor(private paymentsRepo: BillingPaymentRepository) {}
@@ -57,7 +108,7 @@ export class BillingInvoiceRepository {
 		}
 		const ids = refsPage.rows.map((r) => r.provider_id);
 		const rows = await fetchMany<BillingInvoiceRow>(FETCH_BY_PROVIDER_IDS, {provider_ids: ids});
-		return {rows, pageState: refsPage.pageState};
+		return {rows: restoreReferenceOrder(refsPage.rows, rows), pageState: refsPage.pageState};
 	}
 
 	async listBySubscription(
@@ -79,7 +130,7 @@ export class BillingInvoiceRepository {
 		}
 		const ids = refsPage.rows.map((r) => r.provider_id);
 		const rows = await fetchMany<BillingInvoiceRow>(FETCH_BY_PROVIDER_IDS, {provider_ids: ids});
-		return {rows, pageState: refsPage.pageState};
+		return {rows: restoreReferenceOrder(refsPage.rows, rows), pageState: refsPage.pageState};
 	}
 
 	async listByUser(
@@ -89,20 +140,69 @@ export class BillingInvoiceRepository {
 			pageState?: string | null;
 		},
 	): Promise<PagedQueryResult<BillingInvoiceRow>> {
+		const pageSize = page?.pageSize ?? 50;
 		const customerRefs = await fetchMany<{
 			provider_id: string;
 		}>(FETCH_CUSTOMERS_BY_USER, {user_id: userId});
 		if (customerRefs.length === 0) {
 			return {rows: [], pageState: null};
 		}
-		const aggregated: Array<BillingInvoiceRow> = [];
-		let lastPageState: string | null = null;
-		for (const ref of customerRefs) {
-			const result = await this.listByCustomer(ref.provider_id, page);
-			aggregated.push(...result.rows);
-			lastPageState = result.pageState;
+		const customerIds = customerRefs.map((ref) => ref.provider_id).sort();
+		const decoded = page?.pageState ? decodeUserInvoicePageState(page.pageState) : null;
+		if (
+			decoded &&
+			decoded.partitions
+				.map((partition) => partition.customerId)
+				.sort()
+				.join('\0') !== customerIds.join('\0')
+		) {
+			throw new Error('Billing invoice user page state does not match the current customer partitions');
 		}
-		return {rows: aggregated, pageState: lastPageState};
+		const partitions: Array<UserInvoicePartitionState> =
+			decoded?.partitions ??
+			customerIds.map((customerId) => ({customerId, nextPageState: null, exhausted: false, buffer: []}));
+		const fill = async (partition: UserInvoicePartitionState): Promise<void> => {
+			if (partition.buffer.length > 0 || partition.exhausted) return;
+			const refsPage = await fetchPage<InvoiceRef>(
+				FETCH_BY_CUSTOMER_PARTITION,
+				{customer_id: partition.customerId},
+				{pageSize, pageState: partition.nextPageState},
+			);
+			partition.buffer = refsPage.rows.map((ref) => ({
+				providerId: ref.provider_id,
+				stripeCreatedAt: ref.stripe_created_at.toISOString(),
+			}));
+			partition.nextPageState = refsPage.pageState;
+			partition.exhausted = refsPage.pageState === null;
+		};
+		await Promise.all(partitions.map(fill));
+		const selected: Array<{provider_id: string}> = [];
+		while (selected.length < pageSize) {
+			let selectedPartition: UserInvoicePartitionState | null = null;
+			for (const partition of partitions) {
+				const candidate = partition.buffer[0];
+				const current = selectedPartition?.buffer[0];
+				if (
+					candidate &&
+					(!current ||
+						candidate.stripeCreatedAt > current.stripeCreatedAt ||
+						(candidate.stripeCreatedAt === current.stripeCreatedAt && candidate.providerId < current.providerId))
+				) {
+					selectedPartition = partition;
+				}
+			}
+			if (!selectedPartition) break;
+			const next = selectedPartition.buffer.shift()!;
+			selected.push({provider_id: next.providerId});
+			await fill(selectedPartition);
+		}
+		const ids = selected.map((ref) => ref.provider_id);
+		const rows = ids.length === 0 ? [] : await fetchMany<BillingInvoiceRow>(FETCH_BY_PROVIDER_IDS, {provider_ids: ids});
+		const hasMore = partitions.some((partition) => partition.buffer.length > 0 || !partition.exhausted);
+		return {
+			rows: restoreReferenceOrder(selected, rows),
+			pageState: hasMore ? encodeUserInvoicePageState({version: 1, partitions}) : null,
+		};
 	}
 
 	async upsertFromStripe(

--- a/fluxer_api/src/api/billing/repositories/BillingPaymentIntentRepository.ts
+++ b/fluxer_api/src/api/billing/repositories/BillingPaymentIntentRepository.ts
@@ -10,7 +10,7 @@ import {
 	BillingPaymentsByInvoice,
 } from '../../Tables';
 import {mapStripePaymentIntentToRow} from '../mappers/StripeToBillingMapper';
-import {isExistingNewer} from './BillingRepoHelpers';
+import {BILLING_REVERSE_CHRONOLOGICAL_ORDER, isExistingNewer, restoreReferenceOrder} from './BillingRepoHelpers';
 
 const FETCH_BY_ID = BillingPaymentIntents.selectCql({
 	where: BillingPaymentIntents.where.eq('provider_id'),
@@ -18,6 +18,7 @@ const FETCH_BY_ID = BillingPaymentIntents.selectCql({
 });
 const FETCH_BY_CUSTOMER = BillingPaymentIntentsByCustomer.selectCql({
 	where: BillingPaymentIntentsByCustomer.where.eq('customer_id'),
+	orderBy: BILLING_REVERSE_CHRONOLOGICAL_ORDER,
 });
 const FETCH_BY_PROVIDER_IDS = BillingPaymentIntents.selectCql({
 	where: BillingPaymentIntents.where.in('provider_id', 'provider_ids'),
@@ -56,7 +57,7 @@ export class BillingPaymentIntentRepository {
 		}
 		const ids = refsPage.rows.map((r) => r.provider_id);
 		const rows = await fetchMany<BillingPaymentIntentRow>(FETCH_BY_PROVIDER_IDS, {provider_ids: ids});
-		return {rows, pageState: refsPage.pageState};
+		return {rows: restoreReferenceOrder(refsPage.rows, rows), pageState: refsPage.pageState};
 	}
 
 	async findByInvoiceId(invoiceId: string): Promise<BillingPaymentIntentRow | null> {

--- a/fluxer_api/src/api/billing/repositories/BillingRefundRepository.ts
+++ b/fluxer_api/src/api/billing/repositories/BillingRefundRepository.ts
@@ -10,7 +10,7 @@ import {
 	BillingRefundsByPaymentIntent,
 } from '../../Tables';
 import {mapStripeRefundToRow} from '../mappers/StripeToBillingMapper';
-import {isExistingNewer} from './BillingRepoHelpers';
+import {isExistingNewer, restoreReferenceOrder} from './BillingRepoHelpers';
 
 const FETCH_BY_ID = BillingRefunds.selectCql({
 	where: BillingRefunds.where.eq('provider_id'),
@@ -36,7 +36,8 @@ async function hydrate(
 ): Promise<Array<BillingRefundRow>> {
 	if (refs.length === 0) return [];
 	const ids = refs.map((r) => r.provider_id);
-	return fetchMany<BillingRefundRow>(FETCH_BY_PROVIDER_IDS, {provider_ids: ids});
+	const rows = await fetchMany<BillingRefundRow>(FETCH_BY_PROVIDER_IDS, {provider_ids: ids});
+	return restoreReferenceOrder(refs, rows);
 }
 
 export class BillingRefundRepository {

--- a/fluxer_api/src/api/billing/repositories/BillingRepoHelpers.ts
+++ b/fluxer_api/src/api/billing/repositories/BillingRepoHelpers.ts
@@ -5,6 +5,22 @@ import type {ColumnName, DbOp, PatchObject, RowValue, Table} from '../../databas
 import {Db} from '../../database/CassandraTypes';
 import {buildPatchFromData} from '../../database/CassandraVersionedUpdate';
 
+export function restoreReferenceOrder<Row extends {provider_id: string}>(
+	refs: ReadonlyArray<{provider_id: string}>,
+	rows: ReadonlyArray<Row>,
+): Array<Row> {
+	const byId = new Map(rows.map((row) => [row.provider_id, row]));
+	return refs.flatMap((ref) => {
+		const row = byId.get(ref.provider_id);
+		return row ? [row] : [];
+	});
+}
+
+export const BILLING_REVERSE_CHRONOLOGICAL_ORDER = [
+	{col: 'stripe_created_at', direction: 'DESC'},
+	{col: 'provider_id', direction: 'ASC'},
+] as const;
+
 function deepEqual(a: unknown, b: unknown): boolean {
 	if (a === b) return true;
 	if (a === null || a === undefined || b === null || b === undefined) {

--- a/fluxer_api/src/api/channel/services/ScheduledMessageService.ts
+++ b/fluxer_api/src/api/channel/services/ScheduledMessageService.ts
@@ -6,11 +6,12 @@ import {FeatureTemporarilyDisabledError} from '@fluxer/errors/src/domains/core/F
 import {InputValidationError} from '@fluxer/errors/src/domains/core/InputValidationError';
 import type {IWorkerService} from '@pkgs/worker/src/contracts/IWorkerService';
 import type {WorkerJobPayload} from '@pkgs/worker/src/contracts/WorkerTypes';
-import {ms, seconds} from 'itty-time';
+
 import {DateTime, IANAZone} from 'luxon';
 import type {ChannelID, MessageID, UserID} from '../../BrandedTypes';
 import {createMessageID} from '../../BrandedTypes';
 import type {ISnowflakeService} from '../../infrastructure/ISnowflakeService';
+import {MAX_JOB_SCHEDULE_DELAY_MS, WORKER_QUEUE_MAX_AGE_MS} from '../../jobs/JobSchedulingPolicy';
 import type {ScheduledMessagePayload} from '../../models/ScheduledMessage';
 import {ScheduledMessage} from '../../models/ScheduledMessage';
 import type {User} from '../../models/User';
@@ -19,7 +20,7 @@ import type {WorkerTaskName} from '../../worker/WorkerLaneConfig';
 import type {MessageRequest} from '../MessageTypes';
 import type {ChannelService} from './ChannelService';
 
-export const SCHEDULED_MESSAGE_TTL_SECONDS = seconds('31 days');
+export const SCHEDULED_MESSAGE_TTL_SECONDS = WORKER_QUEUE_MAX_AGE_MS / 1000;
 const DEFAULT_TIMEZONE = 'UTC';
 const WORKER_TASK_NAME = 'sendScheduledMessage';
 
@@ -135,7 +136,7 @@ export class ScheduledMessageService {
 		if (diffMs <= 0) {
 			throw InputValidationError.fromCode('scheduled_local_at', ValidationErrorCodes.SCHEDULED_TIME_MUST_BE_FUTURE);
 		}
-		if (diffMs > ms('30 days')) {
+		if (diffMs > MAX_JOB_SCHEDULE_DELAY_MS) {
 			throw InputValidationError.fromCode('scheduled_local_at', ValidationErrorCodes.SCHEDULED_MESSAGES_MAX_30_DAYS);
 		}
 		return scheduledAt;

--- a/fluxer_api/src/api/database/CassandraTableDsl.test.ts
+++ b/fluxer_api/src/api/database/CassandraTableDsl.test.ts
@@ -58,6 +58,20 @@ describe('CassandraTableDsl TTL helpers', () => {
 });
 
 describe('CassandraTableDsl select templates', () => {
+	it('compiles tuple cursors and deterministic multi-column ordering', () => {
+		const query = TtlHelperTestRows.select({
+			where: TtlHelperTestRows.where.tupleLt(['id', 'value'], ['cursor_id', 'cursor_value']),
+			orderBy: [
+				{col: 'id', direction: 'DESC'},
+				{col: 'value', direction: 'DESC'},
+			],
+			limit: 25,
+		}).bind({cursor_id: 'b', cursor_value: 'z'});
+
+		expect(query.cql).toContain('(id, value) < (:cursor_id, :cursor_value)');
+		expect(query.cql).toContain('ORDER BY id DESC, value DESC');
+	});
+
 	it('binds LIMIT values for prepared query templates', () => {
 		const shortQuery = TtlHelperTestRows.select({
 			where: TtlHelperTestRows.where.eq('id'),

--- a/fluxer_api/src/api/database/CassandraTableDsl.ts
+++ b/fluxer_api/src/api/database/CassandraTableDsl.ts
@@ -30,13 +30,13 @@ function assertCqlIdentifier(value: string): string {
 }
 
 function compileWhere<Row extends object>(w: WhereExpr<Row>): string {
-	if (w.kind === 'tupleGt') {
+	if (w.kind === 'tupleGt' || w.kind === 'tupleLt') {
 		if (w.cols.length !== w.params.length || w.cols.length === 0) {
-			throw new Error('tupleGt requires equal-length non-empty cols/params');
+			throw new Error(`${w.kind} requires equal-length non-empty cols/params`);
 		}
 		const cols = `(${w.cols.map((c) => assertCqlIdentifier(c as string)).join(', ')})`;
 		const params = `(${w.params.map((p) => `:${assertCqlIdentifier(p as string)}`).join(', ')})`;
-		return `${cols} > ${params}`;
+		return `${cols} ${w.kind === 'tupleGt' ? '>' : '<'} ${params}`;
 	}
 	const col = assertCqlIdentifier(w.col as string);
 	const param = assertCqlIdentifier(w.param as string);
@@ -145,7 +145,7 @@ WHERE ${pk.map((k) => `${k} = :${k}`).join(' AND ')};
 		opts: {
 			columns?: ReadonlyArray<ColumnName<Row>>;
 			where?: WhereExpr<Row> | ReadonlyArray<WhereExpr<Row>>;
-			orderBy?: OrderBy<Row>;
+			orderBy?: OrderBy<Row> | ReadonlyArray<OrderBy<Row>>;
 			limit?: number;
 		} = {},
 		limitParamName?: string,
@@ -158,7 +158,11 @@ WHERE ${pk.map((k) => `${k} = :${k}`).join(' AND ')};
 				where = ` WHERE ${clauses.map((c) => compileWhere<Row>(c)).join(' AND ')}`;
 			}
 		}
-		const orderBy = opts.orderBy != null ? ` ORDER BY ${opts.orderBy.col} ${opts.orderBy.direction ?? 'ASC'}` : '';
+		const orderItems = opts.orderBy == null ? [] : Array.isArray(opts.orderBy) ? opts.orderBy : [opts.orderBy];
+		const orderBy =
+			orderItems.length > 0
+				? ` ORDER BY ${orderItems.map((item) => `${item.col} ${item.direction ?? 'ASC'}`).join(', ')}`
+				: '';
 		const limit = typeof opts.limit === 'number' ? ` LIMIT ${limitParamName ? `:${limitParamName}` : opts.limit}` : '';
 		return `SELECT ${selectCols} FROM ${def.name}${where}${orderBy}${limit};`;
 	}
@@ -166,7 +170,7 @@ WHERE ${pk.map((k) => `${k} = :${k}`).join(' AND ')};
 		opts: {
 			columns?: ReadonlyArray<ColumnName<Row>>;
 			where?: WhereExpr<Row> | ReadonlyArray<WhereExpr<Row>>;
-			orderBy?: OrderBy<Row>;
+			orderBy?: OrderBy<Row> | ReadonlyArray<OrderBy<Row>>;
 			limit?: number;
 		} = {},
 	): string {
@@ -186,7 +190,7 @@ WHERE ${pk.map((k) => `${k} = :${k}`).join(' AND ')};
 		opts: {
 			columns?: ReadonlyArray<ColumnName<Row>>;
 			where?: WhereExpr<Row> | ReadonlyArray<WhereExpr<Row>>;
-			orderBy?: OrderBy<Row>;
+			orderBy?: OrderBy<Row> | ReadonlyArray<OrderBy<Row>>;
 			limit?: number;
 		} = {},
 	): QueryTemplate {
@@ -234,6 +238,49 @@ WHERE ${pk.map((k) => `${k} = :${k}`).join(' AND ')};
 			patch: patch as Partial<Record<ColumnName<Row>, DbOp<unknown>>>,
 			patchKeys,
 			pkColumns: pk,
+		};
+		return prepared(cql, params, kvMeta as KvQueryMeta<Record<string, unknown>>);
+	}
+	function patchByPkIf(
+		pkValues: Pick<Row, PK>,
+		patch: Partial<{
+			[K in Exclude<ColumnName<Row>, PK>]: DbOp<RowValue<Row, K>>;
+		}>,
+		condition:
+			| {col: ColumnName<Row>; expected: RowValue<Row, ColumnName<Row>>}
+			| ReadonlyArray<{col: ColumnName<Row>; expected: RowValue<Row, ColumnName<Row>>}>,
+	): PreparedQuery {
+		const patchKeys = Object.keys(patch) as Array<Exclude<ColumnName<Row>, PK>>;
+		if (patchKeys.length === 0) {
+			throw new Error(`Refusing to execute empty conditional PATCH update on table "${def.name}"`);
+		}
+		patchKeys.sort((a, b) => columns.indexOf(a) - columns.indexOf(b));
+		const conditions = Array.isArray(condition) ? condition : [condition];
+		if (conditions.length === 0) throw new Error('Conditional PATCH requires at least one condition');
+		const conditionParams = conditions.map((item) => `if_${item.col}_expected`);
+		const cql = `UPDATE ${def.name}
+SET ${patchKeys.map((c) => `${c} = :${c}`).join(', ')}
+WHERE ${pk.map((k) => `${k} = :${k}`).join(' AND ')}
+IF ${conditions.map((item, index) => `${item.col} = :${conditionParams[index]}`).join(' AND ')};
+`;
+		const params: CassandraParams = {};
+		for (const k of pk) params[k] = pkValues[k] as CassandraParam;
+		for (const c of patchKeys) params[c] = opToValue(patch[c] as DbOp<unknown>);
+		conditions.forEach((item, index) => {
+			params[conditionParams[index] as string] = item.expected as CassandraParam;
+		});
+		const conditionMeta = conditions.map((item, index) => ({
+			col: item.col,
+			expectedParam: conditionParams[index] as string,
+			expectedValue: item.expected,
+		}));
+		const kvMeta: KvQueryMeta<Row> = {
+			action: 'patch',
+			table: tableSpec,
+			patch: patch as Partial<Record<ColumnName<Row>, DbOp<unknown>>>,
+			patchKeys,
+			pkColumns: pk,
+			...(conditionMeta.length === 1 ? {condition: conditionMeta[0]} : {conditions: conditionMeta}),
 		};
 		return prepared(cql, params, kvMeta as KvQueryMeta<Record<string, unknown>>);
 	}
@@ -418,6 +465,52 @@ WHERE ${pk.map((k) => `${k} = :${k}`).join(' AND ')};
 		};
 		return prepared(cql, params, kvMeta as KvQueryMeta<Record<string, unknown>>);
 	}
+	function patchByPkWithTtlIf(
+		pkValues: Pick<Row, PK>,
+		patch: Partial<{
+			[K in Exclude<ColumnName<Row>, PK>]: DbOp<RowValue<Row, K>>;
+		}>,
+		ttlSeconds: number,
+		condition:
+			| {col: ColumnName<Row>; expected: RowValue<Row, ColumnName<Row>>}
+			| ReadonlyArray<{col: ColumnName<Row>; expected: RowValue<Row, ColumnName<Row>>}>,
+	): PreparedQuery {
+		const patchKeys = Object.keys(patch) as Array<Exclude<ColumnName<Row>, PK>>;
+		if (patchKeys.length === 0) {
+			throw new Error(`Refusing to execute empty conditional TTL PATCH update on table "${def.name}"`);
+		}
+		patchKeys.sort((a, b) => columns.indexOf(a) - columns.indexOf(b));
+		const conditions = Array.isArray(condition) ? condition : [condition];
+		if (conditions.length === 0) throw new Error('Conditional TTL PATCH requires at least one condition');
+		const conditionParams = conditions.map((item) => `if_${item.col}_expected`);
+		const cql = `UPDATE ${def.name} USING TTL :${DEFAULT_TTL_PARAM_NAME}
+SET ${patchKeys.map((c) => `${c} = :${c}`).join(', ')}
+WHERE ${pk.map((k) => `${k} = :${k}`).join(' AND ')}
+IF ${conditions.map((item, index) => `${item.col} = :${conditionParams[index]}`).join(' AND ')};
+`;
+		const params: CassandraParams = {};
+		for (const k of pk) params[k] = pkValues[k] as CassandraParam;
+		for (const c of patchKeys) params[c] = opToValue(patch[c] as DbOp<unknown>);
+		params[DEFAULT_TTL_PARAM_NAME] = ttlSeconds;
+		conditions.forEach((item, index) => {
+			params[conditionParams[index] as string] = item.expected as CassandraParam;
+		});
+		const conditionMeta = conditions.map((item, index) => ({
+			col: item.col,
+			expectedParam: conditionParams[index] as string,
+			expectedValue: item.expected,
+		}));
+		const kvMeta: KvQueryMeta<Row> = {
+			action: 'patch',
+			table: tableSpec,
+			patch: patch as Partial<Record<ColumnName<Row>, DbOp<unknown>>>,
+			patchKeys,
+			pkColumns: pk,
+			ttlParamName: DEFAULT_TTL_PARAM_NAME,
+			...(conditionMeta.length === 1 ? {condition: conditionMeta[0]} : {conditions: conditionMeta}),
+		};
+		return prepared(cql, params, kvMeta as KvQueryMeta<Record<string, unknown>>);
+	}
 	function patchByPkWithTtlParam(
 		pkValues: Pick<Row, PK>,
 		patch: Partial<{
@@ -501,6 +594,7 @@ WHERE ${pk.map((k) => `${k} = :${k}`).join(' AND ')};
 			return prepared(cql, params, kvMeta as KvQueryMeta<Record<string, unknown>>);
 		},
 		patchByPk,
+		patchByPkIf,
 		deleteCql,
 		delete: del,
 		deleteByPk,
@@ -514,6 +608,7 @@ WHERE ${pk.map((k) => `${k} = :${k}`).join(' AND ')};
 		selectCount,
 		insertWithNow,
 		patchByPkWithTtl,
+		patchByPkWithTtlIf,
 		patchByPkWithTtlParam,
 		upsertAllWithTtl,
 		upsertAllWithTtlParam,
@@ -526,6 +621,7 @@ WHERE ${pk.map((k) => `${k} = :${k}`).join(' AND ')};
 			gte: (col, param) => ({kind: 'gte', col, param: param ?? col}),
 			tokenGt: (col, param) => ({kind: 'tokenGt', col, param}),
 			tupleGt: (cols, params) => ({kind: 'tupleGt', cols, params}),
+			tupleLt: (cols, params) => ({kind: 'tupleLt', cols, params}),
 		},
 	};
 }

--- a/fluxer_api/src/api/database/CassandraTypes.test.ts
+++ b/fluxer_api/src/api/database/CassandraTypes.test.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {describe, expect, it} from 'vitest';
+import {InMemoryCassandraQueryExecutor} from '../test/InMemoryCassandraQueryExecutor';
+import {defineTable} from './CassandraTableDsl';
+import {type CassandraParams, normalizeBinaryParams} from './CassandraTypes';
+
+interface BinaryRow {
+	bucket: string;
+	value: Uint8Array;
+	payload: {data: Uint8Array};
+}
+
+const BinaryRows = defineTable<BinaryRow, 'bucket' | 'value', 'bucket'>({
+	name: 'binary_rows',
+	columns: ['bucket', 'value', 'payload'],
+	primaryKey: ['bucket', 'value'],
+	partitionKey: ['bucket'],
+});
+
+describe('normalizeBinaryParams', () => {
+	it('copies Buffer and sliced Uint8Array values into canonical Buffers recursively', () => {
+		const backing = new Uint8Array([0xaa, 0x00, 0x80, 0xff, 0xbb]);
+		const sliced = backing.subarray(1, 4);
+		const original = Buffer.from([0x01, 0x02]);
+		const normalized = normalizeBinaryParams({
+			direct: sliced,
+			array: [sliced],
+			set: new Set([sliced]),
+			map: new Map([[sliced, original]]),
+		} as unknown as CassandraParams);
+
+		expect(normalized.direct).toEqual(Buffer.from([0x00, 0x80, 0xff]));
+		expect(Buffer.isBuffer(normalized.direct)).toBe(true);
+		expect(normalized.direct).not.toBe(sliced);
+		expect((normalized.array as Array<Buffer>)[0]).toEqual(Buffer.from([0x00, 0x80, 0xff]));
+		expect([...(normalized.set as Set<Buffer>)][0]).toEqual(Buffer.from([0x00, 0x80, 0xff]));
+		const [[mapKey, mapValue]] = [...(normalized.map as Map<Buffer, Buffer>)];
+		expect(mapKey).toEqual(Buffer.from([0x00, 0x80, 0xff]));
+		expect(mapValue).toEqual(original);
+		expect(mapValue).not.toBe(original);
+
+		sliced.fill(0x11);
+		original.fill(0x22);
+		expect(normalized.direct).toEqual(Buffer.from([0x00, 0x80, 0xff]));
+		expect(mapValue).toEqual(Buffer.from([0x01, 0x02]));
+	});
+
+	it('keeps Buffer and Uint8Array predicate, ordering, and paging semantics aligned in memory', async () => {
+		const executor = new InMemoryCassandraQueryExecutor();
+		const values = [Buffer.from([0xfb]), Buffer.from([0x00]), Buffer.from([0x7f])];
+		for (const value of values) {
+			const backing = new Uint8Array([0xaa, value[0]!, 0xbb]);
+			await executor.executeQuery(
+				BinaryRows.upsertAll({
+					bucket: 'a',
+					value: backing.subarray(1, 2),
+					payload: {data: backing.subarray(1, 2)},
+				}),
+			);
+		}
+
+		const ordered = await executor.executeQuery<BinaryRow>(
+			BinaryRows.select({
+				where: BinaryRows.where.eq('bucket'),
+				orderBy: [{col: 'value', direction: 'ASC'}],
+			}).bind({bucket: 'a'}),
+		);
+		expect(ordered.map((row) => Buffer.from(row.value).toString('hex'))).toEqual(['00', '7f', 'fb']);
+
+		const inRows = await executor.executeQuery<BinaryRow>(
+			BinaryRows.select({
+				where: [BinaryRows.where.eq('bucket'), BinaryRows.where.in('value', 'values')],
+				orderBy: [{col: 'value', direction: 'ASC'}],
+			}).bind({bucket: 'a', values: [Buffer.from([0x00]), Buffer.from([0xfb])]}),
+		);
+		expect(inRows.map((row) => Buffer.from(row.value).toString('hex'))).toEqual(['00', 'fb']);
+
+		for (const [operator, expected] of [
+			['lt', ['00']],
+			['lte', ['00', '7f']],
+			['gt', ['fb']],
+			['gte', ['7f', 'fb']],
+		] as const) {
+			const rows = await executor.executeQuery<BinaryRow>(
+				BinaryRows.select({
+					where: [BinaryRows.where.eq('bucket'), BinaryRows.where[operator]('value')],
+					orderBy: [{col: 'value', direction: 'ASC'}],
+				}).bind({bucket: 'a', value: Buffer.from([0x7f])}),
+			);
+			expect(rows.map((row) => Buffer.from(row.value).toString('hex'))).toEqual(expected);
+		}
+
+		const tupleRows = await executor.executeQuery<BinaryRow>(
+			BinaryRows.select({
+				where: BinaryRows.where.tupleGt(['bucket', 'value'], ['bucket', 'value']),
+				orderBy: [
+					{col: 'bucket', direction: 'ASC'},
+					{col: 'value', direction: 'ASC'},
+				],
+			}).bind({bucket: 'a', value: Buffer.from([0x7f])}),
+		);
+		expect(tupleRows.map((row) => Buffer.from(row.value).toString('hex'))).toEqual(['fb']);
+
+		const firstPage = await executor.executePagedQuery<BinaryRow>(
+			BinaryRows.select({
+				where: BinaryRows.where.eq('bucket'),
+				orderBy: [{col: 'value', direction: 'ASC'}],
+			}).bind({bucket: 'a'}),
+			{pageSize: 2},
+		);
+		const secondPage = await executor.executePagedQuery<BinaryRow>(
+			BinaryRows.select({
+				where: BinaryRows.where.eq('bucket'),
+				orderBy: [{col: 'value', direction: 'ASC'}],
+			}).bind({bucket: 'a'}),
+			{pageSize: 2, pageState: firstPage.pageState},
+		);
+		expect(firstPage.rows.map((row) => Buffer.from(row.value).toString('hex'))).toEqual(['00', '7f']);
+		expect(secondPage.rows.map((row) => Buffer.from(row.value).toString('hex'))).toEqual(['fb']);
+
+		ordered[0]!.value[0] = 0x22;
+		ordered[0]!.payload.data[0] = 0x33;
+		const refetched = await executor.executeQuery<BinaryRow>(
+			BinaryRows.select({where: BinaryRows.where.eq('bucket')}).bind({bucket: 'a'}),
+		);
+		expect(refetched.some((row) => Buffer.from(row.value).equals(Buffer.from([0x00])))).toBe(true);
+		expect(refetched.some((row) => Buffer.from(row.payload.data).equals(Buffer.from([0x00])))).toBe(true);
+	});
+});

--- a/fluxer_api/src/api/database/CassandraTypes.ts
+++ b/fluxer_api/src/api/database/CassandraTypes.ts
@@ -49,11 +49,17 @@ export interface KvTableSpec<Row extends object = Record<string, unknown>> {
 	partitionKey: ReadonlyArray<ColumnName<Row>>;
 }
 
+export interface KvCondition<Row extends object = Record<string, unknown>> {
+	col: ColumnName<Row>;
+	expectedParam: string;
+	expectedValue: unknown;
+}
+
 export interface KvQueryMeta<Row extends object = Record<string, unknown>> {
 	action: KvAction;
 	table: KvTableSpec<Row>;
 	where?: ReadonlyArray<WhereExpr<Row>>;
-	orderBy?: OrderBy<Row>;
+	orderBy?: OrderBy<Row> | ReadonlyArray<OrderBy<Row>>;
 	limit?: number;
 	columns?: ReadonlyArray<ColumnName<Row>>;
 	patch?: Partial<Record<ColumnName<Row>, DbOp<unknown>>>;
@@ -62,11 +68,8 @@ export interface KvQueryMeta<Row extends object = Record<string, unknown>> {
 	ttlSeconds?: number;
 	ttlParamName?: string;
 	nowColumn?: ColumnName<Row>;
-	condition?: {
-		col: ColumnName<Row>;
-		expectedParam: string;
-		expectedValue: unknown;
-	};
+	condition?: KvCondition<Row>;
+	conditions?: ReadonlyArray<KvCondition<Row>>;
 	ifNotExists?: boolean;
 }
 
@@ -125,6 +128,11 @@ export type WhereExpr<Row extends object> =
 			kind: 'tupleGt';
 			cols: ReadonlyArray<ColumnName<Row>>;
 			params: ReadonlyArray<string>;
+	  }
+	| {
+			kind: 'tupleLt';
+			cols: ReadonlyArray<ColumnName<Row>>;
+			params: ReadonlyArray<string>;
 	  };
 export type OrderBy<Row extends object> = {
 	col: ColumnName<Row>;
@@ -139,13 +147,13 @@ export interface Table<Row extends object, PK extends ColumnName<Row>, PartKey e
 	selectCql(opts?: {
 		columns?: ReadonlyArray<ColumnName<Row>>;
 		where?: WhereExpr<Row> | ReadonlyArray<WhereExpr<Row>>;
-		orderBy?: OrderBy<Row>;
+		orderBy?: OrderBy<Row> | ReadonlyArray<OrderBy<Row>>;
 		limit?: number;
 	}): string;
 	select(opts?: {
 		columns?: ReadonlyArray<ColumnName<Row>>;
 		where?: WhereExpr<Row> | ReadonlyArray<WhereExpr<Row>>;
-		orderBy?: OrderBy<Row>;
+		orderBy?: OrderBy<Row> | ReadonlyArray<OrderBy<Row>>;
 		limit?: number;
 	}): QueryTemplate;
 	updateAllCql(): string;
@@ -156,6 +164,15 @@ export interface Table<Row extends object, PK extends ColumnName<Row>, PartKey e
 		patch: Partial<{
 			[K in Exclude<ColumnName<Row>, PK>]: DbOp<RowValue<Row, K>>;
 		}>,
+	): PreparedQuery;
+	patchByPkIf(
+		pk: Pick<Row, PK>,
+		patch: Partial<{
+			[K in Exclude<ColumnName<Row>, PK>]: DbOp<RowValue<Row, K>>;
+		}>,
+		condition:
+			| {col: ColumnName<Row>; expected: RowValue<Row, ColumnName<Row>>}
+			| ReadonlyArray<{col: ColumnName<Row>; expected: RowValue<Row, ColumnName<Row>>}>,
 	): PreparedQuery;
 	deleteCql(opts?: {where?: WhereExpr<Row> | ReadonlyArray<WhereExpr<Row>>}): string;
 	delete(opts?: {where?: WhereExpr<Row> | ReadonlyArray<WhereExpr<Row>>}): QueryTemplate;
@@ -176,6 +193,16 @@ export interface Table<Row extends object, PK extends ColumnName<Row>, PartKey e
 		}>,
 		ttlSeconds: number,
 	): PreparedQuery;
+	patchByPkWithTtlIf(
+		pk: Pick<Row, PK>,
+		patch: Partial<{
+			[K in Exclude<ColumnName<Row>, PK>]: DbOp<RowValue<Row, K>>;
+		}>,
+		ttlSeconds: number,
+		condition:
+			| {col: ColumnName<Row>; expected: RowValue<Row, ColumnName<Row>>}
+			| ReadonlyArray<{col: ColumnName<Row>; expected: RowValue<Row, ColumnName<Row>>}>,
+	): PreparedQuery;
 	patchByPkWithTtlParam(
 		pk: Pick<Row, PK>,
 		patch: Partial<{
@@ -195,6 +222,7 @@ export interface Table<Row extends object, PK extends ColumnName<Row>, PartKey e
 		gte: <K extends ColumnName<Row>>(col: K, param?: string) => WhereExpr<Row>;
 		tokenGt: <K extends ColumnName<Row>>(col: K, param: string) => WhereExpr<Row>;
 		tupleGt: <K extends ColumnName<Row>>(cols: ReadonlyArray<K>, params: ReadonlyArray<string>) => WhereExpr<Row>;
+		tupleLt: <K extends ColumnName<Row>>(cols: ReadonlyArray<K>, params: ReadonlyArray<string>) => WhereExpr<Row>;
 	};
 }
 

--- a/fluxer_api/src/api/database/CassandraTypes.ts
+++ b/fluxer_api/src/api/database/CassandraTypes.ts
@@ -79,8 +79,25 @@ export interface PreparedQuery<P extends CassandraParams = CassandraParams> {
 	kvMeta?: KvQueryMeta;
 }
 
+function normalizeBinaryValue(value: unknown): unknown {
+	if (value instanceof Uint8Array) return Buffer.from(value);
+	if (Array.isArray(value)) return value.map(normalizeBinaryValue);
+	if (value instanceof Set) return new Set([...value].map(normalizeBinaryValue));
+	if (value instanceof Map) {
+		return new Map([...value].map(([key, entry]) => [normalizeBinaryValue(key), normalizeBinaryValue(entry)]));
+	}
+	if (value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+		return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, normalizeBinaryValue(entry)]));
+	}
+	return value;
+}
+
+export function normalizeBinaryParams<P extends CassandraParams>(params: P): P {
+	return normalizeBinaryValue(params) as P;
+}
+
 export function prepared<P extends CassandraParams>(cql: string, params: P, kvMeta?: KvQueryMeta): PreparedQuery<P> {
-	return {cql, params, kvMeta};
+	return {cql, params: normalizeBinaryParams(params), kvMeta};
 }
 
 export interface QueryTemplate<P extends CassandraParams = CassandraParams> {

--- a/fluxer_api/src/api/database/PostgresKvQueryExecutor.Integration.test.ts
+++ b/fluxer_api/src/api/database/PostgresKvQueryExecutor.Integration.test.ts
@@ -5,9 +5,14 @@ import {existsSync} from 'node:fs';
 import {getDefaultPostgresClient, initPostgres, quoteIdentifier, shutdownPostgres} from '@pkgs/postgres/src/Client';
 import cassandra from 'cassandra-driver';
 import {afterAll, beforeAll, describe, expect, test} from 'vitest';
+import {createUserID} from '../BrandedTypes';
+import {JOB_HISTORY_RETENTION_SECONDS, JobLedgerRepository} from '../jobs/JobLedgerRepository';
+import {AuthSessions, JobsActive, JobsActiveLegacy, JobsByDayBucket} from '../Tables';
+import {setCassandraQueryExecutorForTesting} from './CassandraQueryExecution';
 import {defineTable} from './CassandraTableDsl';
 import {Db} from './CassandraTypes';
 import {ensurePostgresKvSchema, PostgresKvQueryExecutor, pruneExpiredPostgresKvRows} from './PostgresKvQueryExecutor';
+import type {AuthSessionRow} from './types/AuthTypes';
 
 interface TestRow {
 	tenant_id: string;
@@ -18,6 +23,16 @@ interface TestRow {
 	counts: Map<string, bigint> | null;
 	local_day: cassandra.types.LocalDate | null;
 	note: string | null;
+}
+
+interface BinaryRow {
+	bucket: string;
+	value: Buffer;
+}
+
+interface Uint8ArrayRow {
+	id: string;
+	value: Uint8Array;
 }
 
 function postgresHost(): string {
@@ -35,6 +50,17 @@ const TestRows = defineTable<TestRow, 'tenant_id' | 'item_id', 'tenant_id'>({
 	columns: ['tenant_id', 'item_id', 'created_at', 'payload', 'tags', 'counts', 'local_day', 'note'],
 	primaryKey: ['tenant_id', 'item_id'],
 	partitionKey: ['tenant_id'],
+});
+const BinaryRows = defineTable<BinaryRow, 'bucket' | 'value', 'bucket'>({
+	name: `pg_kv_binary_test_${randomUUID().replaceAll('-', '_')}`,
+	columns: ['bucket', 'value'],
+	primaryKey: ['bucket', 'value'],
+	partitionKey: ['bucket'],
+});
+const Uint8ArrayRows = defineTable<Uint8ArrayRow, 'id'>({
+	name: `pg_kv_uint8_test_${randomUUID().replaceAll('-', '_')}`,
+	columns: ['id', 'value'],
+	primaryKey: ['id'],
 });
 
 describe('PostgresKvQueryExecutor', () => {
@@ -55,11 +81,13 @@ describe('PostgresKvQueryExecutor', () => {
 		const client = getDefaultPostgresClient();
 		await ensurePostgresKvSchema(client);
 		executor = new PostgresKvQueryExecutor(client);
+		setCassandraQueryExecutorForTesting(executor);
 	});
 
 	afterAll(async () => {
 		if (!initialized) return;
 		try {
+			setCassandraQueryExecutorForTesting(null);
 			await getDefaultPostgresClient().query(`DROP TABLE IF EXISTS ${quoteIdentifier(kvTable)}`);
 		} finally {
 			await shutdownPostgres();
@@ -118,6 +146,182 @@ describe('PostgresKvQueryExecutor', () => {
 		expect(fetched[0]!.counts!.get('seen')).toBe(5n);
 		expect(fetched[0]!.local_day?.toString()).toBe('2026-01-02');
 		expect(fetched[0]!.note).toBe('second');
+	});
+
+	test('selects an auth session by its Buffer primary key through the production query shape', async () => {
+		const sessionIdHash = Buffer.from([0x00, 0x2f, 0x7f, 0x80, 0xff]);
+		const row: AuthSessionRow = {
+			user_id: createUserID(1001n),
+			session_id_hash: sessionIdHash,
+			created_at: new Date('2026-08-11T20:53:07.000Z'),
+			approx_last_used_at: new Date('2026-08-11T20:53:07.000Z'),
+			client_ip: '127.0.0.1',
+			client_user_agent: 'postgres-buffer-regression',
+			client_is_desktop: true,
+			client_os: 'linux',
+			client_platform: 'desktop',
+			client_country: 'SE',
+			version: 1,
+		};
+		await executor.executeQuery(AuthSessions.upsertAll(row));
+
+		const productionQuery = AuthSessions.selectCql({
+			where: AuthSessions.where.eq('session_id_hash'),
+			limit: 1,
+		});
+		const fetched = await executor.executeQuery<AuthSessionRow>({
+			cql: productionQuery,
+			params: {session_id_hash: sessionIdHash},
+		});
+
+		expect(fetched).toHaveLength(1);
+		expect(fetched[0]).toMatchObject({user_id: row.user_id, client_user_agent: row.client_user_agent});
+		expect(fetched[0]!.session_id_hash.equals(sessionIdHash)).toBe(true);
+	});
+
+	test('compares binary values consistently for IN, range, tuple, ordering, and page cursors', async () => {
+		const low = Buffer.from([0x00]);
+		const middle = Buffer.from([0x7f]);
+		const high = Buffer.from([0xfb]);
+		for (const value of [high, low, middle]) {
+			await executor.executeQuery(BinaryRows.upsertAll({bucket: 'binary-order', value}));
+		}
+
+		const selectedByIn = await executor.executeQuery<BinaryRow>(
+			BinaryRows.select({
+				where: [BinaryRows.where.eq('bucket'), BinaryRows.where.in('value', 'values')],
+				orderBy: {col: 'value', direction: 'ASC'},
+				limit: 2,
+			}).bind({bucket: 'binary-order', values: [high, low]}),
+		);
+		expect(selectedByIn.map((row) => row.value)).toEqual([low, high]);
+
+		const selectedByRange = await executor.executeQuery<BinaryRow>(
+			BinaryRows.select({
+				where: [BinaryRows.where.eq('bucket'), BinaryRows.where.gt('value', 'after_value')],
+				orderBy: {col: 'value', direction: 'ASC'},
+				limit: 2,
+			}).bind({bucket: 'binary-order', after_value: low}),
+		);
+		expect(selectedByRange.map((row) => row.value)).toEqual([middle, high]);
+
+		const selectedByTuple = await executor.executeQuery<BinaryRow>(
+			BinaryRows.select({
+				where: BinaryRows.where.tupleGt(['bucket', 'value'], ['cursor_bucket', 'cursor_value']),
+				orderBy: {col: 'value', direction: 'ASC'},
+				limit: 2,
+			}).bind({cursor_bucket: 'binary-order', cursor_value: low}),
+		);
+		expect(selectedByTuple.map((row) => row.value)).toEqual([middle, high]);
+
+		const pagedQuery = BinaryRows.select({
+			where: BinaryRows.where.eq('bucket'),
+			orderBy: {col: 'value', direction: 'ASC'},
+		}).bind({bucket: 'binary-order'});
+		const firstPage = await executor.executePagedQuery<BinaryRow>(pagedQuery, {pageSize: 2});
+		const secondPage = await executor.executePagedQuery<BinaryRow>(pagedQuery, {
+			pageSize: 2,
+			pageState: firstPage.pageState,
+		});
+		expect(firstPage.rows.map((row) => row.value)).toEqual([low, middle]);
+		expect(secondPage.rows.map((row) => row.value)).toEqual([high]);
+	});
+
+	test('stores Uint8Array values using the canonical binary encoding', async () => {
+		const backing = new Uint8Array([0xaa, 0x00, 0x80, 0xff, 0xbb]);
+		const value = backing.subarray(1, 4);
+		await executor.executeQuery(Uint8ArrayRows.upsertAll({id: 'uint8-array', value}));
+
+		const fetched = await executor.executeQuery<Uint8ArrayRow>(
+			Uint8ArrayRows.select({where: Uint8ArrayRows.where.eq('id'), limit: 1}).bind({id: 'uint8-array'}),
+		);
+
+		expect(Buffer.isBuffer(fetched[0]!.value)).toBe(true);
+		expect(Buffer.from(fetched[0]!.value)).toEqual(Buffer.from(value));
+	});
+
+	test('preserves terminal job status, bounded authority and history TTLs, and removes active indexes', async () => {
+		const repository = new JobLedgerRepository();
+		const jobId = 9001001n;
+		await repository.createJob({
+			jobId,
+			taskType: 'postgres-terminal-invariant',
+			payload: {source: 'integration'},
+			requestedByUserId: null,
+			auditLogReason: null,
+			maxAttempts: 3,
+			runAt: null,
+			jetStreamLane: 'worker-batch',
+			jetStreamSeq: '1',
+		});
+		const created = await repository.getJob(jobId);
+		expect(created?.status).toBe('queued');
+
+		const leaseToken = 'postgres-terminal-lease';
+		const claimed = await repository.claimJob(jobId, 'worker-batch', leaseToken, new Date(), 60_000);
+		expect(claimed).toMatchObject({status: 'running', lease_token: leaseToken});
+		expect(await repository.markSucceeded(jobId, {ok: true}, leaseToken)).toBe(true);
+
+		const terminal = await repository.getJob(jobId);
+		expect(terminal).toMatchObject({status: 'succeeded', lease_token: null, lease_expires_at: null});
+		expect(terminal?.completed_at).toBeInstanceOf(Date);
+		const history = await executor.executeQuery(
+			JobsByDayBucket.select({
+				where: [
+					JobsByDayBucket.where.eq('bucket_day'),
+					JobsByDayBucket.where.eq('created_at'),
+					JobsByDayBucket.where.eq('job_id'),
+				],
+				limit: 1,
+			}).bind({
+				bucket_day: created!.created_at.toISOString().slice(0, 10),
+				created_at: created!.created_at,
+				job_id: jobId,
+			}),
+		);
+		expect(history).toMatchObject([{status: 'succeeded', job_id: jobId}]);
+
+		const active = await executor.executeQuery(
+			JobsActive.select({
+				where: [JobsActive.where.eq('shard'), JobsActive.where.eq('job_id')],
+				limit: 1,
+			}).bind({shard: Number(jobId % 64n), job_id: jobId}),
+		);
+		const legacyActive = await executor.executeQuery(
+			JobsActiveLegacy.select({where: JobsActiveLegacy.where.eq('job_id'), limit: 1}).bind({job_id: jobId}),
+		);
+		expect(active).toEqual([]);
+		expect(legacyActive).toEqual([]);
+		const physicalActive = await getDefaultPostgresClient().query<{count: string}>(
+			`SELECT count(*)::text AS count
+			 FROM ${quoteIdentifier(kvTable)}
+			 WHERE table_name = ANY($1::text[])
+			   AND row_data -> 'job_id' ->> 'value' = $2`,
+			[['jobs_active', 'jobs_active_v2'], jobId.toString()],
+		);
+		expect(physicalActive.rows[0]?.count).toBe('0');
+
+		const physical = await getDefaultPostgresClient().query<{
+			table_name: string;
+			expires_at: Date | null;
+			status: string;
+		}>(
+			`SELECT table_name, expires_at, row_data ->> 'status' AS status
+			 FROM ${quoteIdentifier(kvTable)}
+			 WHERE table_name = ANY($1::text[])
+			   AND row_data -> 'job_id' ->> 'value' = $2
+			 ORDER BY table_name`,
+			[['jobs_by_day_bucket', 'jobs_by_id'], jobId.toString()],
+		);
+		expect(physical.rows.map((row) => [row.table_name, row.status])).toEqual([
+			['jobs_by_day_bucket', 'succeeded'],
+			['jobs_by_id', 'succeeded'],
+		]);
+		const expectedExpiry = terminal!.completed_at!.getTime() + JOB_HISTORY_RETENTION_SECONDS * 1000;
+		for (const row of physical.rows) {
+			expect(row.expires_at).toBeInstanceOf(Date);
+			expect(Math.abs(row.expires_at!.getTime() - expectedExpiry)).toBeLessThanOrEqual(1000);
+		}
 	});
 
 	test('applies every compare-and-set condition and treats missing legacy fields as null', async () => {

--- a/fluxer_api/src/api/database/PostgresKvQueryExecutor.Integration.test.ts
+++ b/fluxer_api/src/api/database/PostgresKvQueryExecutor.Integration.test.ts
@@ -84,6 +84,24 @@ describe('PostgresKvQueryExecutor', () => {
 		await expect(
 			executor.executeQuery<{['[applied]']: boolean}>(TestRows.insertIfNotExists({...row, note: 'second'})),
 		).resolves.toEqual([{'[applied]': false}]);
+		await expect(
+			executor.executeQuery<{['[applied]']: boolean}>(
+				TestRows.patchByPkIf(
+					{tenant_id: 'tenant-a', item_id: 10n},
+					{note: Db.set('second')},
+					{col: 'note', expected: 'first'},
+				),
+			),
+		).resolves.toEqual([{'[applied]': true}]);
+		await expect(
+			executor.executeQuery<{['[applied]']: boolean}>(
+				TestRows.patchByPkIf(
+					{tenant_id: 'tenant-a', item_id: 10n},
+					{note: Db.set('third')},
+					{col: 'note', expected: 'first'},
+				),
+			),
+		).resolves.toEqual([{'[applied]': false}]);
 
 		const fetched = await executor.executeQuery<TestRow>(
 			TestRows.select({
@@ -99,7 +117,42 @@ describe('PostgresKvQueryExecutor', () => {
 		expect([...fetched[0]!.tags!.values()].sort()).toEqual(['alpha', 'beta']);
 		expect(fetched[0]!.counts!.get('seen')).toBe(5n);
 		expect(fetched[0]!.local_day?.toString()).toBe('2026-01-02');
-		expect(fetched[0]!.note).toBe('first');
+		expect(fetched[0]!.note).toBe('second');
+	});
+
+	test('applies every compare-and-set condition and treats missing legacy fields as null', async () => {
+		const row: TestRow = {
+			tenant_id: 'tenant-multi-condition',
+			item_id: 1n,
+			created_at: new Date('2026-01-03T00:00:00.000Z'),
+			payload: null,
+			tags: null,
+			counts: null,
+			local_day: null,
+			note: null,
+		};
+		await executor.executeQuery(TestRows.upsertAll(row));
+		await getDefaultPostgresClient().query(
+			`UPDATE ${quoteIdentifier(kvTable)} SET row_data = row_data - 'note' WHERE table_name = $1`,
+			[logicalTableName],
+		);
+
+		await expect(
+			executor.executeQuery<{['[applied]']: boolean}>(
+				TestRows.patchByPkIf({tenant_id: row.tenant_id, item_id: row.item_id}, {note: Db.set('claimed')}, [
+					{col: 'note', expected: null},
+					{col: 'created_at', expected: row.created_at},
+				]),
+			),
+		).resolves.toEqual([{'[applied]': true}]);
+		await expect(
+			executor.executeQuery<{['[applied]']: boolean}>(
+				TestRows.patchByPkIf({tenant_id: row.tenant_id, item_id: row.item_id}, {note: Db.set('stolen')}, [
+					{col: 'note', expected: null},
+					{col: 'created_at', expected: row.created_at},
+				]),
+			),
+		).resolves.toEqual([{'[applied]': false}]);
 	});
 
 	test('filters, orders, patches, pages, and deletes logical rows', async () => {
@@ -138,6 +191,36 @@ describe('PostgresKvQueryExecutor', () => {
 			].map((query) => ({query: query.cql, params: query.params, meta: query.kvMeta})),
 		);
 
+		const boundedFirst = await executor.executeQuery<TestRow>(
+			TestRows.select({
+				where: TestRows.where.eq('tenant_id'),
+				orderBy: [
+					{col: 'created_at', direction: 'DESC'},
+					{col: 'item_id', direction: 'DESC'},
+				],
+				limit: 2,
+			}).bind({tenant_id: 'tenant-b'}),
+		);
+		expect(boundedFirst.map((row) => row.item_id)).toEqual([3n, 2n]);
+		const boundedSecond = await executor.executeQuery<TestRow>(
+			TestRows.select({
+				where: [
+					TestRows.where.eq('tenant_id'),
+					TestRows.where.tupleLt(['created_at', 'item_id'], ['cursor_created_at', 'cursor_item_id']),
+				],
+				orderBy: [
+					{col: 'created_at', direction: 'DESC'},
+					{col: 'item_id', direction: 'DESC'},
+				],
+				limit: 2,
+			}).bind({
+				tenant_id: 'tenant-b',
+				cursor_created_at: boundedFirst[1]!.created_at,
+				cursor_item_id: boundedFirst[1]!.item_id,
+			}),
+		);
+		expect(boundedSecond.map((row) => row.item_id)).toEqual([1n]);
+
 		const firstPage = await executor.executePagedQuery<TestRow>(
 			TestRows.select({
 				where: TestRows.where.eq('tenant_id'),
@@ -147,6 +230,7 @@ describe('PostgresKvQueryExecutor', () => {
 		);
 		expect(firstPage.rows.map((row) => row.item_id)).toEqual([3n, 2n]);
 		expect(firstPage.pageState).not.toBeNull();
+		await executor.executeQuery(TestRows.deleteByPk({tenant_id: 'tenant-b', item_id: 3n}));
 
 		const secondPage = await executor.executePagedQuery<TestRow>(
 			TestRows.select({
@@ -172,6 +256,94 @@ describe('PostgresKvQueryExecutor', () => {
 			TestRows.select({where: TestRows.where.eq('tenant_id')}).bind({tenant_id: 'tenant-b'}),
 		);
 		expect(remaining).toEqual([]);
+	});
+
+	test('uses stable mixed-direction keyset paging across concurrent deletion', async () => {
+		const makeRow = (itemId: bigint, createdAt: string): TestRow => ({
+			tenant_id: 'tenant-keyset',
+			item_id: itemId,
+			created_at: new Date(createdAt),
+			payload: null,
+			tags: null,
+			counts: null,
+			local_day: null,
+			note: null,
+		});
+		for (const row of [
+			makeRow(1n, '2026-03-02T00:00:00.000Z'),
+			makeRow(2n, '2026-03-02T00:00:00.000Z'),
+			makeRow(3n, '2026-03-03T00:00:00.000Z'),
+		]) {
+			await executor.executeQuery(TestRows.upsertAll(row));
+		}
+		const query = TestRows.select({
+			where: TestRows.where.eq('tenant_id'),
+			orderBy: [
+				{col: 'created_at', direction: 'DESC'},
+				{col: 'item_id', direction: 'ASC'},
+			],
+		}).bind({tenant_id: 'tenant-keyset'});
+
+		const first = await executor.executePagedQuery<TestRow>(query, {pageSize: 2});
+		expect(first.rows.map((row) => row.item_id)).toEqual([3n, 1n]);
+		expect(first.pageState).not.toBeNull();
+		await expect(
+			executor.executePagedQuery<TestRow>(
+				TestRows.select({
+					where: TestRows.where.eq('tenant_id'),
+					orderBy: [
+						{col: 'created_at', direction: 'DESC'},
+						{col: 'item_id', direction: 'ASC'},
+					],
+				}).bind({tenant_id: 'another-tenant'}),
+				{pageSize: 2, pageState: first.pageState},
+			),
+		).rejects.toThrow('page state does not match query scope');
+		await executor.executeQuery(TestRows.deleteByPk({tenant_id: 'tenant-keyset', item_id: 3n}));
+		const second = await executor.executePagedQuery<TestRow>(query, {pageSize: 2, pageState: first.pageState});
+		expect(second.rows.map((row) => row.item_id)).toEqual([2n]);
+		expect(second.pageState).toBeNull();
+	});
+
+	test('applies conditional TTL patches atomically and rejects mismatched or expired rows', async () => {
+		const row: TestRow = {
+			tenant_id: 'tenant-conditional-ttl',
+			item_id: 1n,
+			created_at: new Date('2026-02-03T00:00:00.000Z'),
+			payload: null,
+			tags: null,
+			counts: null,
+			local_day: null,
+			note: 'running',
+		};
+		await executor.executeQuery(TestRows.upsertAll(row));
+
+		await expect(
+			executor.executeQuery<{['[applied]']: boolean}>(
+				TestRows.patchByPkWithTtlIf({tenant_id: row.tenant_id, item_id: row.item_id}, {note: Db.set('deadletter')}, 1, {
+					col: 'note',
+					expected: 'running',
+				}),
+			),
+		).resolves.toEqual([{'[applied]': true}]);
+		await expect(
+			executor.executeQuery<{['[applied]']: boolean}>(
+				TestRows.patchByPkWithTtlIf({tenant_id: row.tenant_id, item_id: row.item_id}, {note: Db.set('failed')}, 1, {
+					col: 'note',
+					expected: 'running',
+				}),
+			),
+		).resolves.toEqual([{'[applied]': false}]);
+
+		await sleep(1100);
+		await expect(
+			executor.executeQuery<{['[applied]']: boolean}>(
+				TestRows.patchByPkWithTtlIf({tenant_id: row.tenant_id, item_id: row.item_id}, {note: Db.set('failed')}, 1, {
+					col: 'note',
+					expected: 'deadletter',
+				}),
+			),
+		).resolves.toEqual([{'[applied]': false}]);
 	});
 
 	test('filters expired rows and prunes them physically', async () => {

--- a/fluxer_api/src/api/database/PostgresKvQueryExecutor.test.ts
+++ b/fluxer_api/src/api/database/PostgresKvQueryExecutor.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {IPostgresClient} from '@pkgs/postgres/src/Client';
+import {describe, expect, it, vi} from 'vitest';
+import {defineTable} from './CassandraTableDsl';
+import {PostgresKvQueryExecutor} from './PostgresKvQueryExecutor';
+
+interface BoundedRow {
+	bucket: string;
+	created_at: Date;
+	job_id: bigint;
+}
+
+const BoundedRows = defineTable<BoundedRow, 'bucket' | 'created_at' | 'job_id', 'bucket'>({
+	name: 'bounded_rows',
+	columns: ['bucket', 'created_at', 'job_id'],
+	primaryKey: ['bucket', 'created_at', 'job_id'],
+	partitionKey: ['bucket'],
+});
+
+interface SingleKeyRow {
+	id: bigint;
+}
+
+interface NullableOrderRow {
+	id: bigint;
+	ordered_at: Date | null;
+}
+
+const NullableOrderRows = defineTable<NullableOrderRow, 'id'>({
+	name: 'nullable_order_rows',
+	columns: ['id', 'ordered_at'],
+	primaryKey: ['id'],
+});
+
+const SingleKeyRows = defineTable<SingleKeyRow, 'id'>({
+	name: 'single_key_rows',
+	columns: ['id'],
+	primaryKey: ['id'],
+});
+
+describe('PostgresKvQueryExecutor bounded selects', () => {
+	it('pushes tuple predicates, ordering, and LIMIT into PostgreSQL', async () => {
+		const query = vi.fn().mockResolvedValue({rows: [], rowCount: 0});
+		const client = {
+			kvTable: () => 'fluxer_kv_test',
+			query,
+		} as unknown as IPostgresClient;
+		const executor = new PostgresKvQueryExecutor(client);
+
+		await executor.executeQuery(
+			BoundedRows.select({
+				where: [
+					BoundedRows.where.eq('bucket'),
+					BoundedRows.where.tupleLt(['created_at', 'job_id'], ['cursor_created_at', 'cursor_job_id']),
+				],
+				orderBy: [
+					{col: 'created_at', direction: 'DESC'},
+					{col: 'job_id', direction: 'DESC'},
+				],
+				limit: 25,
+			}).bind({
+				bucket: '2026-08-11',
+				cursor_created_at: new Date('2026-08-11T00:00:00.000Z'),
+				cursor_job_id: 42n,
+			}),
+		);
+
+		const sql = String(query.mock.calls[0]?.[0]);
+		expect(sql).toContain('LIMIT');
+		expect(sql).toContain('ORDER BY');
+		expect(sql).toContain('<');
+	});
+
+	it('bounds paged compatibility queries in PostgreSQL instead of materializing the partition', async () => {
+		const query = vi.fn().mockResolvedValue({rows: [], rowCount: 0});
+		const client = {kvTable: () => 'fluxer_kv_test', query} as unknown as IPostgresClient;
+		const executor = new PostgresKvQueryExecutor(client);
+
+		await executor.executePagedQuery(BoundedRows.select().bind({}), {pageSize: 25, pageState: null});
+
+		const sql = String(query.mock.calls[0]?.[0]);
+		expect(sql).toContain('LIMIT');
+		expect(sql).toContain('ORDER BY');
+	});
+
+	it('preserves explicit order and limit for primary-key IN selects', async () => {
+		const query = vi.fn().mockResolvedValue({rows: [], rowCount: 0});
+		const client = {kvTable: () => 'fluxer_kv_test', query} as unknown as IPostgresClient;
+		const executor = new PostgresKvQueryExecutor(client);
+
+		await executor.executeQuery(
+			SingleKeyRows.select({
+				where: SingleKeyRows.where.in('id', 'ids'),
+				orderBy: {col: 'id', direction: 'DESC'},
+				limit: 2,
+			}).bind({ids: [3n, 2n, 1n]}),
+		);
+
+		const sql = String(query.mock.calls[0]?.[0]);
+		expect(sql).toContain('LIMIT');
+		expect(sql).toContain('ORDER BY');
+	});
+
+	it('continues keyset paging when the last ordered value is null', async () => {
+		const encodedId = (id: string) => ({__fluxer_type: 'bigint', value: id});
+		const query = vi
+			.fn()
+			.mockResolvedValueOnce({
+				rows: [
+					{row_key: '1', row_data: {id: encodedId('1'), ordered_at: null}},
+					{row_key: '2', row_data: {id: encodedId('2'), ordered_at: null}},
+				],
+				rowCount: 2,
+			})
+			.mockResolvedValueOnce({rows: [], rowCount: 0});
+		const client = {kvTable: () => 'fluxer_kv_test', query} as unknown as IPostgresClient;
+		const executor = new PostgresKvQueryExecutor(client);
+		const prepared = NullableOrderRows.select({
+			orderBy: [
+				{col: 'ordered_at', direction: 'DESC'},
+				{col: 'id', direction: 'ASC'},
+			],
+		}).bind({});
+
+		const first = await executor.executePagedQuery<NullableOrderRow>(prepared, {pageSize: 1});
+		expect(first.pageState).not.toBeNull();
+		await expect(
+			executor.executePagedQuery<NullableOrderRow>(prepared, {pageSize: 1, pageState: first.pageState}),
+		).resolves.toEqual({rows: [], pageState: null});
+		expect(String(query.mock.calls[1]?.[0])).toContain('COALESCE(row_data ->');
+	});
+});

--- a/fluxer_api/src/api/database/PostgresKvQueryExecutor.ts
+++ b/fluxer_api/src/api/database/PostgresKvQueryExecutor.ts
@@ -35,11 +35,19 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype;
 }
 
+function isBinaryValue(value: unknown): value is Uint8Array {
+	return value instanceof Uint8Array;
+}
+
+function binaryBuffer(value: Uint8Array): Buffer {
+	return Buffer.isBuffer(value) ? value : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+}
+
 function encodeValue(value: unknown): unknown {
 	if (value === null || value === undefined) return null;
 	if (typeof value === 'bigint') return {[ENCODED_TYPE_KEY]: 'bigint', value: value.toString()};
 	if (value instanceof Date) return {[ENCODED_TYPE_KEY]: 'date', value: value.toISOString()};
-	if (Buffer.isBuffer(value)) return {[ENCODED_TYPE_KEY]: 'buffer', value: value.toString('base64')};
+	if (isBinaryValue(value)) return {[ENCODED_TYPE_KEY]: 'buffer', value: binaryBuffer(value).toString('base64')};
 	if (value instanceof Set) return {[ENCODED_TYPE_KEY]: 'set', value: [...value.values()].map(encodeValue)};
 	if (value instanceof Map) {
 		return {
@@ -156,7 +164,7 @@ function compareValues(left: unknown, right: unknown): number {
 	const l = left instanceof Date ? left.getTime() : left?.constructor?.name === 'LocalDate' ? left.toString() : left;
 	const r =
 		right instanceof Date ? right.getTime() : right?.constructor?.name === 'LocalDate' ? right.toString() : right;
-	if (Buffer.isBuffer(l) && Buffer.isBuffer(r)) return Buffer.compare(l, r);
+	if (isBinaryValue(l) && isBinaryValue(r)) return Buffer.compare(binaryBuffer(l), binaryBuffer(r));
 	if (l === r) return 0;
 	return (l as number | string) < (r as number | string) ? -1 : 1;
 }
@@ -164,7 +172,7 @@ function compareValues(left: unknown, right: unknown): number {
 function valuesEqual(left: unknown, right: unknown): boolean {
 	if (left == null && right == null) return true;
 	if (left instanceof Date && right instanceof Date) return left.getTime() === right.getTime();
-	if (Buffer.isBuffer(left) && Buffer.isBuffer(right)) return left.equals(right);
+	if (isBinaryValue(left) && isBinaryValue(right)) return binaryBuffer(left).equals(binaryBuffer(right));
 	if (left?.constructor?.name === 'LocalDate' || right?.constructor?.name === 'LocalDate') {
 		return left?.toString() === right?.toString();
 	}
@@ -234,6 +242,9 @@ function sqlComparable(
 	}
 	if (value?.constructor?.name === 'LocalDate') {
 		return {left: `row_data -> ${key} ->> 'value'`, right: bind(value.toString())};
+	}
+	if (isBinaryValue(value)) {
+		return {left: `decode(row_data -> ${key} ->> 'value', 'base64')`, right: `${bind(binaryBuffer(value))}::bytea`};
 	}
 	if (typeof value === 'number') {
 		return {left: `(row_data ->> ${key})::double precision`, right: `${bind(value)}::double precision`};
@@ -312,6 +323,7 @@ function sqlOrderByItems(items: ReadonlyArray<EffectiveOrderItem>, bind: (value:
 		return [
 			`(CASE WHEN ${node} ->> '${ENCODED_TYPE_KEY}' = 'bigint' THEN ${node} ->> 'value' END)::numeric ${direction}`,
 			`CASE WHEN ${node} ->> '${ENCODED_TYPE_KEY}' IN ('date', 'local_date') THEN ${node} ->> 'value' END ${direction}`,
+			`CASE WHEN ${node} ->> '${ENCODED_TYPE_KEY}' = 'buffer' THEN decode(${node} ->> 'value', 'base64') END ${direction}`,
 			`(CASE WHEN jsonb_typeof(${node}) = 'number' THEN ${node} #>> '{}' END)::numeric ${direction}`,
 			`CASE WHEN jsonb_typeof(${node}) IN ('string', 'boolean') THEN ${node} #>> '{}' END ${direction}`,
 		];

--- a/fluxer_api/src/api/database/PostgresKvQueryExecutor.ts
+++ b/fluxer_api/src/api/database/PostgresKvQueryExecutor.ts
@@ -14,8 +14,15 @@ interface StoredRow {
 }
 
 interface PageState {
-	offset: number;
+	version: 1;
+	table: string;
+	scope: string;
+	order: Array<{col: string; direction: 'ASC' | 'DESC'}>;
+	values: Array<unknown>;
+	remaining: number | null;
 }
+
+type EffectiveOrderItem = {col: string; direction: 'ASC' | 'DESC'};
 
 const VALUE_SEPARATOR = '\u001f';
 const ENCODED_TYPE_KEY = '__fluxer_type';
@@ -193,24 +200,161 @@ function matchesWhere(row: Row, where: ReadonlyArray<WhereExpr<Row>> | undefined
 			case 'gte':
 				if (compareValues(row[clause.col], getParam(params, clause.param)) < 0) return false;
 				break;
-			case 'tupleGt': {
+			case 'tupleGt':
+			case 'tupleLt': {
 				const left = clause.cols.map((column) => row[column]);
 				const right = clause.params.map((param) => getParam(params, param));
-				let greater = false;
+				let comparison = 0;
 				for (let i = 0; i < left.length; i += 1) {
 					const cmp = compareValues(left[i], right[i]);
-					if (cmp > 0) {
-						greater = true;
+					if (cmp !== 0) {
+						comparison = cmp;
 						break;
 					}
-					if (cmp < 0) break;
 				}
-				if (!greater) return false;
+				if (clause.kind === 'tupleGt' ? comparison <= 0 : comparison >= 0) return false;
 				break;
 			}
 		}
 	}
 	return true;
+}
+
+function sqlComparable(
+	column: string,
+	value: unknown,
+	bind: (value: unknown) => string,
+): {left: string; right: string} | null {
+	const key = bind(column);
+	if (typeof value === 'bigint') {
+		return {left: `(row_data -> ${key} ->> 'value')::numeric`, right: `${bind(value.toString())}::numeric`};
+	}
+	if (value instanceof Date) {
+		return {left: `row_data -> ${key} ->> 'value'`, right: bind(value.toISOString())};
+	}
+	if (value?.constructor?.name === 'LocalDate') {
+		return {left: `row_data -> ${key} ->> 'value'`, right: bind(value.toString())};
+	}
+	if (typeof value === 'number') {
+		return {left: `(row_data ->> ${key})::double precision`, right: `${bind(value)}::double precision`};
+	}
+	if (typeof value === 'boolean') {
+		return {left: `(row_data ->> ${key})::boolean`, right: `${bind(value)}::boolean`};
+	}
+	if (typeof value === 'string') {
+		return {left: `row_data ->> ${key}`, right: bind(value)};
+	}
+	return null;
+}
+
+function sqlWhereClause(clause: WhereExpr<Row>, params: CassandraParams, bind: (value: unknown) => string): string {
+	if (clause.kind === 'tupleGt' || clause.kind === 'tupleLt') {
+		const comparisons = clause.cols.map((column, index) => {
+			const comparable = sqlComparable(column, getParam(params, clause.params[index]!), bind);
+			if (!comparable) throw new Error(`Unsupported Postgres KV tuple value for ${column}`);
+			return comparable;
+		});
+		return `(${comparisons.map((entry) => entry.left).join(', ')}) ${clause.kind === 'tupleGt' ? '>' : '<'} (${comparisons.map((entry) => entry.right).join(', ')})`;
+	}
+	const value = getParam(params, clause.param);
+	if (clause.kind === 'in') {
+		const values = value instanceof Set ? [...value] : ((value as ReadonlyArray<unknown> | undefined) ?? []);
+		if (values.length === 0) return 'FALSE';
+		return `(${values
+			.map((entry) => {
+				const comparable = sqlComparable(clause.col, entry, bind);
+				if (!comparable) throw new Error(`Unsupported Postgres KV IN value for ${clause.col}`);
+				return `${comparable.left} = ${comparable.right}`;
+			})
+			.join(' OR ')})`;
+	}
+	if (clause.kind === 'eq' && value == null) {
+		const key = bind(clause.col);
+		return `COALESCE(row_data -> ${key}, 'null'::jsonb) = 'null'::jsonb`;
+	}
+	const comparable = sqlComparable(clause.col, value, bind);
+	if (!comparable) throw new Error(`Unsupported Postgres KV comparison value for ${clause.col}`);
+	const operator =
+		clause.kind === 'eq'
+			? '='
+			: clause.kind === 'lt'
+				? '<'
+				: clause.kind === 'lte'
+					? '<='
+					: clause.kind === 'gte'
+						? '>='
+						: '>';
+	return `${comparable.left} ${operator} ${comparable.right}`;
+}
+
+function effectiveOrder(meta: KvQueryMeta): Array<EffectiveOrderItem> {
+	const declared = meta.orderBy
+		? Array.isArray(meta.orderBy)
+			? meta.orderBy
+			: [meta.orderBy]
+		: meta.table.primaryKey.map((col) => ({col, direction: 'ASC' as const}));
+	const result = declared.map((item) => ({
+		col: String(item.col),
+		direction: item.direction === 'DESC' ? ('DESC' as const) : ('ASC' as const),
+	}));
+	const seen = new Set(result.map((item) => item.col));
+	for (const col of meta.table.primaryKey) {
+		if (!seen.has(String(col))) result.push({col: String(col), direction: 'ASC'});
+	}
+	return result;
+}
+
+function sqlOrderByItems(items: ReadonlyArray<EffectiveOrderItem>, bind: (value: unknown) => string): string {
+	const expressions = items.flatMap((item) => {
+		const key = bind(item.col);
+		const node = `row_data -> ${key}`;
+		const direction = item.direction;
+		return [
+			`(CASE WHEN ${node} ->> '${ENCODED_TYPE_KEY}' = 'bigint' THEN ${node} ->> 'value' END)::numeric ${direction}`,
+			`CASE WHEN ${node} ->> '${ENCODED_TYPE_KEY}' IN ('date', 'local_date') THEN ${node} ->> 'value' END ${direction}`,
+			`(CASE WHEN jsonb_typeof(${node}) = 'number' THEN ${node} #>> '{}' END)::numeric ${direction}`,
+			`CASE WHEN jsonb_typeof(${node}) IN ('string', 'boolean') THEN ${node} #>> '{}' END ${direction}`,
+		];
+	});
+	return expressions.length > 0 ? ` ORDER BY ${expressions.join(', ')}` : '';
+}
+
+function sqlOrderBy(meta: KvQueryMeta, bind: (value: unknown) => string): string {
+	return sqlOrderByItems(effectiveOrder(meta), bind);
+}
+
+function sqlAfterCursor(
+	items: ReadonlyArray<EffectiveOrderItem>,
+	cursorValues: ReadonlyArray<unknown>,
+	bind: (value: unknown) => string,
+): string {
+	const isSqlNull = (value: unknown): boolean => value === null || value === undefined;
+	const nullPredicate = (column: string, negate = false): string => {
+		const key = bind(column);
+		const expression = `COALESCE(row_data -> ${key}, 'null'::jsonb) = 'null'::jsonb`;
+		return negate ? `NOT (${expression})` : expression;
+	};
+	const equalsCursor = (item: EffectiveOrderItem, value: unknown): string => {
+		if (isSqlNull(value)) return nullPredicate(item.col);
+		const comparable = sqlComparable(item.col, value, bind);
+		if (!comparable) throw new Error(`Unsupported Postgres KV page cursor value for ${item.col}`);
+		return `${comparable.left} = ${comparable.right}`;
+	};
+	const afterCursor = (item: EffectiveOrderItem, value: unknown): string => {
+		if (isSqlNull(value)) return item.direction === 'DESC' ? nullPredicate(item.col, true) : 'FALSE';
+		const comparable = sqlComparable(item.col, value, bind);
+		if (!comparable) throw new Error(`Unsupported Postgres KV page cursor value for ${item.col}`);
+		const comparison = `${comparable.left} ${item.direction === 'DESC' ? '<' : '>'} ${comparable.right}`;
+		return item.direction === 'ASC' ? `(${comparison} OR ${nullPredicate(item.col)})` : comparison;
+	};
+	const alternatives = items.map((item, index) => {
+		const equals = items
+			.slice(0, index)
+			.map((previous, previousIndex) => equalsCursor(previous, cursorValues[previousIndex]));
+		const comparison = afterCursor(item, cursorValues[index]);
+		return `(${[...equals, comparison].join(' AND ')})`;
+	});
+	return `(${alternatives.join(' OR ')})`;
 }
 
 function projectRow(row: Row, columns: ReadonlyArray<string> | undefined): Row {
@@ -223,14 +367,12 @@ function projectRow(row: Row, columns: ReadonlyArray<string> | undefined): Row {
 }
 
 function sortRows(meta: KvQueryMeta, rows: Array<Row>): Array<Row> {
-	if (meta.orderBy) {
-		const direction = meta.orderBy.direction === 'DESC' ? -1 : 1;
-		return rows.sort((left, right) => compareValues(left[meta.orderBy!.col], right[meta.orderBy!.col]) * direction);
-	}
+	const orderItems = effectiveOrder(meta);
 	return rows.sort((left, right) => {
-		for (const column of meta.table.primaryKey) {
-			const cmp = compareValues(left[column], right[column]);
-			if (cmp !== 0) return cmp;
+		for (const item of orderItems) {
+			const direction = item.direction === 'DESC' ? -1 : 1;
+			const comparison = compareValues(left[item.col], right[item.col]) * direction;
+			if (comparison !== 0) return comparison;
 		}
 		return 0;
 	});
@@ -282,16 +424,42 @@ function ttlExpiresAt(meta: KvQueryMeta, params: CassandraParams): Date | null |
 }
 
 function encodePageState(pageState: PageState): string {
-	return Buffer.from(JSON.stringify(pageState)).toString('base64url');
+	return Buffer.from(JSON.stringify({...pageState, values: pageState.values.map(encodeValue)})).toString('base64url');
 }
 
-function decodePageState(pageState: string | null | undefined): PageState {
-	if (!pageState) return {offset: 0};
-	const decoded = JSON.parse(Buffer.from(pageState, 'base64url').toString('utf8')) as PageState;
-	if (!Number.isInteger(decoded.offset) || decoded.offset < 0) {
+function pageScope(meta: KvQueryMeta, params: CassandraParams): string {
+	return JSON.stringify({
+		where: meta.where ?? [],
+		columns: meta.columns ?? null,
+		limit: meta.limit ?? null,
+		params: Object.keys(params)
+			.sort()
+			.map((key) => [key, encodeValue(params[key])]),
+	});
+}
+
+function decodePageState(pageState: string | null | undefined): PageState | null {
+	if (!pageState) return null;
+	const decoded = JSON.parse(Buffer.from(pageState, 'base64url').toString('utf8')) as Partial<PageState>;
+	if (
+		decoded.version !== 1 ||
+		typeof decoded.table !== 'string' ||
+		typeof decoded.scope !== 'string' ||
+		!Array.isArray(decoded.order) ||
+		!Array.isArray(decoded.values) ||
+		decoded.order.length === 0 ||
+		decoded.order.length !== decoded.values.length ||
+		!(decoded.remaining === null || (Number.isInteger(decoded.remaining) && decoded.remaining! >= 0)) ||
+		!decoded.order.every(
+			(item) =>
+				isPlainObject(item) &&
+				typeof item['col'] === 'string' &&
+				(item['direction'] === 'ASC' || item['direction'] === 'DESC'),
+		)
+	) {
 		throw new Error('Invalid Postgres KV page state');
 	}
-	return decoded;
+	return {...(decoded as PageState), values: decoded.values.map(decodeValue)};
 }
 
 function parseRawMeta(cql: string): KvQueryMeta<Row> | null {
@@ -434,8 +602,7 @@ export class PostgresKvQueryExecutor {
 			case 'insert':
 				return (await this.upsert(meta, query.params, db)) as Array<T>;
 			case 'patch':
-				await this.patch(meta, query.params, db);
-				return [];
+				return (await this.patch(meta, query.params, db)) as Array<T>;
 			case 'delete':
 				await this.delete(meta, query.params, db);
 				return [];
@@ -452,13 +619,43 @@ export class PostgresKvQueryExecutor {
 		query: PreparedQuery<P>,
 		options: {pageSize: number; pageState?: string | null},
 	): Promise<{rows: Array<T>; pageState: string | null}> {
+		if (!Number.isInteger(options.pageSize) || options.pageSize <= 0) {
+			throw new Error('Postgres KV page size must be a positive integer');
+		}
+		const meta = this.meta(query);
+		if (meta.action !== 'select') throw new Error('Postgres KV paging requires a select query');
+		const order = effectiveOrder(meta);
+		const scope = pageScope(meta, query.params);
 		const state = decodePageState(options.pageState);
-		const rows = await this.executeQuery<T, P>(query);
-		const pageRows = rows.slice(state.offset, state.offset + options.pageSize);
-		const nextOffset = state.offset + pageRows.length;
+		if (
+			state !== null &&
+			(state.table !== meta.table.name ||
+				state.scope !== scope ||
+				JSON.stringify(state.order) !== JSON.stringify(order))
+		) {
+			throw new Error('Postgres KV page state does not match query scope or ordering');
+		}
+		const remaining = state?.remaining ?? meta.limit ?? null;
+		if (remaining === 0) return {rows: [], pageState: null};
+		const fetchLimit = Math.min(options.pageSize + 1, remaining ?? options.pageSize + 1);
+		const rows = await this.pagedRows(meta, query.params, order, state?.values ?? null, fetchLimit);
+		const pageRows = rows.slice(0, options.pageSize);
+		const remainingAfter = remaining === null ? null : Math.max(0, remaining - pageRows.length);
+		const hasMore = rows.length > options.pageSize && remainingAfter !== 0;
+		const last = pageRows.at(-1);
 		return {
-			rows: pageRows,
-			pageState: nextOffset < rows.length ? encodePageState({offset: nextOffset}) : null,
+			rows: pageRows.map((row) => projectRow(row, meta.columns as ReadonlyArray<string> | undefined)) as Array<T>,
+			pageState:
+				hasMore && last
+					? encodePageState({
+							version: 1,
+							table: meta.table.name,
+							scope,
+							order,
+							values: order.map((item) => last[item.col]),
+							remaining: remainingAfter,
+						})
+					: null,
 		};
 	}
 
@@ -487,16 +684,64 @@ export class PostgresKvQueryExecutor {
 		return meta;
 	}
 
+	private async pagedRows(
+		meta: KvQueryMeta,
+		params: CassandraParams,
+		order: ReadonlyArray<EffectiveOrderItem>,
+		cursorValues: ReadonlyArray<unknown> | null,
+		limit: number,
+	): Promise<Array<Row>> {
+		const values: Array<unknown> = [meta.table.name];
+		const bind = (value: unknown): string => {
+			values.push(value);
+			return `$${values.length}`;
+		};
+		const predicates = ['table_name = $1', '(expires_at IS NULL OR expires_at > now())'];
+		if (hasFullPartition(meta)) predicates.push(`partition_key = ${bind(partitionKeyFromParams(meta, params))}`);
+		for (const clause of meta.where ?? []) {
+			predicates.push(sqlWhereClause(clause as WhereExpr<Row>, params, bind));
+		}
+		if (cursorValues !== null) predicates.push(sqlAfterCursor(order, cursorValues, bind));
+		const orderBy = sqlOrderByItems(order, bind);
+		const sqlLimit = bind(limit);
+		const result = await this.client.query<StoredRow>(
+			`SELECT row_key, row_data FROM ${this.table} WHERE ${predicates.join(' AND ')}${orderBy} LIMIT ${sqlLimit}`,
+			values,
+		);
+		return result.rows.map((stored) => decodeRow(stored.row_data));
+	}
+
 	private async candidates(
 		meta: KvQueryMeta,
 		params: CassandraParams,
 		db: PostgresQueryable,
 	): Promise<Array<StoredRow>> {
 		const rowKeys = fullRowKeysFromWhere(meta, params);
-		if (rowKeys) {
+		if (rowKeys && typeof meta.limit !== 'number') {
 			const result = await db.query<StoredRow>(
 				`SELECT row_key, row_data FROM ${this.table} WHERE table_name = $1 AND row_key = ANY($2::text[]) AND (expires_at IS NULL OR expires_at > now())`,
 				[meta.table.name, rowKeys],
+			);
+			return result.rows;
+		}
+		if (typeof meta.limit === 'number') {
+			const values: Array<unknown> = [meta.table.name];
+			const bind = (value: unknown): string => {
+				values.push(value);
+				return `$${values.length}`;
+			};
+			const predicates = ['table_name = $1', '(expires_at IS NULL OR expires_at > now())'];
+			if (hasFullPartition(meta)) {
+				predicates.push(`partition_key = ${bind(partitionKeyFromParams(meta, params))}`);
+			}
+			for (const clause of meta.where ?? []) {
+				predicates.push(sqlWhereClause(clause as WhereExpr<Row>, params, bind));
+			}
+			const orderBy = sqlOrderBy(meta, bind);
+			const limit = bind(meta.limit);
+			const result = await db.query<StoredRow>(
+				`SELECT row_key, row_data FROM ${this.table} WHERE ${predicates.join(' AND ')}${orderBy} LIMIT ${limit}`,
+				values,
 			);
 			return result.rows;
 		}
@@ -559,8 +804,36 @@ WHERE NOT $6`,
 		return [];
 	}
 
-	private async patch(meta: KvQueryMeta, params: CassandraParams, db: PostgresQueryable): Promise<void> {
+	private async patch(meta: KvQueryMeta, params: CassandraParams, db: PostgresQueryable): Promise<Array<Row>> {
 		const key = rowKeyFromParams(meta, params);
+		const conditions = meta.conditions ?? (meta.condition ? [meta.condition] : []);
+		if (conditions.length > 0) {
+			const patchRow: Row = {};
+			for (const column of meta.patchKeys ?? []) {
+				patchRow[column] = column in params ? params[column] : null;
+			}
+			const ttl = ttlExpiresAt(meta, params);
+			const conditionClauses = conditions.map((_, index) => {
+				const parameter = 6 + index * 2;
+				return `COALESCE(row_data -> $${parameter}, 'null'::jsonb) = $${parameter + 1}::jsonb`;
+			});
+			const conditionParams = conditions.flatMap((condition) => {
+				const expected = encodeRow({[condition.col]: params[condition.expectedParam]})[condition.col];
+				return [condition.col, JSON.stringify(expected)];
+			});
+			const result = await db.query(
+				`UPDATE ${this.table}
+SET row_data = row_data || $3::jsonb,
+    expires_at = CASE WHEN $4 THEN $5::timestamptz ELSE expires_at END,
+    updated_at = now()
+WHERE table_name = $1
+  AND row_key = $2
+  AND (expires_at IS NULL OR expires_at > now())
+  AND ${conditionClauses.join('\n  AND ')}`,
+				[meta.table.name, key, JSON.stringify(encodeRow(patchRow)), ttl !== undefined, ttl ?? null, ...conditionParams],
+			);
+			return [{'[applied]': result.rowCount === 1}];
+		}
 		const existing = await this.getRow(meta, key, db);
 		const base = existing ?? paramsRow(params, (meta.pkColumns ?? meta.table.primaryKey) as ReadonlyArray<string>);
 		const next = {...base};
@@ -576,6 +849,7 @@ ON CONFLICT (table_name, row_key)
 DO UPDATE SET partition_key = EXCLUDED.partition_key, row_data = EXCLUDED.row_data, expires_at = EXCLUDED.expires_at, updated_at = now()`,
 			[meta.table.name, partitionKey(meta, next), key, JSON.stringify(encodeRow(next)), expiresAt ?? null],
 		);
+		return [];
 	}
 
 	private async delete(meta: KvQueryMeta, params: CassandraParams, db: PostgresQueryable): Promise<void> {

--- a/fluxer_api/src/api/database/types/JobLedgerTypes.ts
+++ b/fluxer_api/src/api/database/types/JobLedgerTypes.ts
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-export type JobStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'deadletter';
+export type JobStatus =
+	| 'queued'
+	| 'running'
+	| 'deadletter_pending'
+	| 'succeeded'
+	| 'failed'
+	| 'cancelled'
+	| 'deadletter';
 
 export interface JobByIdRow {
 	job_id: bigint;
@@ -13,12 +20,16 @@ export interface JobByIdRow {
 	result: string | null;
 	error_message: string | null;
 	created_at: Date;
+	state_changed_at: Date | null;
 	started_at: Date | null;
 	completed_at: Date | null;
 	requested_by_user_id: bigint | null;
 	audit_log_reason: string | null;
 	jet_stream_seq: string | null;
 	jet_stream_lane: string | null;
+	lease_token: string | null;
+	lease_expires_at: Date | null;
+	dlq_attempts: number;
 	attempts: number;
 	max_attempts: number;
 	run_at: Date | null;
@@ -37,12 +48,16 @@ export const JOB_BY_ID_COLUMNS = [
 	'result',
 	'error_message',
 	'created_at',
+	'state_changed_at',
 	'started_at',
 	'completed_at',
 	'requested_by_user_id',
 	'audit_log_reason',
 	'jet_stream_seq',
 	'jet_stream_lane',
+	'lease_token',
+	'lease_expires_at',
+	'dlq_attempts',
 	'attempts',
 	'max_attempts',
 	'run_at',
@@ -85,3 +100,11 @@ export const JOB_ACTIVE_COLUMNS = [
 	'created_at',
 	'started_at',
 ] as const satisfies ReadonlyArray<keyof JobActiveRow>;
+
+export interface JobActiveV2Row extends JobActiveRow {
+	shard: number;
+}
+
+export const JOB_ACTIVE_V2_COLUMNS = ['shard', ...JOB_ACTIVE_COLUMNS] as const satisfies ReadonlyArray<
+	keyof JobActiveV2Row
+>;

--- a/fluxer_api/src/api/jobs/IJobLedgerRepository.ts
+++ b/fluxer_api/src/api/jobs/IJobLedgerRepository.ts
@@ -31,30 +31,103 @@ export interface ListJobsResult {
 	nextCursor: ListJobsCursor | null;
 }
 
+export interface ReconcileActiveJobsInput {
+	now: Date;
+	staleBefore: Date;
+	limit: number;
+}
+
+export interface ReconcileActiveJobsResult {
+	scanned: number;
+	removedMissing: number;
+	removedTerminal: number;
+	failedStaleQueued: number;
+	failedExpiredRunning: number;
+	failedExpiredDeadletter: number;
+	skippedFresh: number;
+	skippedScheduled: number;
+	skippedRunning: number;
+	skippedStateChanged: number;
+}
+
+export interface ListActiveJobsInput {
+	limit: number;
+	pageState: string | null;
+	taskType?: string | null;
+}
+
+export interface ListActiveJobsResult {
+	jobs: Array<JobByIdRow>;
+	nextPageState: string | null;
+}
+
+export interface DeadletterPublicationLease {
+	leaseToken: string;
+	errorMessage: string;
+}
+
 export abstract class IJobLedgerRepository {
 	abstract createJob(input: CreateJobInput): Promise<void>;
 
 	abstract getJob(jobId: bigint): Promise<JobByIdRow | null>;
 
-	abstract markRunning(jobId: bigint, lane: string): Promise<void>;
+	abstract claimJob(
+		jobId: bigint,
+		lane: string,
+		leaseToken: string,
+		now: Date,
+		leaseDurationMs: number,
+	): Promise<JobByIdRow | null>;
 
-	abstract markSucceeded(jobId: bigint, result: Record<string, unknown> | null): Promise<void>;
+	abstract renewLease(jobId: bigint, leaseToken: string, now: Date, leaseDurationMs: number): Promise<boolean>;
 
-	abstract markFailed(jobId: bigint, errorMessage: string): Promise<void>;
+	abstract releaseForRetry(
+		jobId: bigint,
+		errorMessage: string,
+		incrementAttempt: boolean,
+		leaseToken: string,
+	): Promise<boolean>;
 
-	abstract markCancelled(jobId: bigint): Promise<void>;
+	abstract markEnqueueFailed(jobId: bigint, errorMessage: string): Promise<boolean>;
 
-	abstract markDeadletter(jobId: bigint, errorMessage: string): Promise<void>;
+	abstract markSucceeded(jobId: bigint, result: Record<string, unknown> | null, leaseToken: string): Promise<boolean>;
 
-	abstract reportProgress(jobId: bigint, current: number, total: number | null, message: string | null): Promise<void>;
+	abstract markFailed(jobId: bigint, errorMessage: string, leaseToken?: string | null): Promise<boolean>;
 
-	abstract setContextLink(jobId: bigint, link: string): Promise<void>;
+	abstract markCancelled(jobId: bigint, leaseToken: string): Promise<boolean>;
 
-	abstract requestCancel(jobId: bigint): Promise<void>;
+	abstract markDeadletterPending(
+		jobId: bigint,
+		errorMessage: string,
+		leaseToken?: string | null,
+		now?: Date,
+		leaseDurationMs?: number,
+	): Promise<DeadletterPublicationLease | null>;
+
+	abstract renewDeadletterPublicationLease(
+		jobId: bigint,
+		leaseToken: string,
+		now: Date,
+		leaseDurationMs: number,
+	): Promise<boolean>;
+
+	abstract recordDlqPublishFailure(jobId: bigint, leaseToken: string): Promise<number | null>;
+
+	abstract markDeadletter(jobId: bigint, errorMessage: string, leaseToken: string): Promise<boolean>;
+
+	abstract reportProgress(
+		jobId: bigint,
+		current: number,
+		total: number | null,
+		message: string | null,
+		leaseToken: string,
+	): Promise<void>;
+
+	abstract setContextLink(jobId: bigint, link: string, leaseToken: string): Promise<void>;
+
+	abstract requestCancel(jobId: bigint): Promise<boolean>;
 
 	abstract isCancelRequested(jobId: bigint): Promise<boolean>;
-
-	abstract incrementAttempts(jobId: bigint): Promise<void>;
 
 	abstract listJobs(opts: {
 		limit: number;
@@ -63,7 +136,12 @@ export abstract class IJobLedgerRepository {
 		maxLookbackDays: number;
 	}): Promise<ListJobsResult>;
 
-	abstract listActiveJobs(): Promise<Array<JobByIdRow>>;
+	abstract reconcileActiveJobs(input: ReconcileActiveJobsInput): Promise<ReconcileActiveJobsResult>;
 
-	abstract listActiveJobsByTaskType(taskType: string): Promise<Array<JobByIdRow>>;
+	abstract listActiveJobs(input: ListActiveJobsInput): Promise<ListActiveJobsResult>;
+
+	abstract listActiveJobsByTaskType(
+		taskType: string,
+		input: Omit<ListActiveJobsInput, 'taskType'>,
+	): Promise<ListActiveJobsResult>;
 }

--- a/fluxer_api/src/api/jobs/JOB_LEDGER_INVARIANTS.md
+++ b/fluxer_api/src/api/jobs/JOB_LEDGER_INVARIANTS.md
@@ -1,0 +1,90 @@
+# Job ledger lifecycle invariants
+
+This ledger is a recoverable distributed state machine. `jobs_by_id` is authoritative. `jobs_active`,
+`jobs_by_day_bucket`, and the JetStream delivery are projections or recovery mechanisms; none may
+silently override authoritative state.
+
+The table below is the required review surface. Test names are behavioral contracts rather than
+implementation details.
+
+## Authoritative state and projections
+
+| Invariant / failure boundary | Required result | Deterministic regression |
+| --- | --- | --- |
+| Create authority before publishing broker work | Publication never precedes a complete authoritative row; failed publication terminalizes the row | `WorkerService.test.ts`: “persists a complete ledger record before publishing the queue message”, “marks a precreated ledger job failed when queue publication fails”, “does not publish when authoritative ledger creation fails” |
+| Non-terminal mutation wins | Authoritative, active, and history rows converge to the same non-terminal state without a terminal TTL | `JobLedgerRepository.test.ts`: “atomically releases running work to a claimable queued retry”, “repairs a speculative terminal bucket when the authoritative CAS errors” |
+| Non-terminal mutation loses a race | The winner is re-read; neither active nor history may be overwritten from the loser | `JobLedgerRepository.test.ts`: “does not overwrite a newer running active index while releasing a retry”, “does not resurrect an active row when a newer claimant terminalizes during retry repair” |
+| Terminal transition before authoritative CAS | History is written with its final retention deadline while active remains as a durable repair index | `JobLedgerRepository.test.ts`: “writes terminal bucket retention before the authoritative terminal CAS” |
+| Terminal CAS loses to a non-terminal winner | Both secondary projections are restored from authority and speculative TTL is removed | `JobLedgerRepository.test.ts`: “repairs the history bucket when reconciliation terminalization loses to lease renewal” |
+| Terminal CAS loses to a terminal winner | The winning terminal status and original retention deadline replace the speculative loser | `JobLedgerRepository.test.ts`: “repairs the winning terminal bucket when a conflicting terminal CAS loses” |
+| Terminal CAS errors before application | Best-effort immediate repair restores projections; the primary error remains visible | `JobLedgerRepository.test.ts`: “repairs a speculative terminal bucket when the authoritative CAS errors” |
+| Immediate conflict repair also errors | Active state remains discoverable and bounded reconciliation restores non-terminal history and removes speculative TTL | `JobLedgerRepository.test.ts`: “uses reconciliation to repair a speculative bucket after immediate conflict repair also fails” |
+| Authoritative CAS succeeds but active deletion errors | Authority and terminal history remain valid; retrying the same terminal outcome idempotently repairs active state | `JobLedgerRepository.test.ts`: “repairs terminal indexes when retrying after active-index deletion fails” |
+| Authority is terminal but active remains | Reconciliation rewrites history with remaining—not restarted—retention and removes active | `JobLedgerRepository.test.ts`: “repairs a terminal day bucket using only the authoritative remaining retention” |
+| Authority has expired or is missing | Reconciliation deletes both derivable secondary rows | `JobLedgerRepository.test.ts`: “removes orphaned and terminal active-index rows” |
+| Retention deadline passes | Complete authoritative and history records expire together | `JobLedgerRepository.test.ts`: “expires complete terminal history rows after the retention window” |
+
+## Lease ownership and lifecycle fencing
+
+| Invariant / interleaving | Required result | Deterministic regression |
+| --- | --- | --- |
+| Expired-lease takeover races owner renewal | Takeover conditions on observed token and expiry; renewal wins | `JobLedgerRepository.test.ts`: “does not steal an expired lease that is concurrently renewed by its owner” |
+| Reconciliation races renewal | Reconciliation conditions on the complete observed lease generation | `JobLedgerRepository.test.ts`: “does not fail a running job that renews while reconciliation is terminalizing it” |
+| Legacy null-lease reconciliation races claim | Null token and null expiry are fenced; claimant wins | `JobLedgerRepository.test.ts`: “does not fail a legacy row that is concurrently claimed during reconciliation” |
+| Stale owner mutates after takeover | Completion and every non-terminal mutation are rejected by lease CAS | `JobLedgerRepository.test.ts`: “reclaims an expired running lease while rejecting a fresh lease and stale owner completion”, “does not regress or resurrect terminal jobs through late worker mutations” |
+| Cancellation loses terminal CAS | The caller receives `false`; the broker message is retained | `WorkerService.test.ts`: “returns false when cancellation loses its terminalization compare-and-set race”; `WorkerRunnerPayload.test.ts`: “keeps the broker message when cancellation cannot be terminalized” |
+| Retry release | Running work atomically becomes queued, clears lease ownership, increments attempts once, and remains claimable | `JobLedgerRepository.test.ts`: “atomically releases running work to a claimable queued retry”; `WorkerRunnerPayload.test.ts`: “releases a failed attempt so the broker redelivery can claim and execute the retry” |
+| Stale queued observation races a claim/retry ABA cycle | Reconciliation conditions on the observed transition generation and attempt count; it cannot overwrite or regress the released retry | `JobLedgerRepository.test.ts`: “does not terminalize a queued retry released after stale reconciliation observation” |
+| Dead-letter publication | Durable pending state precedes publication; one renewable publication lease owns each generation; contenders NAK without publishing; reconciliation fences the complete observed generation | `JobLedgerRepository.test.ts`: pending transition and publication/reconciliation race tests; `WorkerRunnerPayload.test.ts`: publication-owner, pending-DLQ retry, and retained-ledger tests |
+
+## Scheduling and recovery age
+
+| Invariant | Required result | Deterministic regression |
+| --- | --- | --- |
+| Maximum accepted schedule versus source retention | Source `max_age` is at least maximum schedule delay plus the full recovery window; existing streams are upgraded | `JetStreamWorkerQueue.test.ts`: “retains permitted 30-day schedules plus the queue recovery window”, “updates an existing source stream to the schedule-safe retained lifetime” |
+| Scheduled-message authority versus source retention | The authoritative scheduled-message row survives for the same complete schedule-plus-recovery horizon as its source delivery | `JobSchedulingPolicy.test.ts`: “retains scheduled-message authority for the complete queue schedule and recovery horizon” |
+| Future delivery handling | The original durable delivery receives one native delayed NAK; it is not acknowledged and republished | `WorkerRunnerPayload.test.ts`: “preserves the ledger identity through the real future-message processing path” |
+| Newly scheduled queued age | Recovery starts at the later of due time and queued transition time | `JobLedgerRepository.test.ts`: scheduled pending/due/future tests |
+| Scheduled retry age | A retry after the original due date ages from its new queued transition | `JobLedgerRepository.test.ts`: “ages a scheduled retry from its latest queued transition after the original due time” |
+| Dead-letter recovery age | Age is measured from the dead-letter transition, not creation | `JobLedgerRepository.test.ts`: “fails dead-letter-pending work only after the source stream recovery window expires” |
+
+The shared policy in `JobSchedulingPolicy.ts` is the single source for maximum scheduling delay, queue
+recovery window, and source-stream lifetime. The API validator, stream configuration, and reconciler
+must import it rather than duplicate durations.
+
+## Bounded reconciliation and pagination
+
+| Invariant | Required result | Deterministic regression |
+| --- | --- | --- |
+| Bounded active scan | Physical query carries a limit and a continuation predicate | PostgreSQL query-shape and integration tests; `JobLedgerRepository.test.ts`: bounded rotation tests |
+| Fair wraparound | Cursor ordering and comparison describe the same traversal; shuffled insertion `[93, 91, 92]` with limit one visits every row | `JobLedgerRepository.test.ts`: “rotates fairly across shuffled active-row insertion order” |
+| Stable history cursor | Cursor identifies the last returned `(created_at, job_id)` and strict tuple continuation cannot skip equal timestamps | `JobLedgerRepository.test.ts`: stable cursor and equal-timestamp tests |
+| Sparse filters | Bounded chunks continue until a page is filled or lookback ends | `JobLedgerRepository.test.ts`: “continues scanning a bucket until sparse filters fill the page” |
+| Backend parity | Cassandra metadata, emitted PostgreSQL, and compatibility executor apply the same predicates, deterministic order, null conditions, and limit | `CassandraTableDsl.test.ts`, `PostgresKvQueryExecutor.test.ts`, `PostgresKvQueryExecutor.Integration.test.ts` |
+| Compatibility paging under mutation | PostgreSQL uses a physical `LIMIT` and a typed, order-bound keyset cursor; deletion before the cursor cannot skip later rows; declared mixed clustering order is preserved | `PostgresKvQueryExecutor.test.ts`: bounded page and limited-IN query shapes; `PostgresKvQueryExecutor.Integration.test.ts`: mixed-direction keyset deletion regression |
+
+## Worker and broker lifecycle
+
+| Invariant / interleaving | Required result | Deterministic regression |
+| --- | --- | --- |
+| Stop with active plus prefetched work | Active work drains; prefetched work never starts and is released | `WorkerRunnerPayload.test.ts`: “drains active work and does not start prefetched work after stop begins” |
+| Stop during consumer acquisition | A consumer acquired after stop starts is closed before `start()` returns | `WorkerRunnerPayload.test.ts`: “closes a consumer acquired after stop begins before start can return” |
+| Consumer close fails | Close error is preserved only after already-started work drains | `WorkerRunnerPayload.test.ts`: “drains active work even when closing the consumer fails” |
+| Concurrent stop calls overlap a close failure | Every caller joins one stop promise; no caller waits separately on a stuck iterator | `WorkerRunnerPayload.test.ts`: “joins concurrent stop callers when consumer close fails instead of awaiting a stuck iterator” |
+| Fatal and graceful shutdown overlap | All callers join one complete backend cleanup; all runners are awaited even when one stop rejects | `WorkerMainLifecycle.test.ts`: joinable-shutdown and all-runner-settlement tests |
+| Lease heartbeat | Durable lease and broker acknowledgement timer renew for the complete active execution | `WorkerRunnerPayload.test.ts`: “renews the durable lease and broker ack timer while task execution is active” |
+| Terminal CAS loses | Worker retains the broker message rather than acknowledging uncommitted work | `WorkerRunnerPayload.test.ts`: successful/cancellation terminalization-loss tests |
+| DLQ deduplication | Stable message ID and duplicate window cover the retained DLQ lifetime | `JetStreamWorkerQueue.test.ts`: DLQ duplicate-window and stable-message-ID tests |
+
+## Review gate
+
+A candidate is eligible for approval only when all of the following bind to the same staged Git tree:
+
+1. focused deterministic regressions pass;
+2. TypeScript and Biome pass;
+3. real PostgreSQL integration passes;
+4. Cassandra-specific conditional/schema semantics are checked;
+5. the complete API suite passes; and
+6. two independent read-only reviewers return explicit `PASS` for that exact tree.
+
+Any source, test, schema, or documentation edit invalidates earlier full-suite and review evidence.

--- a/fluxer_api/src/api/jobs/JobAdminService.ts
+++ b/fluxer_api/src/api/jobs/JobAdminService.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import type {JobLedgerEntry, ListJobsRequest} from '@fluxer/schema/src/domains/admin/JobsSchemas';
+import type {ActiveJobsRequest, JobLedgerEntry, ListJobsRequest} from '@fluxer/schema/src/domains/admin/JobsSchemas';
 import type {IWorkerService} from '@pkgs/worker/src/contracts/IWorkerService';
 import type {JobByIdRow} from '../database/types/JobLedgerTypes';
 import type {IJobLedgerRepository} from './IJobLedgerRepository';
@@ -62,11 +62,16 @@ export class JobAdminService {
 		return {cancelled};
 	}
 
-	async listActiveJobs(): Promise<{
+	async listActiveJobs(req: ActiveJobsRequest): Promise<{
 		jobs: Array<JobLedgerEntry>;
+		next_page_state: string | null;
 	}> {
-		const rows = await this.ledger.listActiveJobs();
-		return {jobs: rows.map(rowToEntry)};
+		const result = await this.ledger.listActiveJobs({
+			limit: req.limit,
+			pageState: req.page_state ?? null,
+			taskType: req.task_type ?? null,
+		});
+		return {jobs: result.jobs.map(rowToEntry), next_page_state: result.nextPageState};
 	}
 }
 

--- a/fluxer_api/src/api/jobs/JobLedgerRepository.test.ts
+++ b/fluxer_api/src/api/jobs/JobLedgerRepository.test.ts
@@ -1,0 +1,1064 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {ListJobsRequest} from '@fluxer/schema/src/domains/admin/JobsSchemas';
+import {seconds} from 'itty-time';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {fetchMany, fetchOne, setCassandraQueryExecutorForTesting, upsertOne} from '../database/CassandraQueryExecution';
+import {type CassandraParams, Db, type KvQueryMeta, type PreparedQuery} from '../database/CassandraTypes';
+import type {JobActiveRow, JobActiveV2Row, JobByDayBucketRow, JobByIdRow} from '../database/types/JobLedgerTypes';
+import {JobsActive, JobsActiveLegacy, JobsByDayBucket, JobsById} from '../Tables';
+import {InMemoryCassandraQueryExecutor} from '../test/InMemoryCassandraQueryExecutor';
+import {JOB_HISTORY_RETENTION_SECONDS, JobLedgerRepository} from './JobLedgerRepository';
+
+interface RecordedBatchQuery {
+	query: string;
+	params: object;
+	meta?: KvQueryMeta;
+}
+
+class RecordingExecutor extends InMemoryCassandraQueryExecutor {
+	readonly batchQueries: Array<RecordedBatchQuery> = [];
+	readonly queries: Array<PreparedQuery> = [];
+	beforeConditional: (() => Promise<void>) | null = null;
+	afterConditional: (() => Promise<void>) | null = null;
+	onActiveUpsert: (() => Promise<void>) | null = null;
+	beforeActiveDelete: (() => Promise<void>) | null = null;
+	onBucketUpsert: ((query: PreparedQuery) => Promise<void>) | null = null;
+
+	override async executeQuery<T = Record<string, unknown>>(query: PreparedQuery): Promise<Array<T>> {
+		this.queries.push(query);
+		if (query.kvMeta?.table.name === 'jobs_active' && query.kvMeta.action === 'upsert' && this.onActiveUpsert) {
+			await this.onActiveUpsert();
+		}
+		if (query.kvMeta?.table.name === 'jobs_active' && query.kvMeta.action === 'delete' && this.beforeActiveDelete) {
+			const hook = this.beforeActiveDelete;
+			this.beforeActiveDelete = null;
+			await hook();
+		}
+		if (query.kvMeta?.table.name === 'jobs_by_day_bucket' && query.kvMeta.action === 'upsert' && this.onBucketUpsert) {
+			await this.onBucketUpsert(query);
+		}
+		if ((query.kvMeta?.condition || query.kvMeta?.conditions) && this.beforeConditional) {
+			const hook = this.beforeConditional;
+			this.beforeConditional = null;
+			await hook();
+		}
+		const result = await super.executeQuery<T>(query);
+		if ((query.kvMeta?.condition || query.kvMeta?.conditions) && this.afterConditional) {
+			const hook = this.afterConditional;
+			this.afterConditional = null;
+			await hook();
+		}
+		return result;
+	}
+
+	override async executeBatch(queries: Array<RecordedBatchQuery>): Promise<void> {
+		this.batchQueries.push(...queries);
+		await super.executeBatch(queries);
+	}
+}
+
+let executor: RecordingExecutor;
+let repository: JobLedgerRepository;
+let leaseCounter: number;
+const claimedLeaseTokens = new Map<bigint, string>();
+
+async function claimRunning(jobId: bigint, lane: string): Promise<boolean> {
+	leaseCounter += 1;
+	const leaseToken = `test-lease-${leaseCounter}`;
+	const claimed = await repository.claimJob(jobId, lane, leaseToken, new Date(), seconds('1 day') * 1000);
+	if (claimed !== null) claimedLeaseTokens.set(jobId, leaseToken);
+	return claimed !== null;
+}
+
+function leaseTokenFor(jobId: bigint): string {
+	const leaseToken = claimedLeaseTokens.get(jobId);
+	if (!leaseToken) throw new Error(`Job ${jobId.toString()} has no claimed test lease`);
+	return leaseToken;
+}
+
+async function fetchBucket(jobId: bigint, createdAt: Date): Promise<JobByDayBucketRow | null> {
+	return fetchOne<JobByDayBucketRow>(
+		JobsByDayBucket.select({
+			where: [
+				JobsByDayBucket.where.eq('bucket_day'),
+				JobsByDayBucket.where.eq('created_at'),
+				JobsByDayBucket.where.eq('job_id'),
+			],
+		}).bind({bucket_day: createdAt.toISOString().slice(0, 10), created_at: createdAt, job_id: jobId}),
+	);
+}
+
+describe('JobLedgerRepository', () => {
+	beforeEach(() => {
+		executor = new RecordingExecutor();
+		setCassandraQueryExecutorForTesting(executor);
+		leaseCounter = 0;
+		claimedLeaseTokens.clear();
+		repository = new JobLedgerRepository();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		executor.reset();
+		setCassandraQueryExecutorForTesting(null);
+	});
+
+	it('uses the last returned row as a stable cursor without skipping the next job', async () => {
+		vi.useFakeTimers();
+		for (const [jobId, timestamp] of [
+			[65n, '2026-08-10T00:01:00.000Z'],
+			[66n, '2026-08-10T00:02:00.000Z'],
+			[67n, '2026-08-10T00:03:00.000Z'],
+		] as const) {
+			vi.setSystemTime(new Date(timestamp));
+			await createQueuedJob(jobId, null);
+		}
+		const first = await repository.listJobs({limit: 1, cursor: null, filters: {}, maxLookbackDays: 1});
+		const second = await repository.listJobs({limit: 1, cursor: first.nextCursor, filters: {}, maxLookbackDays: 1});
+
+		expect(first.jobs.map((job) => job.job_id)).toEqual([67n]);
+		expect(first.nextCursor?.jobId).toBe(67n);
+		expect(second.jobs.map((job) => job.job_id)).toEqual([66n]);
+	});
+
+	it('rejects a history cursor whose timestamp does not belong to its UTC day bucket', () => {
+		expect(
+			ListJobsRequest.safeParse({
+				cursor: {
+					bucket_day: '2026-08-10',
+					created_at: '2026-08-11T00:00:00.000Z',
+					job_id: '1',
+				},
+			}),
+		).toMatchObject({success: false});
+	});
+
+	it('bounds active-index reads and authority hydration with an opaque continuation', async () => {
+		await createQueuedJob(3001n, null);
+		await createQueuedJob(3002n, null);
+		await createQueuedJob(3003n, null);
+
+		const jobs = await collectAllActiveJobs(2);
+		expect(jobs.map((job) => job.job_id).sort()).toEqual([3001n, 3002n, 3003n]);
+	});
+
+	it('continuously sweeps legacy rows skipped by mutable offset paging', async () => {
+		const createdAt = new Date('2026-08-01T00:00:00.000Z');
+		for (const jobId of [1n, 2n, 3n, 4n]) {
+			await upsertOne(
+				JobsActiveLegacy.upsertAll({
+					job_id: jobId,
+					task_type: 'legacy',
+					status: 'queued',
+					requested_by_user_id: null,
+					created_at: createdAt,
+					started_at: null,
+				}),
+			);
+		}
+		const input = {limit: 2, now: createdAt, staleBefore: createdAt};
+		expect((await repository.reconcileActiveJobs(input)).removedMissing).toBe(2);
+		expect((await repository.reconcileActiveJobs(input)).removedMissing).toBe(0);
+		expect((await repository.reconcileActiveJobs(input)).removedMissing).toBe(2);
+		expect(await fetchMany<JobActiveRow>(JobsActiveLegacy.select().bind({}))).toEqual([]);
+	});
+
+	it('paginates equal-timestamp rows by descending job id', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-10T00:04:00.000Z'));
+		await createQueuedJob(71n, null);
+		await createQueuedJob(72n, null);
+
+		const first = await repository.listJobs({limit: 1, cursor: null, filters: {}, maxLookbackDays: 1});
+		const second = await repository.listJobs({limit: 1, cursor: first.nextCursor, filters: {}, maxLookbackDays: 1});
+
+		expect(first.jobs.map((job) => job.job_id)).toEqual([72n]);
+		expect(second.jobs.map((job) => job.job_id)).toEqual([71n]);
+	});
+
+	it('continues scanning a bucket until sparse filters fill the page', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-10T00:01:00.000Z'));
+		await createQueuedJob(68n, null);
+		expect(await repository.markEnqueueFailed(68n, 'expected')).toBe(true);
+		vi.setSystemTime(new Date('2026-08-10T00:02:00.000Z'));
+		await createQueuedJob(69n, null);
+		vi.setSystemTime(new Date('2026-08-10T00:03:00.000Z'));
+		await createQueuedJob(70n, null);
+
+		const page = await repository.listJobs({
+			limit: 1,
+			cursor: null,
+			filters: {status: 'failed'},
+			maxLookbackDays: 1,
+		});
+
+		expect(page.jobs.map((job) => job.job_id)).toEqual([68n]);
+	});
+
+	it('writes terminal bucket retention before the authoritative terminal CAS', async () => {
+		await createQueuedJob(76n, null);
+		const leaseToken = 'retention-lease';
+		expect(await repository.claimJob(76n, 'worker-batch', leaseToken, new Date(), 60_000)).not.toBeNull();
+		let retainedBucketBeforeCas = false;
+		executor.beforeConditional = async () => {
+			executor.beforeConditional = null;
+			retainedBucketBeforeCas = executor.queries.some(
+				(query) => query.kvMeta?.table.name === 'jobs_by_day_bucket' && typeof query.kvMeta.ttlParamName === 'string',
+			);
+		};
+
+		expect(await repository.markSucceeded(76n, {ok: true}, leaseToken)).toBe(true);
+		expect(retainedBucketBeforeCas).toBe(true);
+	});
+
+	it('repairs the history bucket when reconciliation terminalization loses to lease renewal', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(78n, null);
+		const before = await repository.getJob(78n);
+		expect(before).not.toBeNull();
+		expect(await repository.claimJob(78n, 'worker-batch', 'lease-a', new Date(), 60_000)).not.toBeNull();
+		vi.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
+		executor.beforeConditional = async () => {
+			executor.beforeConditional = null;
+			expect(await repository.renewLease(78n, 'lease-a', new Date(), 120_000)).toBe(true);
+		};
+
+		const result = await repository.reconcileActiveJobs({
+			now: new Date(),
+			staleBefore: new Date('2026-08-12T00:00:00.000Z'),
+			limit: 100,
+		});
+
+		const authoritative = await repository.getJob(78n);
+		const bucket = await fetchBucket(78n, before!.created_at);
+		expect(result.failedExpiredRunning).toBe(0);
+		expect(authoritative?.status).toBe('running');
+		expect(bucket?.status).toBe('running');
+	});
+
+	it('repairs the winning terminal bucket when a conflicting terminal CAS loses', async () => {
+		await createQueuedJob(82n, null);
+		const before = await repository.getJob(82n);
+		expect(await repository.claimJob(82n, 'worker-batch', 'lease-terminal', new Date(), 60_000)).not.toBeNull();
+		executor.beforeConditional = async () => {
+			executor.beforeConditional = null;
+			expect(await repository.markSucceeded(82n, {winner: true}, 'lease-terminal')).toBe(true);
+		};
+
+		expect(await repository.markFailed(82n, 'loser', 'lease-terminal')).toBe(false);
+		expect(await repository.getJob(82n)).toMatchObject({status: 'succeeded'});
+		expect(await fetchBucket(82n, before!.created_at)).toMatchObject({status: 'succeeded'});
+	});
+
+	it('repairs a speculative terminal bucket when the authoritative CAS errors', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(79n, null);
+		const before = await repository.getJob(79n);
+		expect(await repository.claimJob(79n, 'worker-batch', 'lease-error', new Date(), 60_000)).not.toBeNull();
+		executor.beforeConditional = async () => {
+			throw new Error('conditional write unavailable');
+		};
+
+		await expect(repository.markFailed(79n, 'failed', 'lease-error')).rejects.toThrow('conditional write unavailable');
+		expect((await repository.getJob(79n))?.status).toBe('running');
+		expect((await fetchBucket(79n, before!.created_at))?.status).toBe('running');
+		vi.setSystemTime(new Date('2026-08-09T00:00:00.000Z'));
+		expect(await fetchBucket(79n, before!.created_at)).not.toBeNull();
+	});
+
+	it('uses reconciliation to repair a speculative bucket after immediate conflict repair also fails', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(81n, null);
+		const before = await repository.getJob(81n);
+		expect(await repository.claimJob(81n, 'worker-batch', 'lease-repair', new Date(), 60_000)).not.toBeNull();
+		executor.beforeConditional = async () => {
+			throw new Error('conditional write unavailable');
+		};
+		executor.onBucketUpsert = async (query) => {
+			if ((query.params as CassandraParams).status === 'running') {
+				executor.onBucketUpsert = null;
+				throw new Error('bucket repair unavailable');
+			}
+		};
+
+		await expect(repository.markFailed(81n, 'failed', 'lease-repair')).rejects.toThrow('conditional write unavailable');
+		expect((await fetchBucket(81n, before!.created_at))?.status).toBe('failed');
+
+		await repository.reconcileActiveJobs({
+			now: new Date('2026-08-02T00:00:00.000Z'),
+			staleBefore: new Date('2026-07-25T00:00:00.000Z'),
+			limit: 100,
+		});
+		expect((await fetchBucket(81n, before!.created_at))?.status).toBe('running');
+		vi.setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
+		expect(await fetchBucket(81n, before!.created_at)).not.toBeNull();
+	});
+
+	it('repairs terminal indexes when retrying after active-index deletion fails', async () => {
+		await createQueuedJob(80n, null);
+		expect(await repository.claimJob(80n, 'worker-batch', 'lease-delete', new Date(), 60_000)).not.toBeNull();
+		executor.beforeActiveDelete = async () => {
+			throw new Error('active delete unavailable');
+		};
+
+		await expect(repository.markSucceeded(80n, {ok: true}, 'lease-delete')).rejects.toThrow(
+			'active delete unavailable',
+		);
+		expect((await repository.getJob(80n))?.status).toBe('succeeded');
+		expect((await collectAllActiveJobs()).map((job) => job.job_id)).not.toContain(80n);
+
+		expect(await repository.markSucceeded(80n, {ok: true}, 'lease-delete')).toBe(true);
+		expect(
+			(await repository.listActiveJobs({limit: 200, pageState: null})).jobs.map((job) => job.job_id),
+		).not.toContain(80n);
+	});
+
+	it('publishes terminal status consistently and removes active state', async () => {
+		await repository.createJob({
+			auditLogReason: null,
+			jetStreamLane: 'maintenance',
+			jetStreamSeq: null,
+			jobId: 42n,
+			maxAttempts: 5,
+			payload: {},
+			requestedByUserId: null,
+			runAt: null,
+			taskType: 'flushUserActivityBuffer',
+		});
+
+		expect(await claimRunning(42n, 'worker-batch')).toBe(true);
+		await repository.markSucceeded(42n, null, leaseTokenFor(42n));
+
+		expect((await repository.getJob(42n))?.status).toBe('succeeded');
+		expect((await repository.listActiveJobs({limit: 200, pageState: null})).jobs).toEqual([]);
+		expect(
+			(
+				await repository.listJobs({
+					filters: {status: 'succeeded'},
+					limit: 10,
+					maxLookbackDays: 1,
+					cursor: null,
+				})
+			).jobs.map((job) => job.job_id),
+		).toEqual([42n]);
+		expect(
+			(
+				await repository.listJobs({
+					filters: {status: 'queued'},
+					limit: 10,
+					maxLookbackDays: 1,
+					cursor: null,
+				})
+			).jobs,
+		).toEqual([]);
+	});
+
+	it('expires complete terminal history rows after the retention window', async () => {
+		await repository.createJob({
+			auditLogReason: null,
+			jetStreamLane: 'maintenance',
+			jetStreamSeq: null,
+			jobId: 43n,
+			maxAttempts: 5,
+			payload: {},
+			requestedByUserId: null,
+			runAt: null,
+			taskType: 'flushUserActivityBuffer',
+		});
+		executor.batchQueries.length = 0;
+		executor.queries.length = 0;
+
+		expect(await claimRunning(43n, 'worker-batch')).toBe(true);
+		await repository.markSucceeded(43n, null, leaseTokenFor(43n));
+
+		const historyWrites = executor.queries.filter(
+			(query) =>
+				(query.kvMeta?.table.name === 'jobs_by_id' || query.kvMeta?.table.name === 'jobs_by_day_bucket') &&
+				query.kvMeta.ttlParamName,
+		);
+		expect(historyWrites).toHaveLength(2);
+		for (const write of historyWrites) {
+			expect(write.kvMeta?.ttlParamName).toBeTruthy();
+			const ttlParamName = write.kvMeta?.ttlParamName as string;
+			expect((write.params as CassandraParams)[ttlParamName]).toBe(JOB_HISTORY_RETENTION_SECONDS);
+		}
+		expect(historyWrites.find((write) => write.kvMeta?.table.name === 'jobs_by_id')?.kvMeta?.condition).toEqual(
+			expect.objectContaining({col: 'lease_token', expectedValue: leaseTokenFor(43n)}),
+		);
+	});
+
+	it('fails stale due jobs while preserving fresh and future-scheduled jobs', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(44n, null);
+		await createQueuedJob(45n, new Date('2026-08-12T00:00:00.000Z'));
+		await createQueuedJob(47n, null);
+		vi.setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
+		await claimRunning(47n, 'worker-batch');
+		await createQueuedJob(46n, null);
+
+		const result = await repository.reconcileActiveJobs({
+			limit: 100,
+			now: new Date(),
+			staleBefore: new Date('2026-08-02T00:00:00.000Z'),
+		});
+
+		expect(result).toMatchObject({
+			failedStaleQueued: 1,
+			removedMissing: 0,
+			removedTerminal: 0,
+			skippedFresh: 1,
+			skippedScheduled: 1,
+			skippedRunning: 1,
+			skippedStateChanged: 0,
+		});
+		expect((await repository.getJob(44n))?.status).toBe('failed');
+		expect((await repository.getJob(47n))?.status).toBe('running');
+		expect((await collectAllActiveJobs()).map((job) => job.job_id).sort()).toEqual([45n, 46n, 47n]);
+	});
+
+	it('does not fail a queued job that becomes running during reconciliation', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(50n, null);
+		vi.setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
+		executor.beforeConditional = async () => {
+			await claimRunning(50n, 'worker-batch');
+		};
+
+		const result = await repository.reconcileActiveJobs({
+			limit: 100,
+			now: new Date(),
+			staleBefore: new Date('2026-08-02T00:00:00.000Z'),
+		});
+
+		expect(result.failedStaleQueued).toBe(0);
+		expect((await repository.getJob(50n))?.status).toBe('running');
+	});
+
+	it('atomically releases running work to a claimable queued retry', async () => {
+		await createQueuedJob(54n, null);
+		expect(await claimRunning(54n, 'worker-batch')).toBe(true);
+
+		expect(await repository.releaseForRetry(54n, 'temporary failure', true, leaseTokenFor(54n))).toBe(true);
+		expect(await repository.getJob(54n)).toMatchObject({
+			status: 'queued',
+			attempts: 1,
+			error_message: 'temporary failure',
+			started_at: null,
+		});
+		expect(await claimRunning(54n, 'worker-batch')).toBe(true);
+	});
+
+	it('does not overwrite a newer running active index while releasing a retry', async () => {
+		await createQueuedJob(55n, null);
+		expect(await claimRunning(55n, 'worker-batch')).toBe(true);
+		const releasingLease = leaseTokenFor(55n);
+		executor.afterConditional = async () => {
+			expect(await claimRunning(55n, 'worker-retry')).toBe(true);
+		};
+
+		expect(await repository.releaseForRetry(55n, 'temporary failure', true, releasingLease)).toBe(true);
+
+		expect((await repository.getJob(55n))?.status).toBe('running');
+		const active = await fetchOne<JobActiveV2Row>(
+			JobsActive.select({where: [JobsActive.where.eq('shard'), JobsActive.where.eq('job_id')], limit: 1}).bind({
+				shard: 55,
+				job_id: 55n,
+			}),
+		);
+		expect(active).toMatchObject({status: 'running'});
+	});
+
+	it('does not resurrect an active row when a newer claimant terminalizes during retry repair', async () => {
+		await createQueuedJob(56n, null);
+		expect(await claimRunning(56n, 'worker-batch')).toBe(true);
+		let activeUpserts = 0;
+		const releasingLease = leaseTokenFor(56n);
+		executor.afterConditional = async () => {
+			expect(await claimRunning(56n, 'worker-retry')).toBe(true);
+		};
+		executor.onActiveUpsert = async () => {
+			activeUpserts += 1;
+			if (activeUpserts === 3) {
+				executor.onActiveUpsert = null;
+				expect(await repository.markSucceeded(56n, null, leaseTokenFor(56n))).toBe(true);
+			}
+		};
+
+		expect(await repository.releaseForRetry(56n, 'temporary failure', true, releasingLease)).toBe(true);
+
+		expect((await repository.getJob(56n))?.status).toBe('succeeded');
+		const active = await fetchOne<JobActiveV2Row>(
+			JobsActive.select({where: [JobsActive.where.eq('shard'), JobsActive.where.eq('job_id')], limit: 1}).bind({
+				shard: 56,
+				job_id: 56n,
+			}),
+		);
+		expect(active).toBeNull();
+	});
+
+	it('persists a dead-letter-pending state before publication and terminalizes it conditionally', async () => {
+		await createQueuedJob(57n, null);
+		expect(await claimRunning(57n, 'worker-batch')).toBe(true);
+
+		const firstPublication = await repository.markDeadletterPending(57n, 'permanent failure', leaseTokenFor(57n));
+		expect(firstPublication).not.toBeNull();
+		expect(await repository.getJob(57n)).toMatchObject({
+			status: 'deadletter_pending',
+			error_message: 'permanent failure',
+			dlq_attempts: 0,
+		});
+		expect(await repository.recordDlqPublishFailure(57n, firstPublication!.leaseToken)).toBe(1);
+		const secondPublication = await repository.markDeadletterPending(57n, 'ignored after durable transition');
+		expect(secondPublication).not.toBeNull();
+		expect(await repository.recordDlqPublishFailure(57n, secondPublication!.leaseToken)).toBe(2);
+		const finalPublication = await repository.markDeadletterPending(57n, 'ignored after durable transition');
+		expect(finalPublication).not.toBeNull();
+		expect(await repository.markDeadletter(57n, 'permanent failure', finalPublication!.leaseToken)).toBe(true);
+		expect(await repository.getJob(57n)).toMatchObject({status: 'deadletter'});
+	});
+
+	it('allows only one dead-letter publisher per renewable lease generation', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(85n, null);
+		expect(await repository.claimJob(85n, 'worker-batch', 'task-owner', new Date(), 60_000)).not.toBeNull();
+		const first = await repository.markDeadletterPending(85n, 'permanent', 'task-owner', new Date(), 60_000);
+		expect(first).not.toBeNull();
+		expect(await repository.markDeadletterPending(85n, 'permanent', null, new Date(), 60_000)).toBeNull();
+		expect(
+			await repository.renewDeadletterPublicationLease(
+				85n,
+				first!.leaseToken,
+				new Date('2026-08-01T00:00:30.000Z'),
+				60_000,
+			),
+		).toBe(true);
+		expect(
+			await repository.markDeadletterPending(85n, 'permanent', null, new Date('2026-08-01T00:01:01.000Z'), 60_000),
+		).toBeNull();
+		const second = await repository.markDeadletterPending(
+			85n,
+			'permanent',
+			null,
+			new Date('2026-08-01T00:01:31.000Z'),
+			60_000,
+		);
+		expect(second).not.toBeNull();
+		expect(await repository.markDeadletter(85n, 'permanent', first!.leaseToken)).toBe(false);
+		expect(await repository.markDeadletter(85n, 'permanent', second!.leaseToken)).toBe(true);
+	});
+
+	it('does not steal an expired lease that is concurrently renewed by its owner', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
+		await createQueuedJob(61n, null);
+		expect(
+			await repository.claimJob(61n, 'worker-batch', 'lease-a', new Date('2026-08-10T00:00:00.000Z'), 60_000),
+		).not.toBeNull();
+		executor.beforeConditional = async () => {
+			expect(await repository.renewLease(61n, 'lease-a', new Date('2026-08-10T00:01:00.000Z'), 60_000)).toBe(true);
+		};
+
+		expect(
+			await repository.claimJob(61n, 'worker-batch', 'lease-b', new Date('2026-08-10T00:01:01.000Z'), 60_000),
+		).toBeNull();
+		expect(await repository.getJob(61n)).toMatchObject({
+			lease_token: 'lease-a',
+			lease_expires_at: new Date('2026-08-10T00:02:00.000Z'),
+		});
+	});
+
+	it('never shortens a worker lease when overlapping renewals complete out of order', async () => {
+		await createQueuedJob(62n, null);
+		expect(
+			await repository.claimJob(62n, 'worker-batch', 'lease-a', new Date('2026-08-10T00:00:00.000Z'), 60_000),
+		).not.toBeNull();
+		executor.beforeConditional = async () => {
+			expect(await repository.renewLease(62n, 'lease-a', new Date('2026-08-10T00:02:00.000Z'), 60_000)).toBe(true);
+		};
+
+		expect(await repository.renewLease(62n, 'lease-a', new Date('2026-08-10T00:01:00.000Z'), 60_000)).toBe(true);
+		expect((await repository.getJob(62n))?.lease_expires_at).toEqual(new Date('2026-08-10T00:03:00.000Z'));
+	});
+
+	it('never shortens a dead-letter publication lease when renewals complete out of order', async () => {
+		await createQueuedJob(86n, null);
+		expect(
+			await repository.claimJob(86n, 'worker-batch', 'task-owner', new Date('2026-08-10T00:00:00.000Z'), 60_000),
+		).not.toBeNull();
+		const publication = await repository.markDeadletterPending(
+			86n,
+			'permanent',
+			'task-owner',
+			new Date('2026-08-10T00:00:00.000Z'),
+			60_000,
+		);
+		expect(publication).not.toBeNull();
+		executor.beforeConditional = async () => {
+			expect(
+				await repository.renewDeadletterPublicationLease(
+					86n,
+					publication!.leaseToken,
+					new Date('2026-08-10T00:02:00.000Z'),
+					60_000,
+				),
+			).toBe(true);
+		};
+
+		expect(
+			await repository.renewDeadletterPublicationLease(
+				86n,
+				publication!.leaseToken,
+				new Date('2026-08-10T00:01:00.000Z'),
+				60_000,
+			),
+		).toBe(true);
+		expect((await repository.getJob(86n))?.lease_expires_at).toEqual(new Date('2026-08-10T00:03:00.000Z'));
+	});
+
+	it('reclaims a stale pre-upgrade running row without lease fields', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(63n, null);
+		expect(await claimRunning(63n, 'worker-batch')).toBe(true);
+		await upsertOne(
+			JobsById.patchByPk(
+				{job_id: 63n},
+				{lease_token: Db.clear(), lease_expires_at: Db.clear(), state_changed_at: Db.clear()},
+			),
+		);
+
+		const reclaimed = await repository.claimJob(
+			63n,
+			'worker-batch',
+			'upgraded-lease',
+			new Date('2026-08-10T00:00:00.000Z'),
+			60_000,
+		);
+
+		expect(reclaimed).toMatchObject({status: 'running', lease_token: 'upgraded-lease'});
+	});
+
+	it('terminalizes a stale pre-upgrade running row when no broker delivery remains', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(64n, null);
+		expect(await claimRunning(64n, 'worker-batch')).toBe(true);
+		await upsertOne(
+			JobsById.patchByPk(
+				{job_id: 64n},
+				{lease_token: Db.clear(), lease_expires_at: Db.clear(), state_changed_at: Db.clear()},
+			),
+		);
+
+		const result = await repository.reconcileActiveJobs({
+			now: new Date('2026-08-10T00:00:00.000Z'),
+			staleBefore: new Date('2026-08-02T00:00:00.000Z'),
+			limit: 500,
+		});
+
+		expect(result.failedExpiredRunning).toBe(1);
+		expect(await repository.getJob(64n)).toMatchObject({status: 'failed'});
+	});
+
+	it('does not fail a running job that renews while reconciliation is terminalizing it', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(73n, null);
+		expect(
+			await repository.claimJob(73n, 'worker-batch', 'lease-a', new Date(), seconds('1 minute') * 1000),
+		).not.toBeNull();
+		vi.setSystemTime(new Date('2026-08-02T00:00:00.000Z'));
+		executor.beforeConditional = async () => {
+			executor.beforeConditional = null;
+			expect(await repository.renewLease(73n, 'lease-a', new Date(), seconds('1 day') * 1000)).toBe(true);
+		};
+
+		const result = await repository.reconcileActiveJobs({
+			now: new Date(),
+			staleBefore: new Date('2026-08-01T12:00:00.000Z'),
+			limit: 500,
+		});
+
+		expect(result.failedExpiredRunning).toBe(0);
+		expect((await repository.getJob(73n))?.status).toBe('running');
+	});
+
+	it('does not fail a legacy row that is concurrently claimed during reconciliation', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(74n, null);
+		expect(
+			await repository.claimJob(74n, 'worker-batch', 'legacy-owner', new Date(), seconds('1 minute') * 1000),
+		).not.toBeNull();
+		await upsertOne(
+			JobsById.patchByPk(
+				{job_id: 74n},
+				{lease_token: Db.clear(), lease_expires_at: Db.clear(), state_changed_at: Db.clear()},
+			),
+		);
+		vi.setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
+		executor.beforeConditional = async () => {
+			executor.beforeConditional = null;
+			expect(
+				await repository.claimJob(74n, 'worker-recovery', 'lease-b', new Date(), seconds('1 day') * 1000),
+			).not.toBeNull();
+		};
+
+		const result = await repository.reconcileActiveJobs({
+			now: new Date(),
+			staleBefore: new Date('2026-08-02T00:00:00.000Z'),
+			limit: 500,
+		});
+
+		expect(result.failedExpiredRunning).toBe(0);
+		expect((await repository.getJob(74n))?.lease_token).toBe('lease-b');
+	});
+
+	it('reclaims an expired running lease while rejecting a fresh lease and stale owner completion', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
+		await createQueuedJob(58n, null);
+
+		expect(
+			await repository.claimJob(58n, 'worker-batch', 'lease-a', new Date('2026-08-10T00:00:00.000Z'), 60_000),
+		).toMatchObject({status: 'running', lease_token: 'lease-a'});
+		expect(
+			await repository.claimJob(58n, 'worker-batch', 'lease-b', new Date('2026-08-10T00:00:30.000Z'), 60_000),
+		).toBeNull();
+		expect(
+			await repository.claimJob(58n, 'worker-batch', 'lease-b', new Date('2026-08-10T00:01:01.000Z'), 60_000),
+		).toMatchObject({status: 'running', lease_token: 'lease-b'});
+
+		expect(await repository.markSucceeded(58n, null, 'lease-a')).toBe(false);
+		await repository.reportProgress(58n, 1, 2, 'stale', 'lease-a');
+		expect(await repository.getJob(58n)).toMatchObject({progress_current: null, progress_message: null});
+		await repository.reportProgress(58n, 1, 2, 'current', 'lease-b');
+		expect(await repository.getJob(58n)).toMatchObject({progress_current: 1n, progress_message: 'current'});
+		expect(await repository.markSucceeded(58n, null, 'lease-b')).toBe(true);
+		expect(await repository.getJob(58n)).toMatchObject({
+			status: 'succeeded',
+			lease_token: null,
+			lease_expires_at: null,
+		});
+	});
+
+	it('fails an abandoned running lease only after both its lease and queue recovery window expire', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(59n, null);
+		await repository.claimJob(59n, 'worker-batch', 'abandoned', new Date(), 60_000);
+
+		vi.setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
+		const result = await repository.reconcileActiveJobs({
+			now: new Date(),
+			staleBefore: new Date('2026-08-02T00:00:00.000Z'),
+			limit: 500,
+		});
+
+		expect(result.failedExpiredRunning).toBe(1);
+		expect(await repository.getJob(59n)).toMatchObject({status: 'failed'});
+	});
+
+	it('preserves a newly pending scheduled job for a full recovery window after it runs', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+		await createQueuedJob(62n, new Date('2026-02-01T00:00:00.000Z'));
+		const claimNow = new Date('2026-02-01T00:00:00.000Z');
+		vi.setSystemTime(claimNow);
+		const leaseToken = 'scheduled-lease';
+		expect(
+			await repository.claimJob(62n, 'worker-batch', leaseToken, claimNow, seconds('1 day') * 1000),
+		).not.toBeNull();
+		expect(await repository.markDeadletterPending(62n, 'publish later', leaseToken)).not.toBeNull();
+
+		const result = await repository.reconcileActiveJobs({
+			now: new Date('2026-02-01T00:01:00.000Z'),
+			staleBefore: new Date('2026-01-24T00:01:00.000Z'),
+			limit: 500,
+		});
+
+		expect(result.failedExpiredDeadletter).toBe(0);
+		expect(await repository.getJob(62n)).toMatchObject({status: 'deadletter_pending'});
+	});
+
+	it('fails a scheduled queued job only after the recovery window measured from its due time', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+		await createQueuedJob(75n, new Date('2026-02-01T00:00:00.000Z'));
+		vi.setSystemTime(new Date('2026-02-10T00:00:00.000Z'));
+
+		const result = await repository.reconcileActiveJobs({
+			now: new Date(),
+			staleBefore: new Date('2026-02-02T00:00:00.000Z'),
+			limit: 500,
+		});
+
+		expect(result.failedStaleQueued).toBe(1);
+		expect((await repository.getJob(75n))?.status).toBe('failed');
+	});
+
+	it('does not terminalize a queued retry released after stale reconciliation observation', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(83n, null);
+		vi.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
+		executor.beforeConditional = async () => {
+			executor.beforeConditional = null;
+			expect(await repository.claimJob(83n, 'worker-batch', 'retry-owner', new Date(), 60_000)).not.toBeNull();
+			expect(await repository.releaseForRetry(83n, 'retry', true, 'retry-owner')).toBe(true);
+		};
+
+		const result = await repository.reconcileActiveJobs({
+			now: new Date(),
+			staleBefore: new Date('2026-08-12T00:00:00.000Z'),
+			limit: 100,
+		});
+
+		expect(result.failedStaleQueued).toBe(0);
+		expect(result.skippedStateChanged).toBe(1);
+		expect(await repository.getJob(83n)).toMatchObject({status: 'queued', attempts: 1});
+	});
+
+	it('ages a scheduled retry from its latest queued transition after the original due time', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(77n, new Date('2026-08-02T00:00:00.000Z'));
+		vi.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
+		const claimed = await repository.claimJob(77n, 'worker-batch', 'retry-lease', new Date(), 60_000);
+		expect(claimed).not.toBeNull();
+		expect(await repository.releaseForRetry(77n, 'temporary failure', true, 'retry-lease')).toBe(true);
+
+		const result = await repository.reconcileActiveJobs({
+			now: new Date(),
+			staleBefore: new Date('2026-08-12T00:00:00.000Z'),
+			limit: 100,
+		});
+
+		expect(result.failedStaleQueued).toBe(0);
+		expect((await repository.getJob(77n))?.status).toBe('queued');
+	});
+
+	it('does not fail dead-letter work claimed for publication after stale reconciliation observation', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(84n, null);
+		expect(await repository.claimJob(84n, 'worker-batch', 'task-owner', new Date(), 60_000)).not.toBeNull();
+		expect(await repository.markDeadletterPending(84n, 'publish me', 'task-owner', new Date(), 1000)).not.toBeNull();
+		vi.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
+		executor.beforeConditional = async () => {
+			executor.beforeConditional = null;
+			expect(await repository.markDeadletterPending(84n, 'durable error', null, new Date(), 60_000)).not.toBeNull();
+		};
+
+		const result = await repository.reconcileActiveJobs({
+			now: new Date(),
+			staleBefore: new Date('2026-08-12T00:00:00.000Z'),
+			limit: 100,
+		});
+
+		expect(result.failedExpiredDeadletter).toBe(0);
+		expect(result.skippedStateChanged).toBe(1);
+		expect(await repository.getJob(84n)).toMatchObject({status: 'deadletter_pending'});
+	});
+
+	it('fails dead-letter-pending work only after the source stream recovery window expires', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(60n, null);
+		await repository.claimJob(60n, 'worker-batch', 'owner', new Date(), 60_000);
+		await repository.markDeadletterPending(60n, 'permanent', 'owner');
+
+		vi.setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
+		const result = await repository.reconcileActiveJobs({
+			now: new Date(),
+			staleBefore: new Date('2026-08-02T00:00:00.000Z'),
+			limit: 500,
+		});
+
+		expect(result.failedExpiredDeadletter).toBe(1);
+		expect(await repository.getJob(60n)).toMatchObject({status: 'failed'});
+	});
+
+	it('preserves an old scheduled job when its run time becomes due', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		await createQueuedJob(51n, new Date('2026-08-10T00:00:00.000Z'));
+		vi.setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
+
+		const result = await repository.reconcileActiveJobs({
+			limit: 100,
+			now: new Date(),
+			staleBefore: new Date('2026-08-02T00:00:00.000Z'),
+		});
+
+		expect(result.failedStaleQueued).toBe(0);
+		expect((await repository.getJob(51n))?.status).toBe('queued');
+	});
+
+	it('does not regress or resurrect terminal jobs through late worker mutations', async () => {
+		await createQueuedJob(52n, null);
+		await claimRunning(52n, 'worker-batch');
+		await repository.markSucceeded(52n, {ok: true}, leaseTokenFor(52n));
+
+		await claimRunning(52n, 'late-worker');
+		await repository.reportProgress(52n, 1, 2, 'late progress', leaseTokenFor(52n));
+		await repository.setContextLink(52n, '/late', leaseTokenFor(52n));
+		await repository.requestCancel(52n);
+		expect(await repository.releaseForRetry(52n, 'late retry', true, leaseTokenFor(52n))).toBe(false);
+
+		const job = await repository.getJob(52n);
+		expect(job).toMatchObject({
+			status: 'succeeded',
+			attempts: 0,
+			cancel_requested: false,
+			context_link: null,
+			progress_current: null,
+			jet_stream_lane: 'worker-batch',
+		});
+		expect((await repository.listActiveJobs({limit: 200, pageState: null})).jobs).toEqual([]);
+	});
+
+	it('removes orphaned and terminal active-index rows', async () => {
+		const createdAt = new Date('2026-08-01T00:00:00.000Z');
+		vi.useFakeTimers();
+		vi.setSystemTime(createdAt);
+		await createQueuedJob(48n, null);
+		expect(await claimRunning(48n, 'worker-batch')).toBe(true);
+		await repository.markSucceeded(48n, null, leaseTokenFor(48n));
+		await upsertOne(
+			JobsActive.upsertAll({
+				shard: 48,
+				job_id: 48n,
+				created_at: createdAt,
+				task_type: 'flushUserActivityBuffer',
+				status: 'succeeded',
+				requested_by_user_id: null,
+				started_at: null,
+			}),
+		);
+		await createQueuedJob(99n, null);
+		await executor.executeQuery(JobsById.deleteByPk({job_id: 99n}));
+		expect((await repository.listActiveJobs({limit: 200, pageState: null})).jobs).toEqual([]);
+
+		const result = await repository.reconcileActiveJobs({
+			limit: 100,
+			now: new Date('2026-08-10T00:00:00.000Z'),
+			staleBefore: new Date('2026-08-02T00:00:00.000Z'),
+		});
+
+		expect(result).toMatchObject({removedMissing: 1, removedTerminal: 1});
+		expect((await repository.listActiveJobs({limit: 200, pageState: null})).jobs).toEqual([]);
+		expect(await fetchBucket(99n, createdAt)).toBeNull();
+	});
+
+	it('rotates bounded reconciliation batches past preserved rows', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('1969-01-01T00:00:00.000Z'));
+		for (let index = 0; index < 500; index += 1) {
+			await createQueuedJob(BigInt(64_000 + index * 64), new Date('1971-01-01T00:00:00.000Z'));
+		}
+		await createQueuedJob(1n, null);
+
+		const first = await repository.reconcileActiveJobs({
+			limit: 500,
+			now: new Date('1970-01-01T00:00:00.000Z'),
+			staleBefore: new Date('1969-12-31T00:00:00.000Z'),
+		});
+		expect(first.failedStaleQueued).toBe(0);
+		expect((await repository.getJob(1n))?.status).toBe('queued');
+
+		const second = await repository.reconcileActiveJobs({
+			limit: 500,
+			now: new Date('1970-01-01T01:00:00.000Z'),
+			staleBefore: new Date('1969-12-31T00:00:00.000Z'),
+		});
+
+		expect(second.failedStaleQueued).toBe(1);
+		expect((await repository.getJob(1n))?.status).toBe('failed');
+	});
+
+	it('rotates fairly across shuffled active-row insertion order', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+		for (const jobId of [66n, 64n, 65n]) await createQueuedJob(jobId, null);
+
+		for (let pass = 0; pass < 6; pass += 1) {
+			await repository.reconcileActiveJobs({
+				limit: 1,
+				now: new Date('2026-08-20T00:00:00.000Z'),
+				staleBefore: new Date('2026-08-12T00:00:00.000Z'),
+			});
+		}
+
+		for (const jobId of [64n, 65n, 66n]) expect((await repository.getJob(jobId))?.status).toBe('failed');
+	});
+
+	it('repairs a terminal day bucket using only the authoritative remaining retention', async () => {
+		vi.useFakeTimers();
+		const completedAt = new Date('2026-08-01T00:00:00.000Z');
+		vi.setSystemTime(completedAt);
+		await createQueuedJob(53n, null);
+		expect(await claimRunning(53n, 'worker-batch')).toBe(true);
+		await repository.markSucceeded(53n, null, leaseTokenFor(53n));
+		await upsertOne(
+			JobsActive.upsertAll({
+				shard: 53,
+				job_id: 53n,
+				created_at: completedAt,
+				task_type: 'flushUserActivityBuffer',
+				status: 'succeeded',
+				requested_by_user_id: null,
+				started_at: completedAt,
+			}),
+		);
+		executor.queries.length = 0;
+
+		await repository.reconcileActiveJobs({
+			limit: 100,
+			now: new Date('2026-08-04T00:00:00.000Z'),
+			staleBefore: new Date('2026-08-02T00:00:00.000Z'),
+		});
+
+		const bucketRepair = executor.queries.find(
+			(query) => query.kvMeta?.table.name === 'jobs_by_day_bucket' && query.kvMeta.ttlParamName,
+		);
+		expect(bucketRepair).toBeDefined();
+		const ttlParamName = bucketRepair?.kvMeta?.ttlParamName as string;
+		expect((bucketRepair?.params as CassandraParams)[ttlParamName]).toBe(seconds('4 days'));
+	});
+});
+
+async function createQueuedJob(jobId: bigint, runAt: Date | null): Promise<void> {
+	await repository.createJob({
+		auditLogReason: null,
+		jetStreamLane: 'maintenance',
+		jetStreamSeq: null,
+		jobId,
+		maxAttempts: 5,
+		payload: {},
+		requestedByUserId: null,
+		runAt,
+		taskType: 'flushUserActivityBuffer',
+	});
+}
+
+async function collectAllActiveJobs(limit = 200): Promise<Array<JobByIdRow>> {
+	const jobs: Array<JobByIdRow> = [];
+	let pageState: string | null = null;
+	for (let page = 0; page < 65; page += 1) {
+		const result = await repository.listActiveJobs({limit, pageState});
+		expect(result.jobs.length).toBeLessThanOrEqual(limit);
+		jobs.push(...result.jobs);
+		pageState = result.nextPageState;
+		if (pageState === null) return jobs;
+	}
+	throw new Error('active-job pagination did not terminate');
+}

--- a/fluxer_api/src/api/jobs/JobLedgerRepository.ts
+++ b/fluxer_api/src/api/jobs/JobLedgerRepository.ts
@@ -1,15 +1,37 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import {BatchBuilder, deleteOneOrMany, fetchMany, fetchOne, upsertOne} from '../database/CassandraQueryExecution';
-import {Db} from '../database/CassandraTypes';
-import type {JobActiveRow, JobByDayBucketRow, JobByIdRow, JobStatus} from '../database/types/JobLedgerTypes';
-import {JobsActive, JobsByDayBucket, JobsById} from '../Tables';
+import {randomUUID} from 'node:crypto';
+import {seconds} from 'itty-time';
+import {
+	BatchBuilder,
+	deleteOneOrMany,
+	executeQuery,
+	fetchMany,
+	fetchOne,
+	fetchPage,
+	upsertOne,
+} from '../database/CassandraQueryExecution';
+import {type CassandraParams, Db} from '../database/CassandraTypes';
+import type {
+	JobActiveRow,
+	JobActiveV2Row,
+	JobByDayBucketRow,
+	JobByIdRow,
+	JobStatus,
+} from '../database/types/JobLedgerTypes';
+import {Logger} from '../Logger';
+import {JobsActive, JobsActiveLegacy, JobsByDayBucket, JobsById} from '../Tables';
 import {
 	type CreateJobInput,
+	type DeadletterPublicationLease,
 	IJobLedgerRepository,
+	type ListActiveJobsInput,
+	type ListActiveJobsResult,
 	type ListJobsCursor,
 	type ListJobsFilters,
 	type ListJobsResult,
+	type ReconcileActiveJobsInput,
+	type ReconcileActiveJobsResult,
 } from './IJobLedgerRepository';
 
 const FETCH_JOB_BY_ID_QUERY = JobsById.select({
@@ -18,13 +40,96 @@ const FETCH_JOB_BY_ID_QUERY = JobsById.select({
 const FETCH_CANCEL_REQUESTED_QUERY = JobsById.select({
 	where: JobsById.where.eq('job_id'),
 });
-const ACTIVE_JOBS_QUERY = JobsActive.select();
+const ACTIVE_JOBS_SHARD_COUNT = 64;
+const ACTIVE_AUTHORITY_HYDRATION_LIMIT = 200;
+
+export const JOB_HISTORY_RETENTION_SECONDS = seconds('7 days');
+const TERMINAL_JOB_STATUSES = new Set<JobStatus>(['succeeded', 'failed', 'cancelled', 'deadletter']);
+type JobByIdPatch = Parameters<typeof JobsById.patchByPk>[1];
+type JobByIdCondition = Parameters<typeof JobsById.patchByPkIf>[2];
 
 function bucketDayFor(d: Date): string {
 	return d.toISOString().slice(0, 10);
 }
 
 export class JobLedgerRepository extends IJobLedgerRepository {
+	private activeReconcileShard = 0;
+	private activeReconcileCursor: bigint | null = null;
+	private legacyMigrationPageState: string | null = null;
+
+	private activePk(jobId: bigint): {shard: number; job_id: bigint} {
+		return {shard: this.activeShard(jobId), job_id: jobId};
+	}
+
+	private activeShard(jobId: bigint): number {
+		const positive = jobId < 0n ? -jobId : jobId;
+		return Number(positive % BigInt(ACTIVE_JOBS_SHARD_COUNT));
+	}
+
+	private legacyActiveRow(row: JobActiveV2Row): JobActiveRow {
+		const {shard: _shard, ...legacy} = row;
+		return legacy;
+	}
+
+	private async upsertActive(row: JobActiveV2Row): Promise<void> {
+		await Promise.all([
+			upsertOne(JobsActive.upsertAll(row)),
+			upsertOne(JobsActiveLegacy.upsertAll(this.legacyActiveRow(row))),
+		]);
+	}
+
+	private async deleteActive(jobId: bigint): Promise<void> {
+		await Promise.all([
+			deleteOneOrMany(JobsActive.deleteByPk(this.activePk(jobId))),
+			deleteOneOrMany(JobsActiveLegacy.deleteByPk({job_id: jobId})),
+		]);
+	}
+
+	private async migrateLegacyActivePage(limit: number): Promise<void> {
+		if (limit <= 0) return;
+		const page = await fetchPage<JobActiveRow>(JobsActiveLegacy.select().bind({}), undefined, {
+			pageSize: limit,
+			pageState: this.legacyMigrationPageState,
+		});
+		this.legacyMigrationPageState = page.pageState;
+		for (const legacy of page.rows) {
+			await upsertOne(
+				JobsActive.upsertAll({
+					shard: this.activeShard(legacy.job_id),
+					...legacy,
+				}),
+			);
+		}
+	}
+
+	private async fetchActiveReconciliationPage(limit: number): Promise<Array<JobActiveV2Row>> {
+		if (limit <= 0) return [];
+		await this.migrateLegacyActivePage(limit);
+		const rows: Array<JobActiveV2Row> = [];
+		let shardsVisited = 0;
+		while (rows.length < limit && shardsVisited < ACTIVE_JOBS_SHARD_COUNT) {
+			const remaining = limit - rows.length;
+			const where =
+				this.activeReconcileCursor === null
+					? JobsActive.where.eq('shard')
+					: [JobsActive.where.eq('shard'), JobsActive.where.gt('job_id', 'last_job_id')];
+			const query = JobsActive.select({where, orderBy: {col: 'job_id', direction: 'ASC'}, limit: remaining + 1});
+			const params: CassandraParams = {shard: this.activeReconcileShard};
+			if (this.activeReconcileCursor !== null) params['last_job_id'] = this.activeReconcileCursor;
+			const scanned = await fetchMany<JobActiveV2Row>(query.bind(params));
+			const accepted = scanned.slice(0, remaining);
+			rows.push(...accepted);
+			if (scanned.length > remaining) {
+				this.activeReconcileCursor = accepted.at(-1)?.job_id ?? this.activeReconcileCursor;
+				break;
+			}
+			this.activeReconcileCursor = null;
+			this.activeReconcileShard = (this.activeReconcileShard + 1) % ACTIVE_JOBS_SHARD_COUNT;
+			shardsVisited += 1;
+		}
+		return rows;
+	}
+
 	async createJob(input: CreateJobInput): Promise<void> {
 		const now = new Date();
 		const status: JobStatus = 'queued';
@@ -39,12 +144,16 @@ export class JobLedgerRepository extends IJobLedgerRepository {
 			result: null,
 			error_message: null,
 			created_at: now,
+			state_changed_at: now,
 			started_at: null,
 			completed_at: null,
 			requested_by_user_id: input.requestedByUserId,
 			audit_log_reason: input.auditLogReason,
 			jet_stream_seq: input.jetStreamSeq,
 			jet_stream_lane: input.jetStreamLane,
+			lease_token: null,
+			lease_expires_at: null,
+			dlq_attempts: 0,
 			attempts: 0,
 			max_attempts: input.maxAttempts,
 			run_at: input.runAt,
@@ -59,7 +168,8 @@ export class JobLedgerRepository extends IJobLedgerRepository {
 			status,
 			requested_by_user_id: input.requestedByUserId,
 		};
-		const activeRow: JobActiveRow = {
+		const activeRow: JobActiveV2Row = {
+			shard: this.activeShard(input.jobId),
 			job_id: input.jobId,
 			task_type: input.taskType,
 			status,
@@ -71,6 +181,7 @@ export class JobLedgerRepository extends IJobLedgerRepository {
 		batch.addPrepared(JobsById.insert(idRow));
 		batch.addPrepared(JobsByDayBucket.insert(bucketRow));
 		batch.addPrepared(JobsActive.insert(activeRow));
+		batch.addPrepared(JobsActiveLegacy.insert(this.legacyActiveRow(activeRow)));
 		await batch.executeChunked(10, true);
 	}
 
@@ -78,84 +189,483 @@ export class JobLedgerRepository extends IJobLedgerRepository {
 		return fetchOne<JobByIdRow>(FETCH_JOB_BY_ID_QUERY.bind({job_id: jobId}));
 	}
 
-	async markRunning(jobId: bigint, lane: string): Promise<void> {
-		const startedAt = new Date();
-		const status: JobStatus = 'running';
-		await upsertOne(
-			JobsById.patchByPk(
-				{job_id: jobId},
-				{status: Db.set(status), started_at: Db.set(startedAt), jet_stream_lane: Db.set(lane)},
-			),
-		);
-		await upsertOne(JobsActive.patchByPk({job_id: jobId}, {status: Db.set(status), started_at: Db.set(startedAt)}));
+	private async wasApplied(query: ReturnType<typeof JobsById.patchByPkIf>): Promise<boolean> {
+		const [result] = await executeQuery<{'[applied]': boolean}>(query);
+		return result?.['[applied]'] === true;
 	}
 
-	async markSucceeded(jobId: bigint, result: Record<string, unknown> | null): Promise<void> {
-		const completedAt = new Date();
-		const status: JobStatus = 'succeeded';
+	private ownedCondition(leaseToken: string): JobByIdCondition {
+		return {col: 'lease_token', expected: leaseToken};
+	}
+
+	private async writeNonTerminalBucket(job: JobByIdRow): Promise<void> {
 		await upsertOne(
-			JobsById.patchByPk(
+			JobsByDayBucket.upsertAll({
+				bucket_day: bucketDayFor(job.created_at),
+				created_at: job.created_at,
+				job_id: job.job_id,
+				task_type: job.task_type,
+				status: job.status,
+				requested_by_user_id: job.requested_by_user_id,
+			}),
+		);
+	}
+
+	private async synchronizeActiveFromAuthoritative(jobId: bigint): Promise<void> {
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			const current = await this.getJob(jobId);
+			if (!current) {
+				await this.deleteActive(jobId);
+				return;
+			}
+			if (TERMINAL_JOB_STATUSES.has(current.status)) {
+				await this.finalizeTerminalIndexes(current);
+				return;
+			}
+			await this.writeNonTerminalBucket(current);
+			await this.upsertActive({
+				shard: this.activeShard(current.job_id),
+				job_id: current.job_id,
+				task_type: current.task_type,
+				status: current.status,
+				requested_by_user_id: current.requested_by_user_id,
+				created_at: current.created_at,
+				started_at: current.started_at,
+			});
+			const verified = await this.getJob(jobId);
+			if (!verified) {
+				await this.deleteActive(jobId);
+				return;
+			}
+			if (TERMINAL_JOB_STATUSES.has(verified.status)) {
+				await this.finalizeTerminalIndexes(verified);
+				return;
+			}
+			if (verified.status === current.status && verified.started_at?.getTime() === current.started_at?.getTime()) {
+				return;
+			}
+		}
+	}
+
+	private async patchNonTerminal(
+		jobId: bigint,
+		buildPatch: (current: JobByIdRow) => JobByIdPatch,
+		leaseToken: string | null = null,
+	): Promise<boolean> {
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			const current = await this.getJob(jobId);
+			if (!current || TERMINAL_JOB_STATUSES.has(current.status)) return false;
+			if (leaseToken !== null && current.lease_token !== leaseToken) return false;
+			const applied = await this.wasApplied(
+				JobsById.patchByPkIf(
+					{job_id: jobId},
+					buildPatch(current),
+					leaseToken !== null ? this.ownedCondition(leaseToken) : {col: 'status', expected: current.status},
+				),
+			);
+			if (applied) return true;
+		}
+		return false;
+	}
+
+	async claimJob(
+		jobId: bigint,
+		lane: string,
+		leaseToken: string,
+		now: Date,
+		leaseDurationMs: number,
+	): Promise<JobByIdRow | null> {
+		const current = await this.getJob(jobId);
+		if (!current) return null;
+		const leaseExpiresAt = new Date(now.getTime() + leaseDurationMs);
+		let condition: JobByIdCondition;
+		if (current.status === 'queued') {
+			condition = {col: 'status', expected: 'queued'};
+		} else if (
+			current.status === 'running' &&
+			typeof current.lease_token === 'string' &&
+			current.lease_expires_at instanceof Date &&
+			current.lease_expires_at.getTime() <= now.getTime()
+		) {
+			condition = [
+				{col: 'lease_token', expected: current.lease_token},
+				{col: 'lease_expires_at', expected: current.lease_expires_at},
+			];
+		} else if (
+			current.status === 'running' &&
+			current.lease_token == null &&
+			current.lease_expires_at == null &&
+			(current.state_changed_at ?? current.started_at ?? current.created_at).getTime() + leaseDurationMs <=
+				now.getTime()
+		) {
+			condition = [
+				{col: 'status', expected: 'running'},
+				{col: 'lease_token', expected: null},
+				{col: 'lease_expires_at', expected: null},
+			];
+		} else {
+			return null;
+		}
+		const applied = await this.wasApplied(
+			JobsById.patchByPkIf(
+				{job_id: jobId},
+				{
+					status: Db.set('running'),
+					state_changed_at: Db.set(now),
+					started_at: Db.set(current.started_at ?? now),
+					jet_stream_lane: Db.set(lane),
+					lease_token: Db.set(leaseToken),
+					lease_expires_at: Db.set(leaseExpiresAt),
+				},
+				condition,
+			),
+		);
+		if (!applied) return null;
+		await this.synchronizeActiveFromAuthoritative(jobId);
+		const claimed = await this.getJob(jobId);
+		return claimed?.lease_token === leaseToken ? claimed : null;
+	}
+
+	async renewLease(jobId: bigint, leaseToken: string, now: Date, leaseDurationMs: number): Promise<boolean> {
+		return this.extendLeaseIfLater(jobId, leaseToken, new Date(now.getTime() + leaseDurationMs), 'running');
+	}
+
+	private async extendLeaseIfLater(
+		jobId: bigint,
+		leaseToken: string,
+		candidateExpiry: Date,
+		expectedStatus: Extract<JobStatus, 'running' | 'deadletter_pending'>,
+	): Promise<boolean> {
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			const current = await this.getJob(jobId);
+			if (!current || current.status !== expectedStatus || current.lease_token !== leaseToken) return false;
+			if (current.lease_expires_at && current.lease_expires_at.getTime() >= candidateExpiry.getTime()) return true;
+			const applied = await this.wasApplied(
+				JobsById.patchByPkIf({job_id: jobId}, {lease_expires_at: Db.set(candidateExpiry)}, [
+					{col: 'status', expected: expectedStatus},
+					{col: 'lease_token', expected: leaseToken},
+					{col: 'lease_expires_at', expected: current.lease_expires_at},
+				]),
+			);
+			if (applied) return true;
+		}
+		return false;
+	}
+
+	async releaseForRetry(
+		jobId: bigint,
+		errorMessage: string,
+		incrementAttempt: boolean,
+		leaseToken: string,
+	): Promise<boolean> {
+		const current = await this.getJob(jobId);
+		if (!current || current.status !== 'running' || current.lease_token !== leaseToken) return false;
+		const status: JobStatus = 'queued';
+		const applied = await this.wasApplied(
+			JobsById.patchByPkIf(
 				{job_id: jobId},
 				{
 					status: Db.set(status),
-					completed_at: Db.set(completedAt),
-					result: result === null ? Db.clear() : Db.set(JSON.stringify(result)),
+					state_changed_at: Db.set(new Date()),
+					started_at: Db.clear(),
+					lease_token: Db.clear(),
+					lease_expires_at: Db.clear(),
+					error_message: Db.set(errorMessage),
+					attempts: Db.set(current.attempts + (incrementAttempt ? 1 : 0)),
 				},
+				this.ownedCondition(leaseToken),
 			),
 		);
-		await deleteOneOrMany(JobsActive.deleteByPk({job_id: jobId}));
+		if (!applied) {
+			const latest = await this.getJob(jobId);
+			if (!latest || TERMINAL_JOB_STATUSES.has(latest.status)) {
+				await this.deleteActive(jobId);
+			}
+			return false;
+		}
+		await this.upsertActive({
+			shard: this.activeShard(current.job_id),
+			job_id: current.job_id,
+			task_type: current.task_type,
+			status,
+			requested_by_user_id: current.requested_by_user_id,
+			created_at: current.created_at,
+			started_at: null,
+		});
+		await this.synchronizeActiveFromAuthoritative(jobId);
+		return true;
 	}
 
-	async markFailed(jobId: bigint, errorMessage: string): Promise<void> {
+	async markEnqueueFailed(jobId: bigint, errorMessage: string): Promise<boolean> {
+		return this.markTerminal(jobId, 'failed', {result: null, errorMessage}, 'queued');
+	}
+
+	async markSucceeded(jobId: bigint, result: Record<string, unknown> | null, leaseToken: string): Promise<boolean> {
+		return this.markTerminal(
+			jobId,
+			'succeeded',
+			{
+				result: result === null ? null : JSON.stringify(result),
+				errorMessage: null,
+			},
+			'running',
+			leaseToken,
+		);
+	}
+
+	async markFailed(jobId: bigint, errorMessage: string, leaseToken: string | null = null): Promise<boolean> {
+		return this.markTerminal(jobId, 'failed', {result: null, errorMessage}, undefined, leaseToken);
+	}
+
+	private async markFailedIfObserved(job: JobByIdRow, errorMessage: string): Promise<boolean> {
+		return this.markTerminal(job.job_id, 'failed', {result: null, errorMessage}, undefined, null, [
+			{col: 'status', expected: job.status},
+			{col: 'state_changed_at', expected: job.state_changed_at},
+			{col: 'lease_token', expected: job.lease_token},
+			{col: 'lease_expires_at', expected: job.lease_expires_at},
+			{col: 'attempts', expected: job.attempts},
+		]);
+	}
+
+	async markCancelled(jobId: bigint, leaseToken: string): Promise<boolean> {
+		return this.markTerminal(jobId, 'cancelled', {result: null, errorMessage: null}, 'running', leaseToken);
+	}
+
+	async markDeadletterPending(
+		jobId: bigint,
+		errorMessage: string,
+		leaseToken: string | null = null,
+		now = new Date(),
+		leaseDurationMs = 60_000,
+	): Promise<DeadletterPublicationLease | null> {
+		const publicationToken = `deadletter:${randomUUID()}`;
+		const leaseExpiresAt = new Date(now.getTime() + leaseDurationMs);
+		if (leaseToken !== null) {
+			const applied = await this.wasApplied(
+				JobsById.patchByPkIf(
+					{job_id: jobId},
+					{
+						status: Db.set('deadletter_pending'),
+						state_changed_at: Db.set(now),
+						error_message: Db.set(errorMessage),
+						lease_token: Db.set(publicationToken),
+						lease_expires_at: Db.set(leaseExpiresAt),
+						dlq_attempts: Db.set(0),
+					},
+					this.ownedCondition(leaseToken),
+				),
+			);
+			if (!applied) return null;
+			await this.synchronizeActiveFromAuthoritative(jobId);
+			return {leaseToken: publicationToken, errorMessage};
+		}
+
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			const current = await this.getJob(jobId);
+			if (current?.status !== 'deadletter_pending') return null;
+			if (current.lease_expires_at && current.lease_expires_at.getTime() > now.getTime()) return null;
+			const applied = await this.wasApplied(
+				JobsById.patchByPkIf(
+					{job_id: jobId},
+					{
+						state_changed_at: Db.set(now),
+						lease_token: Db.set(publicationToken),
+						lease_expires_at: Db.set(leaseExpiresAt),
+					},
+					[
+						{col: 'status', expected: current.status},
+						{col: 'state_changed_at', expected: current.state_changed_at},
+						{col: 'lease_token', expected: current.lease_token},
+						{col: 'lease_expires_at', expected: current.lease_expires_at},
+					],
+				),
+			);
+			if (applied) {
+				await this.synchronizeActiveFromAuthoritative(jobId);
+				return {leaseToken: publicationToken, errorMessage: current.error_message ?? errorMessage};
+			}
+		}
+		return null;
+	}
+
+	async renewDeadletterPublicationLease(
+		jobId: bigint,
+		leaseToken: string,
+		now: Date,
+		leaseDurationMs: number,
+	): Promise<boolean> {
+		return this.extendLeaseIfLater(jobId, leaseToken, new Date(now.getTime() + leaseDurationMs), 'deadletter_pending');
+	}
+
+	async recordDlqPublishFailure(jobId: bigint, leaseToken: string): Promise<number | null> {
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			const current = await this.getJob(jobId);
+			if (current?.status !== 'deadletter_pending' || current.lease_token !== leaseToken) return null;
+			const nextAttempts = (current.dlq_attempts ?? 0) + 1;
+			const applied = await this.wasApplied(
+				JobsById.patchByPkIf(
+					{job_id: jobId},
+					{
+						dlq_attempts: Db.set(nextAttempts),
+						lease_token: Db.set(`deadletter:released:${randomUUID()}`),
+						lease_expires_at: Db.clear(),
+					},
+					[
+						{col: 'status', expected: 'deadletter_pending'},
+						{col: 'lease_token', expected: leaseToken},
+					],
+				),
+			);
+			if (applied) return nextAttempts;
+		}
+		return null;
+	}
+
+	async markDeadletter(jobId: bigint, errorMessage: string, leaseToken: string): Promise<boolean> {
+		return this.markTerminal(jobId, 'deadletter', {result: null, errorMessage}, 'deadletter_pending', leaseToken);
+	}
+
+	private terminalHistoryTtl(job: JobByIdRow, now = new Date()): number {
+		if (!job.completed_at) return JOB_HISTORY_RETENTION_SECONDS;
+		const deadlineMs = job.completed_at.getTime() + JOB_HISTORY_RETENTION_SECONDS * 1000;
+		return Math.max(0, Math.ceil((deadlineMs - now.getTime()) / 1000));
+	}
+
+	private async writeTerminalBucket(job: JobByIdRow, now = new Date()): Promise<void> {
+		const bucketRow: JobByDayBucketRow = {
+			bucket_day: bucketDayFor(job.created_at),
+			created_at: job.created_at,
+			job_id: job.job_id,
+			task_type: job.task_type,
+			status: job.status,
+			requested_by_user_id: job.requested_by_user_id,
+		};
+		const ttl = this.terminalHistoryTtl(job, now);
+		if (ttl > 0) {
+			await upsertOne(JobsByDayBucket.upsertAllWithTtl(bucketRow, ttl));
+		} else {
+			await deleteOneOrMany(
+				JobsByDayBucket.deleteByPk({
+					bucket_day: bucketRow.bucket_day,
+					created_at: bucketRow.created_at,
+					job_id: bucketRow.job_id,
+				}),
+			);
+		}
+	}
+
+	private async finalizeTerminalIndexes(job: JobByIdRow, now = new Date()): Promise<void> {
+		await this.writeTerminalBucket(job, now);
+		await this.deleteActive(job.job_id);
+	}
+
+	private async markTerminal(
+		jobId: bigint,
+		status: Extract<JobStatus, 'succeeded' | 'failed' | 'cancelled' | 'deadletter'>,
+		outcome: {result: string | null; errorMessage: string | null},
+		expectedStatus?: JobStatus,
+		leaseToken: string | null = null,
+		conditionOverride?: JobByIdCondition,
+	): Promise<boolean> {
+		const current = await this.getJob(jobId);
+		if (!current) return false;
+		if (TERMINAL_JOB_STATUSES.has(current.status)) {
+			await this.finalizeTerminalIndexes(current);
+			return current.status === status;
+		}
+		if (expectedStatus && current.status !== expectedStatus) return false;
+		if (leaseToken !== null && current.lease_token !== leaseToken) return false;
 		const completedAt = new Date();
-		const status: JobStatus = 'failed';
-		await upsertOne(
-			JobsById.patchByPk(
-				{job_id: jobId},
-				{status: Db.set(status), completed_at: Db.set(completedAt), error_message: Db.set(errorMessage)},
-			),
+		const updated: JobByIdRow = {
+			...current,
+			status,
+			state_changed_at: completedAt,
+			completed_at: completedAt,
+			result: outcome.result,
+			error_message: outcome.errorMessage,
+			lease_token: null,
+			lease_expires_at: null,
+			dlq_attempts: current.dlq_attempts ?? 0,
+		};
+		await this.writeTerminalBucket(updated, completedAt);
+		let applied: boolean;
+		try {
+			applied = await this.wasApplied(
+				JobsById.patchByPkWithTtlIf(
+					{job_id: jobId},
+					{
+						task_type: Db.set(updated.task_type),
+						status: Db.set(updated.status),
+						progress_current: Db.set(updated.progress_current),
+						progress_total: Db.set(updated.progress_total),
+						progress_message: Db.set(updated.progress_message),
+						payload: Db.set(updated.payload),
+						result: Db.set(updated.result),
+						error_message: Db.set(updated.error_message),
+						created_at: Db.set(updated.created_at),
+						state_changed_at: Db.set(updated.state_changed_at),
+						started_at: Db.set(updated.started_at),
+						completed_at: Db.set(updated.completed_at),
+						requested_by_user_id: Db.set(updated.requested_by_user_id),
+						audit_log_reason: Db.set(updated.audit_log_reason),
+						jet_stream_seq: Db.set(updated.jet_stream_seq),
+						jet_stream_lane: Db.set(updated.jet_stream_lane),
+						lease_token: Db.set(updated.lease_token),
+						lease_expires_at: Db.set(updated.lease_expires_at),
+						dlq_attempts: Db.set(updated.dlq_attempts),
+						attempts: Db.set(updated.attempts),
+						max_attempts: Db.set(updated.max_attempts),
+						run_at: Db.set(updated.run_at),
+						cancel_requested: Db.set(updated.cancel_requested),
+						context_link: Db.set(updated.context_link),
+					},
+					JOB_HISTORY_RETENTION_SECONDS,
+					conditionOverride ??
+						(leaseToken !== null
+							? {col: 'lease_token', expected: leaseToken}
+							: {col: 'status', expected: expectedStatus ?? current.status}),
+				),
+			);
+		} catch (error) {
+			try {
+				await this.synchronizeActiveFromAuthoritative(jobId);
+			} catch (repairError) {
+				Logger.error({jobId, err: repairError}, 'Failed to repair job indexes after terminal CAS error');
+			}
+			throw error;
+		}
+		if (!applied) {
+			await this.synchronizeActiveFromAuthoritative(jobId);
+			return false;
+		}
+		await this.deleteActive(updated.job_id);
+		return true;
+	}
+
+	async reportProgress(
+		jobId: bigint,
+		current: number,
+		total: number | null,
+		message: string | null,
+		leaseToken: string,
+	): Promise<void> {
+		await this.patchNonTerminal(
+			jobId,
+			() => ({
+				progress_current: Db.set(BigInt(current)),
+				progress_total: total === null ? Db.clear() : Db.set(BigInt(total)),
+				progress_message: message === null ? Db.clear() : Db.set(message),
+			}),
+			leaseToken,
 		);
-		await deleteOneOrMany(JobsActive.deleteByPk({job_id: jobId}));
 	}
 
-	async markCancelled(jobId: bigint): Promise<void> {
-		const completedAt = new Date();
-		const status: JobStatus = 'cancelled';
-		await upsertOne(JobsById.patchByPk({job_id: jobId}, {status: Db.set(status), completed_at: Db.set(completedAt)}));
-		await deleteOneOrMany(JobsActive.deleteByPk({job_id: jobId}));
+	async setContextLink(jobId: bigint, link: string, leaseToken: string): Promise<void> {
+		await this.patchNonTerminal(jobId, () => ({context_link: Db.set(link)}), leaseToken);
 	}
 
-	async markDeadletter(jobId: bigint, errorMessage: string): Promise<void> {
-		const completedAt = new Date();
-		const status: JobStatus = 'deadletter';
-		await upsertOne(
-			JobsById.patchByPk(
-				{job_id: jobId},
-				{status: Db.set(status), completed_at: Db.set(completedAt), error_message: Db.set(errorMessage)},
-			),
-		);
-		await deleteOneOrMany(JobsActive.deleteByPk({job_id: jobId}));
-	}
-
-	async reportProgress(jobId: bigint, current: number, total: number | null, message: string | null): Promise<void> {
-		await upsertOne(
-			JobsById.patchByPk(
-				{job_id: jobId},
-				{
-					progress_current: Db.set(BigInt(current)),
-					progress_total: total === null ? Db.clear() : Db.set(BigInt(total)),
-					progress_message: message === null ? Db.clear() : Db.set(message),
-				},
-			),
-		);
-	}
-
-	async setContextLink(jobId: bigint, link: string): Promise<void> {
-		await upsertOne(JobsById.patchByPk({job_id: jobId}, {context_link: Db.set(link)}));
-	}
-
-	async requestCancel(jobId: bigint): Promise<void> {
-		await upsertOne(JobsById.patchByPk({job_id: jobId}, {cancel_requested: Db.set(true)}));
+	async requestCancel(jobId: bigint): Promise<boolean> {
+		return this.patchNonTerminal(jobId, () => ({cancel_requested: Db.set(true)}));
 	}
 
 	async isCancelRequested(jobId: bigint): Promise<boolean> {
@@ -165,12 +675,6 @@ export class JobLedgerRepository extends IJobLedgerRepository {
 		return row?.cancel_requested === true;
 	}
 
-	async incrementAttempts(jobId: bigint): Promise<void> {
-		const row = await this.getJob(jobId);
-		if (!row) return;
-		await upsertOne(JobsById.patchByPk({job_id: jobId}, {attempts: Db.set(row.attempts + 1)}));
-	}
-
 	async listJobs(opts: {
 		limit: number;
 		cursor: ListJobsCursor | null;
@@ -178,59 +682,228 @@ export class JobLedgerRepository extends IJobLedgerRepository {
 		maxLookbackDays: number;
 	}): Promise<ListJobsResult> {
 		const {limit, cursor, filters, maxLookbackDays} = opts;
+		if (limit <= 0) return {jobs: [], nextCursor: null};
 		const startBucket = cursor ? new Date(`${cursor.bucketDay}T00:00:00Z`) : new Date();
 		const collected: Array<JobByIdRow> = [];
+		let lastReturnedCursor: ListJobsCursor | null = null;
 		let nextCursor: ListJobsCursor | null = null;
-		for (let dayOffset = 0; dayOffset <= maxLookbackDays && collected.length < limit; dayOffset++) {
+		const scanChunkSize = Math.max(25, Math.min(250, limit + 1));
+		const orderBy = [
+			{col: 'created_at' as const, direction: 'DESC' as const},
+			{col: 'job_id' as const, direction: 'DESC' as const},
+		];
+		for (let dayOffset = 0; dayOffset <= maxLookbackDays && nextCursor === null; dayOffset++) {
 			const bucketDate = new Date(startBucket);
 			bucketDate.setUTCDate(bucketDate.getUTCDate() - dayOffset);
 			const bucketDay = bucketDayFor(bucketDate);
-			const remaining = limit - collected.length + 1;
-			const useCursor = dayOffset === 0 && cursor !== null;
-			let bucketRows: Array<JobByDayBucketRow>;
-			if (useCursor && cursor) {
+			let scanCursor = dayOffset === 0 ? cursor : null;
+			while (nextCursor === null) {
 				const query = JobsByDayBucket.select({
-					where: [JobsByDayBucket.where.eq('bucket_day'), JobsByDayBucket.where.lt('created_at')],
-					limit: remaining,
+					where:
+						scanCursor === null
+							? JobsByDayBucket.where.eq('bucket_day')
+							: [
+									JobsByDayBucket.where.eq('bucket_day'),
+									JobsByDayBucket.where.tupleLt(['created_at', 'job_id'], ['cursor_created_at', 'cursor_job_id']),
+								],
+					orderBy,
+					limit: scanChunkSize,
 				});
-				bucketRows = await fetchMany<JobByDayBucketRow>(
-					query.bind({bucket_day: bucketDay, created_at: cursor.createdAt}),
-				);
-			} else {
-				const query = JobsByDayBucket.select({
-					where: JobsByDayBucket.where.eq('bucket_day'),
-					limit: remaining,
-				});
-				bucketRows = await fetchMany<JobByDayBucketRow>(query.bind({bucket_day: bucketDay}));
-			}
-			for (const r of bucketRows) {
-				if (filters.status && r.status !== filters.status) continue;
-				if (filters.taskType && r.task_type !== filters.taskType) continue;
-				if (filters.requestedByUserId !== undefined && filters.requestedByUserId !== null) {
-					if (r.requested_by_user_id !== filters.requestedByUserId) continue;
+				const params: CassandraParams = {bucket_day: bucketDay};
+				if (scanCursor !== null) {
+					params['cursor_created_at'] = scanCursor.createdAt;
+					params['cursor_job_id'] = scanCursor.jobId;
 				}
-				if (collected.length >= limit) {
-					nextCursor = {bucketDay, createdAt: r.created_at, jobId: r.job_id};
-					break;
+				const bucketRows = await fetchMany<JobByDayBucketRow>(query.bind(params));
+				for (const bucketRow of bucketRows) {
+					const fullRow = await this.getJob(bucketRow.job_id);
+					if (!fullRow) continue;
+					if (filters.status && fullRow.status !== filters.status) continue;
+					if (filters.taskType && fullRow.task_type !== filters.taskType) continue;
+					if (
+						filters.requestedByUserId !== undefined &&
+						filters.requestedByUserId !== null &&
+						fullRow.requested_by_user_id !== filters.requestedByUserId
+					) {
+						continue;
+					}
+					if (collected.length === limit) {
+						nextCursor = lastReturnedCursor;
+						break;
+					}
+					collected.push(fullRow);
+					lastReturnedCursor = {bucketDay, createdAt: bucketRow.created_at, jobId: bucketRow.job_id};
 				}
-				const fullRow = await this.getJob(r.job_id);
-				if (fullRow) collected.push(fullRow);
+				if (nextCursor !== null || bucketRows.length < scanChunkSize) break;
+				const lastScanned = bucketRows.at(-1) as JobByDayBucketRow;
+				scanCursor = {bucketDay, createdAt: lastScanned.created_at, jobId: lastScanned.job_id};
 			}
-			if (nextCursor) break;
 		}
 		return {jobs: collected, nextCursor};
 	}
 
-	async listActiveJobs(): Promise<Array<JobByIdRow>> {
-		const activeRows = await fetchMany<JobActiveRow>(ACTIVE_JOBS_QUERY.bind({}));
-		const fullRows = await Promise.all(activeRows.map((r) => this.getJob(r.job_id)));
-		return fullRows.filter((r): r is JobByIdRow => r !== null);
+	async reconcileActiveJobs(input: ReconcileActiveJobsInput): Promise<ReconcileActiveJobsResult> {
+		const result: ReconcileActiveJobsResult = {
+			scanned: 0,
+			removedMissing: 0,
+			removedTerminal: 0,
+			failedStaleQueued: 0,
+			failedExpiredRunning: 0,
+			failedExpiredDeadletter: 0,
+			skippedFresh: 0,
+			skippedScheduled: 0,
+			skippedRunning: 0,
+			skippedStateChanged: 0,
+		};
+		const activeRows = await this.fetchActiveReconciliationPage(Math.max(0, input.limit));
+		for (const active of activeRows) {
+			result.scanned += 1;
+			const job = await this.getJob(active.job_id);
+			if (!job) {
+				await deleteOneOrMany(
+					JobsByDayBucket.deleteByPk({
+						bucket_day: bucketDayFor(active.created_at),
+						created_at: active.created_at,
+						job_id: active.job_id,
+					}),
+				);
+				await this.deleteActive(active.job_id);
+				result.removedMissing += 1;
+				continue;
+			}
+			if (TERMINAL_JOB_STATUSES.has(job.status)) {
+				await this.finalizeTerminalIndexes(job, input.now);
+				result.removedTerminal += 1;
+				continue;
+			}
+			await this.synchronizeActiveFromAuthoritative(job.job_id);
+			if (job.status === 'deadletter_pending') {
+				const pendingSince = job.state_changed_at ?? job.started_at ?? job.created_at;
+				const publicationLeaseExpired =
+					job.lease_expires_at === null || job.lease_expires_at.getTime() <= input.now.getTime();
+				if (pendingSince.getTime() < input.staleBefore.getTime() && publicationLeaseExpired) {
+					const failed = await this.markFailedIfObserved(
+						job,
+						'Dead-letter publication outlived the worker queue recovery window',
+					);
+					if (failed) result.failedExpiredDeadletter += 1;
+					else result.skippedStateChanged += 1;
+				} else {
+					result.skippedFresh += 1;
+				}
+				continue;
+			}
+			if (job.status === 'running') {
+				const runningSince = job.state_changed_at ?? job.started_at ?? job.created_at;
+				const isPastRecoveryWindow = runningSince.getTime() < input.staleBefore.getTime();
+				const hasExpiredLease =
+					typeof job.lease_token === 'string' &&
+					job.lease_expires_at instanceof Date &&
+					job.lease_expires_at.getTime() <= input.now.getTime();
+				const isStaleLegacyLease = job.lease_token == null && job.lease_expires_at == null;
+				if (isPastRecoveryWindow && (hasExpiredLease || isStaleLegacyLease)) {
+					const failed = await this.markFailedIfObserved(
+						job,
+						'Running job lease outlived the worker queue retention window',
+					);
+					if (failed) result.failedExpiredRunning += 1;
+					else result.skippedStateChanged += 1;
+				} else {
+					result.skippedRunning += 1;
+				}
+				continue;
+			}
+			const latestQueuedTransition = job.state_changed_at ?? job.created_at;
+			const queuedSince =
+				job.run_at && job.run_at.getTime() > latestQueuedTransition.getTime() ? job.run_at : latestQueuedTransition;
+			if (queuedSince.getTime() >= input.staleBefore.getTime()) {
+				if (job.run_at && job.run_at.getTime() > input.now.getTime()) result.skippedScheduled += 1;
+				else result.skippedFresh += 1;
+				continue;
+			}
+			const failed = await this.markFailedIfObserved(job, 'Queued job outlived the worker queue retention window');
+			if (failed) result.failedStaleQueued += 1;
+			else result.skippedStateChanged += 1;
+		}
+		return result;
 	}
 
-	async listActiveJobsByTaskType(taskType: string): Promise<Array<JobByIdRow>> {
-		const activeRows = await fetchMany<JobActiveRow>(ACTIVE_JOBS_QUERY.bind({}));
-		const matching = activeRows.filter((r) => r.task_type === taskType);
-		const fullRows = await Promise.all(matching.map((r) => this.getJob(r.job_id)));
-		return fullRows.filter((r): r is JobByIdRow => r !== null);
+	async listActiveJobs(input: ListActiveJobsInput): Promise<ListActiveJobsResult> {
+		const limit = Math.max(0, Math.min(ACTIVE_AUTHORITY_HYDRATION_LIMIT, input.limit));
+		if (limit === 0) return {jobs: [], nextPageState: null};
+		await this.migrateLegacyActivePage(limit);
+		const cursor = this.decodeActiveCursor(input.pageState, input.taskType ?? null);
+		let shard = cursor.shard;
+		let lastJobId = cursor.lastJobId;
+		const pageRows: Array<JobActiveV2Row> = [];
+		let nextPageState: string | null = null;
+		while (pageRows.length < limit) {
+			const remaining = limit - pageRows.length;
+			const query = JobsActive.select({
+				where:
+					lastJobId === null
+						? JobsActive.where.eq('shard')
+						: [JobsActive.where.eq('shard'), JobsActive.where.gt('job_id', 'last_job_id')],
+				orderBy: {col: 'job_id', direction: 'ASC'},
+				limit: remaining + 1,
+			});
+			const params: CassandraParams = {shard};
+			if (lastJobId !== null) params['last_job_id'] = lastJobId;
+			const scanned = await fetchMany<JobActiveV2Row>(query.bind(params));
+			const accepted = scanned.slice(0, remaining);
+			pageRows.push(...accepted);
+			if (scanned.length > remaining) {
+				nextPageState = this.encodeActiveCursor(shard, accepted.at(-1)!.job_id, input.taskType ?? null);
+				break;
+			}
+			if (shard + 1 >= ACTIVE_JOBS_SHARD_COUNT) {
+				nextPageState = null;
+				break;
+			}
+			shard += 1;
+			lastJobId = null;
+			nextPageState = this.encodeActiveCursor(shard, null, input.taskType ?? null);
+		}
+		const matching = input.taskType ? pageRows.filter((row) => row.task_type === input.taskType) : pageRows;
+		const fullRows = await Promise.all(matching.map((row) => this.getJob(row.job_id)));
+		return {
+			jobs: fullRows.filter((row): row is JobByIdRow => row !== null && !TERMINAL_JOB_STATUSES.has(row.status)),
+			nextPageState,
+		};
+	}
+
+	private decodeActiveCursor(
+		pageState: string | null,
+		taskType: string | null,
+	): {shard: number; lastJobId: bigint | null} {
+		if (pageState === null) return {shard: 0, lastJobId: null};
+		const decoded = JSON.parse(Buffer.from(pageState, 'base64url').toString('utf8')) as Record<string, unknown>;
+		if (
+			decoded['version'] !== 1 ||
+			!Number.isInteger(decoded['shard']) ||
+			(decoded['shard'] as number) < 0 ||
+			(decoded['shard'] as number) >= ACTIVE_JOBS_SHARD_COUNT ||
+			(decoded['taskType'] ?? null) !== taskType ||
+			!(decoded['lastJobId'] === null || typeof decoded['lastJobId'] === 'string')
+		) {
+			throw new Error('Invalid active-jobs page state');
+		}
+		return {
+			shard: decoded['shard'] as number,
+			lastJobId: decoded['lastJobId'] === null ? null : BigInt(decoded['lastJobId'] as string),
+		};
+	}
+
+	private encodeActiveCursor(shard: number, lastJobId: bigint | null, taskType: string | null): string {
+		return Buffer.from(
+			JSON.stringify({version: 1, shard, lastJobId: lastJobId?.toString() ?? null, taskType}),
+		).toString('base64url');
+	}
+
+	async listActiveJobsByTaskType(
+		taskType: string,
+		input: Omit<ListActiveJobsInput, 'taskType'>,
+	): Promise<ListActiveJobsResult> {
+		return this.listActiveJobs({...input, taskType});
 	}
 }

--- a/fluxer_api/src/api/jobs/JobSchedulingPolicy.test.ts
+++ b/fluxer_api/src/api/jobs/JobSchedulingPolicy.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {describe, expect, it} from 'vitest';
+import {SCHEDULED_MESSAGE_TTL_SECONDS} from '../channel/services/ScheduledMessageService';
+import {
+	MAX_JOB_SCHEDULE_DELAY_MS,
+	WORKER_QUEUE_MAX_AGE_MS,
+	WORKER_QUEUE_RECOVERY_WINDOW_MS,
+} from './JobSchedulingPolicy';
+
+describe('job scheduling retention policy', () => {
+	it('retains scheduled-message authority for the complete queue schedule and recovery horizon', () => {
+		expect(SCHEDULED_MESSAGE_TTL_SECONDS * 1000).toBe(WORKER_QUEUE_MAX_AGE_MS);
+		expect(WORKER_QUEUE_MAX_AGE_MS).toBe(MAX_JOB_SCHEDULE_DELAY_MS + WORKER_QUEUE_RECOVERY_WINDOW_MS);
+	});
+});

--- a/fluxer_api/src/api/jobs/JobSchedulingPolicy.ts
+++ b/fluxer_api/src/api/jobs/JobSchedulingPolicy.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {ms} from 'itty-time';
+
+export const MAX_JOB_SCHEDULE_DELAY_MS = ms('30 days');
+export const WORKER_QUEUE_RECOVERY_WINDOW_MS = ms('7 days');
+export const WORKER_QUEUE_MAX_AGE_MS = MAX_JOB_SCHEDULE_DELAY_MS + WORKER_QUEUE_RECOVERY_WINDOW_MS;

--- a/fluxer_api/src/api/test/InMemoryCassandraQueryExecutor.ts
+++ b/fluxer_api/src/api/test/InMemoryCassandraQueryExecutor.ts
@@ -11,6 +11,9 @@ function normalizeCql(cql: string): string {
 }
 
 function compareValues(a: unknown, b: unknown): number {
+	if (a == null && b == null) return 0;
+	if (a == null) return 1;
+	if (b == null) return -1;
 	if (typeof a === 'bigint' || typeof b === 'bigint') {
 		const av = typeof a === 'bigint' ? a : BigInt(a as number | string);
 		const bv = typeof b === 'bigint' ? b : BigInt(b as number | string);
@@ -91,20 +94,21 @@ function matchesWhere(row: Row, where: ReadonlyArray<WhereExpr<Row>> | undefined
 				if (compareValues(row[clause.col], getParam(params, clause.param)) < 0) return false;
 				break;
 			case 'tokenGt':
+				if (compareValues(row[clause.col], getParam(params, clause.param)) <= 0) return false;
 				break;
-			case 'tupleGt': {
+			case 'tupleGt':
+			case 'tupleLt': {
 				const left = clause.cols.map((column) => row[column]);
 				const right = clause.params.map((param) => getParam(params, param));
-				let greater = false;
+				let comparison = 0;
 				for (let i = 0; i < left.length; i += 1) {
 					const cmp = compareValues(left[i], right[i]);
-					if (cmp > 0) {
-						greater = true;
+					if (cmp !== 0) {
+						comparison = cmp;
 						break;
 					}
-					if (cmp < 0) break;
 				}
-				if (!greater) return false;
+				if (clause.kind === 'tupleGt' ? comparison <= 0 : comparison >= 0) return false;
 				break;
 			}
 		}
@@ -191,9 +195,10 @@ export class InMemoryCassandraQueryExecutor implements CassandraQueryExecutorFor
 				}
 				this.upsert(meta, query.params);
 				return [];
-			case 'patch':
-				this.patch(meta, query.params);
-				return [];
+			case 'patch': {
+				const applied = this.patch(meta, query.params);
+				return meta.condition || meta.conditions ? ([{'[applied]': applied}] as Array<T>) : [];
+			}
 			case 'delete':
 				this.delete(meta, query.params);
 				return [];
@@ -201,6 +206,37 @@ export class InMemoryCassandraQueryExecutor implements CassandraQueryExecutorFor
 				return [];
 		}
 		return [];
+	}
+
+	async executePagedQuery<T = Row, P extends CassandraParams = CassandraParams>(
+		query: PreparedQuery<P>,
+		options: {pageSize: number; pageState?: string | null},
+	): Promise<{rows: Array<T>; pageState: string | null}> {
+		const meta = this.meta(query);
+		if (meta.action !== 'select') throw new Error('In-memory paging only supports SELECT queries');
+		let offset = 0;
+		if (options.pageState) {
+			const decoded = JSON.parse(Buffer.from(options.pageState, 'base64url').toString('utf8')) as {
+				version?: unknown;
+				table?: unknown;
+				offset?: unknown;
+			};
+			if (decoded.version !== 1 || decoded.table !== meta.table.name || !Number.isInteger(decoded.offset)) {
+				throw new Error('Invalid in-memory Cassandra page state');
+			}
+			offset = decoded.offset as number;
+		}
+		const unboundedMeta = {...meta, limit: undefined};
+		const allRows = this.select(unboundedMeta, query.params) as Array<T>;
+		const rows = allRows.slice(offset, offset + options.pageSize);
+		const nextOffset = offset + rows.length;
+		return {
+			rows,
+			pageState:
+				nextOffset < allRows.length
+					? Buffer.from(JSON.stringify({version: 1, table: meta.table.name, offset: nextOffset})).toString('base64url')
+					: null,
+		};
 	}
 
 	async executeBatch(queries: Array<{query: string; params: object; meta?: KvQueryMeta}>): Promise<void> {
@@ -245,15 +281,23 @@ export class InMemoryCassandraQueryExecutor implements CassandraQueryExecutorFor
 		return true;
 	}
 
-	private patch(meta: KvQueryMeta, params: CassandraParams): void {
+	private patch(meta: KvQueryMeta, params: CassandraParams): boolean {
 		const table = this.table(meta);
 		const key = this.keyFromParams(meta, params);
+		const existing = table.get(key);
+		const conditions = meta.conditions ?? (meta.condition ? [meta.condition] : []);
+		for (const condition of conditions) {
+			if (!existing || compareValues(existing[condition.col], params[condition.expectedParam]) !== 0) {
+				return false;
+			}
+		}
 		const row =
-			table.get(key) ?? this.rowFromParams({...meta, table: {...meta.table, columns: meta.table.primaryKey}}, params);
+			existing ?? this.rowFromParams({...meta, table: {...meta.table, columns: meta.table.primaryKey}}, params);
 		for (const column of meta.patchKeys ?? []) {
 			row[column] = column in params ? cloneValue(params[column]) : null;
 		}
 		table.set(key, row);
+		return true;
 	}
 
 	private delete(meta: KvQueryMeta, params: CassandraParams): void {
@@ -267,13 +311,26 @@ export class InMemoryCassandraQueryExecutor implements CassandraQueryExecutorFor
 
 	private select(meta: KvQueryMeta, params: CassandraParams): Array<Row> {
 		let rows = [...this.table(meta).values()].filter((row) => matchesWhere(row, meta.where, params));
-		if (meta.orderBy) {
-			const direction = meta.orderBy.direction === 'DESC' ? -1 : 1;
-			rows = rows.sort((a, b) => compareValues(a[meta.orderBy!.col], b[meta.orderBy!.col]) * direction);
-		}
+		const orderItems = meta.orderBy
+			? Array.isArray(meta.orderBy)
+				? meta.orderBy
+				: [meta.orderBy]
+			: meta.table.primaryKey.map((col) => ({col, direction: 'ASC' as const}));
+		rows = rows.sort((left, right) => {
+			for (const item of orderItems) {
+				const direction = item.direction === 'DESC' ? -1 : 1;
+				const comparison = compareValues(left[item.col], right[item.col]) * direction;
+				if (comparison !== 0) return comparison;
+			}
+			return 0;
+		});
 		if (typeof meta.limit === 'number') {
 			rows = rows.slice(0, meta.limit);
 		}
-		return rows.map((row) => projectRow(row, meta.columns));
+		return rows.map((row) => {
+			const cassandraRow: Row = {};
+			for (const column of meta.table.columns) cassandraRow[column] = cloneValue(row[column] ?? null);
+			return projectRow(cassandraRow, meta.columns);
+		});
 	}
 }

--- a/fluxer_api/src/api/test/InMemoryCassandraQueryExecutor.ts
+++ b/fluxer_api/src/api/test/InMemoryCassandraQueryExecutor.ts
@@ -6,6 +6,14 @@ import type {CassandraParams, KvQueryMeta, PreparedQuery, WhereExpr} from '../da
 
 type Row = Record<string, unknown>;
 
+function isBinaryValue(value: unknown): value is Uint8Array {
+	return value instanceof Uint8Array;
+}
+
+function binaryBuffer(value: Uint8Array): Buffer {
+	return Buffer.isBuffer(value) ? value : Buffer.from(value);
+}
+
 function normalizeCql(cql: string): string {
 	return cql.replace(/\s+/g, ' ').trim();
 }
@@ -14,6 +22,7 @@ function compareValues(a: unknown, b: unknown): number {
 	if (a == null && b == null) return 0;
 	if (a == null) return 1;
 	if (b == null) return -1;
+	if (isBinaryValue(a) && isBinaryValue(b)) return Buffer.compare(binaryBuffer(a), binaryBuffer(b));
 	if (typeof a === 'bigint' || typeof b === 'bigint') {
 		const av = typeof a === 'bigint' ? a : BigInt(a as number | string);
 		const bv = typeof b === 'bigint' ? b : BigInt(b as number | string);
@@ -29,19 +38,22 @@ function compareValues(a: unknown, b: unknown): number {
 function valuesEqual(a: unknown, b: unknown): boolean {
 	if (a == null && b == null) return true;
 	if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
-	if (Buffer.isBuffer(a) && Buffer.isBuffer(b)) return a.equals(b);
+	if (isBinaryValue(a) && isBinaryValue(b)) return binaryBuffer(a).equals(binaryBuffer(b));
 	return a === b;
 }
 
 function cloneValue<T>(value: T): T {
 	if (value instanceof Date) return new Date(value.getTime()) as T;
+	if (isBinaryValue(value)) return Buffer.from(value) as T;
 	if (value instanceof Set) return new Set([...value].map((entry) => cloneValue(entry))) as T;
 	if (value instanceof Map) {
 		return new Map([...value.entries()].map(([key, entry]) => [cloneValue(key), cloneValue(entry)])) as T;
 	}
 	if (Array.isArray(value)) return value.map((entry) => cloneValue(entry)) as T;
 	if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
-		return {...(value as object)} as T;
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, cloneValue(entry)]),
+		) as T;
 	}
 	return value;
 }
@@ -59,7 +71,7 @@ function pkKey(meta: KvQueryMeta, row: Row): string {
 }
 
 function valueKey(value: unknown): string {
-	if (Buffer.isBuffer(value)) return `buffer:${value.toString('base64')}`;
+	if (isBinaryValue(value)) return `buffer:${binaryBuffer(value).toString('base64')}`;
 	if (value instanceof Date) return `date:${value.toISOString()}`;
 	if (typeof value === 'bigint') return `bigint:${value.toString()}`;
 	return `${typeof value}:${String(value)}`;

--- a/fluxer_api/src/api/worker/CronScheduler.ts
+++ b/fluxer_api/src/api/worker/CronScheduler.ts
@@ -82,6 +82,7 @@ export class CronScheduler {
 	private readonly kvClient: IKVProvider | null;
 	private readonly definitions: Map<string, CronDefinition> = new Map();
 	private intervalId: NodeJS.Timeout | null = null;
+	private activeTick: Promise<void> | null = null;
 
 	constructor(workerService: WorkerService, logger: LoggerInterface, kvClient: IKVProvider | null = null) {
 		this.workerService = workerService;
@@ -104,18 +105,25 @@ export class CronScheduler {
 			return;
 		}
 		this.intervalId = setInterval(() => {
-			this.tick().catch((error) => {
-				this.logger.error({err: error}, 'Cron scheduler tick failed');
-			});
+			if (this.activeTick !== null) return;
+			const tick = this.tick()
+				.catch((error) => {
+					this.logger.error({err: error}, 'Cron scheduler tick failed');
+				})
+				.finally(() => {
+					if (this.activeTick === tick) this.activeTick = null;
+				});
+			this.activeTick = tick;
 		}, 1000);
 		this.logger.info(`Cron scheduler started with ${this.definitions.size} definitions`);
 	}
 
-	stop(): void {
+	async stop(): Promise<void> {
 		if (this.intervalId !== null) {
 			clearInterval(this.intervalId);
 			this.intervalId = null;
 		}
+		await this.activeTick;
 	}
 
 	private async tick(): Promise<void> {
@@ -133,7 +141,7 @@ export class CronScheduler {
 					if (!acquired) {
 						continue;
 					}
-					await this.workerService.addJob(def.taskType, def.payload, {jobKey});
+					await this.workerService.addJob(def.taskType, def.payload, {jobKey, skipLedger: true});
 					this.logger.debug({cronId: def.id, taskType: def.taskType}, 'Cron job fired');
 				} catch (error) {
 					this.logger.error({err: error, cronId: def.id, taskType: def.taskType}, 'Failed to enqueue cron job');

--- a/fluxer_api/src/api/worker/JetStreamWorkerQueue.ts
+++ b/fluxer_api/src/api/worker/JetStreamWorkerQueue.ts
@@ -4,12 +4,15 @@ import {randomUUID} from 'node:crypto';
 import type {JetStreamConnectionManager} from '@pkgs/nats/src/JetStreamConnectionManager';
 import type {WorkerJobPayload} from '@pkgs/worker/src/contracts/WorkerTypes';
 import {AckPolicy, nanos, RetentionPolicy, StorageType} from 'nats';
+import {WORKER_QUEUE_MAX_AGE_MS} from '../jobs/JobSchedulingPolicy';
 import {Logger} from '../Logger';
 import type {WorkerLaneDefinition} from './WorkerLaneConfig';
 
 const STREAM_NAME = 'JOBS';
 const SUBJECT_PREFIX = 'jobs.';
-const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export {WORKER_QUEUE_MAX_AGE_MS, WORKER_QUEUE_RECOVERY_WINDOW_MS} from '../jobs/JobSchedulingPolicy';
+
 const LEGACY_CONSUMER_NAME = 'workers';
 const DLQ_STREAM_NAME = 'JOBS_DLQ';
 const DLQ_SUBJECT_PREFIX = 'dlq.';
@@ -30,17 +33,24 @@ export class JetStreamWorkerQueue {
 			return;
 		}
 		const jsm = await this.connectionManager.getJetStreamManager();
+		let info = null;
 		try {
-			await jsm.streams.info(STREAM_NAME);
+			info = await jsm.streams.info(STREAM_NAME);
 		} catch {
 			await jsm.streams.add({
 				name: STREAM_NAME,
 				subjects: [`${SUBJECT_PREFIX}>`],
 				retention: RetentionPolicy.Workqueue,
 				storage: StorageType.File,
-				max_age: nanos(MAX_AGE_MS),
+				max_age: nanos(WORKER_QUEUE_MAX_AGE_MS),
 				duplicate_window: nanos(2 * 60 * 1000),
 				num_replicas: 1,
+			});
+		}
+		if (info) {
+			await jsm.streams.update(STREAM_NAME, {
+				...info.config,
+				max_age: nanos(WORKER_QUEUE_MAX_AGE_MS),
 			});
 		}
 		this.streamReady = true;
@@ -51,8 +61,9 @@ export class JetStreamWorkerQueue {
 			return;
 		}
 		const jsm = await this.connectionManager.getJetStreamManager();
+		let info = null;
 		try {
-			await jsm.streams.info(DLQ_STREAM_NAME);
+			info = await jsm.streams.info(DLQ_STREAM_NAME);
 		} catch {
 			await jsm.streams.add({
 				name: DLQ_STREAM_NAME,
@@ -60,7 +71,15 @@ export class JetStreamWorkerQueue {
 				retention: RetentionPolicy.Limits,
 				storage: StorageType.File,
 				max_age: nanos(DLQ_MAX_AGE_MS),
+				duplicate_window: nanos(DLQ_MAX_AGE_MS),
 				num_replicas: 1,
+			});
+		}
+		if (info) {
+			await jsm.streams.update(DLQ_STREAM_NAME, {
+				...info.config,
+				max_age: nanos(DLQ_MAX_AGE_MS),
+				duplicate_window: nanos(DLQ_MAX_AGE_MS),
 			});
 		}
 		this.dlqStreamReady = true;
@@ -76,7 +95,7 @@ export class JetStreamWorkerQueue {
 			const config = {
 				durable_name: lane.consumerName,
 				ack_policy: AckPolicy.Explicit,
-				max_deliver: lane.maxDeliver,
+				max_deliver: -1,
 				ack_wait: nanos(lane.ackWaitMs),
 				max_ack_pending: lane.maxAckPending,
 				filter_subjects: filterSubjects,
@@ -179,7 +198,7 @@ export class JetStreamWorkerQueue {
 			failed_at: new Date().toISOString(),
 		});
 		await js.publish(subject, body, {
-			msgID: randomUUID(),
+			msgID: `dlq:${meta.lane}:${taskType}:${meta.originalSeq}`,
 		});
 	}
 

--- a/fluxer_api/src/api/worker/WorkerLaneConfig.ts
+++ b/fluxer_api/src/api/worker/WorkerLaneConfig.ts
@@ -2,6 +2,8 @@
 
 import type {APIWorkerLaneName, APIWorkerMode} from '../config/APIConfig';
 
+export const WORKER_DLQ_PUBLISH_ATTEMPTS = 3;
+
 interface LaneSettings {
 	readonly consumerName: string;
 	readonly tasks: ReadonlyArray<string>;
@@ -73,6 +75,7 @@ const LANE_CONFIG = {
 			'processPendingBulkMessageDeletions',
 			'processPremiumStateReconciliationQueue',
 			'prunePostgresKvTtl',
+			'reconcileActiveJobs',
 			'refreshSearchIndex',
 			'syncDiscoveryIndex',
 			'syncDisposableEmailDomains',

--- a/fluxer_api/src/api/worker/WorkerMain.ts
+++ b/fluxer_api/src/api/worker/WorkerMain.ts
@@ -40,7 +40,7 @@ const SEARCH_REQUIRED_TASKS = new Set<string>([
 	'syncDiscoveryIndex',
 ]);
 
-function registerCronJobs(cron: CronScheduler): void {
+export function registerCronJobs(cron: CronScheduler): void {
 	cron.upsert('processAssetDeletionQueue', 'processAssetDeletionQueue', {}, '0 */5 * * * *');
 	cron.upsert('processBunnyPurgeQueue', 'processBunnyPurgeQueue', {}, '*/10 * * * * *');
 	cron.upsert('processPendingBulkMessageDeletions', 'processPendingBulkMessageDeletions', {}, '0 */10 * * * *');
@@ -50,6 +50,7 @@ function registerCronJobs(cron: CronScheduler): void {
 	cron.upsert('processInactivityDeletions', 'processInactivityDeletions', {}, '0 0 */6 * * *');
 	cron.upsert('expireAttachments', 'expireAttachments', {}, '0 0 */12 * * *');
 	cron.upsert('prunePostgresKvTtl', 'prunePostgresKvTtl', {}, '0 */5 * * * *');
+	cron.upsert('reconcileActiveJobs', 'reconcileActiveJobs', {}, '0 0 * * * *');
 	cron.upsert('syncDiscoveryIndex', 'syncDiscoveryIndex', {}, '0 */15 * * * *');
 	cron.upsert('syncDisposableEmailDomains', 'syncDisposableEmailDomains', {}, '0 */30 * * * *');
 	cron.upsert('syncUrlBlocklists', 'syncUrlBlocklists', {}, '0 0 */6 * * *');
@@ -62,6 +63,20 @@ function workerLanesRequireSearch(activeWorkerLanes: ReadonlyArray<WorkerLaneDef
 	return activeWorkerLanes.some((lane) => lane.taskTypes.some((taskType) => SEARCH_REQUIRED_TASKS.has(taskType)));
 }
 
+export function createJoinableShutdown(action: () => Promise<void>): () => Promise<void> {
+	let shutdownPromise: Promise<void> | null = null;
+	return () => {
+		shutdownPromise ??= action();
+		return shutdownPromise;
+	};
+}
+
+export async function stopWorkerRunners(runners: ReadonlyArray<{stop(): Promise<void>}>): Promise<void> {
+	const results = await Promise.allSettled(runners.map((runner) => runner.stop()));
+	const errors = results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : []));
+	if (errors.length > 0) throw new AggregateError(errors, 'One or more worker runners failed to stop');
+}
+
 export async function startWorkerMain(): Promise<void> {
 	Logger.info('Starting worker backend...');
 	let cassandraInitialized = false;
@@ -72,7 +87,6 @@ export async function startWorkerMain(): Promise<void> {
 	let cron: CronScheduler | null = null;
 	const runners: Array<WorkerRunner> = [];
 	let searchInitialized = false;
-	let shuttingDown = false;
 
 	const cleanupStep = async (label: string, fn: () => Promise<void> | void): Promise<void> => {
 		try {
@@ -82,16 +96,10 @@ export async function startWorkerMain(): Promise<void> {
 		}
 	};
 
-	const shutdown = async (): Promise<void> => {
-		if (shuttingDown) {
-			return;
-		}
-		shuttingDown = true;
+	const shutdown = createJoinableShutdown(async (): Promise<void> => {
 		Logger.info('Shutting down worker backend...');
 		await cleanupStep('cron', () => cron?.stop());
-		await cleanupStep('runners', async () => {
-			await Promise.all(runners.map((runner) => runner.stop()));
-		});
+		await cleanupStep('runners', () => stopWorkerRunners(runners));
 		await cleanupStep('jetstream', async () => {
 			await jsConnectionManager?.drain();
 			jsConnectionManager = null;
@@ -130,7 +138,7 @@ export async function startWorkerMain(): Promise<void> {
 			}
 			setInjectedSnowflakeService(undefined);
 		});
-	};
+	});
 
 	try {
 		if (Config.database.backend === 'postgres') {

--- a/fluxer_api/src/api/worker/WorkerRunner.ts
+++ b/fluxer_api/src/api/worker/WorkerRunner.ts
@@ -5,12 +5,13 @@ import type {IWorkerService} from '@pkgs/worker/src/contracts/IWorkerService';
 import {JobCancelledError, type WorkerTaskHandler} from '@pkgs/worker/src/contracts/WorkerTask';
 import type {WorkerJobPayload} from '@pkgs/worker/src/contracts/WorkerTypes';
 import type {ConsumerMessages, JsMsg} from 'nats';
+import type {JobByIdRow} from '../database/types/JobLedgerTypes';
 import type {IJobLedgerRepository} from '../jobs/IJobLedgerRepository';
 import {Logger} from '../Logger';
 import {getWorkerService} from '../middleware/ServiceRegistry';
 import {isJsonRecord, parseJsonRecord} from '../utils/JsonBoundaryUtils';
 
-const MAX_DLQ_PUBLISH_ATTEMPTS = 3;
+import {WORKER_DLQ_PUBLISH_ATTEMPTS} from './WorkerLaneConfig';
 
 interface WorkerRunnerJetStreamClient {
 	consumers: {
@@ -76,6 +77,9 @@ export class WorkerRunner {
 	private readonly ledger: IJobLedgerRepository;
 	private running = false;
 	private consumerMessages: ConsumerMessages | null = null;
+	private startPromise: Promise<void> | null = null;
+	private stopPromise: Promise<void> | null = null;
+	private processLoop: Promise<void> | null = null;
 	private readonly inFlightJobs = new Set<Promise<void>>();
 
 	constructor(options: WorkerRunnerOptions) {
@@ -96,30 +100,84 @@ export class WorkerRunner {
 			Logger.warn({workerId: this.workerId}, 'Worker already running');
 			return;
 		}
+		if (this.processLoop !== null) {
+			throw new Error('Cannot restart worker while its previous message loop is still active');
+		}
 		this.running = true;
 		Logger.info({workerId: this.workerId, lane: this.laneName, concurrency: this.concurrency}, 'Worker starting');
-		const js = this.queue.getConnectionManager().getJetStreamClient();
-		const consumer = await js.consumers.get(this.queue.getStreamName(), this.consumerName);
-		const prefetch = Math.max(this.concurrency * 2, 16);
-		this.consumerMessages = await consumer.consume({
-			max_messages: prefetch,
-			idle_heartbeat: 5000,
-		});
-		this.processMessages().catch((error) => {
-			Logger.error({workerId: this.workerId, err: error}, 'Worker message processing failed unexpectedly');
-		});
+		const startPromise = (async () => {
+			const js = this.queue.getConnectionManager().getJetStreamClient();
+			const consumer = await js.consumers.get(this.queue.getStreamName(), this.consumerName);
+			const prefetch = Math.max(this.concurrency * 2, 16);
+			const messages = await consumer.consume({
+				max_messages: prefetch,
+				idle_heartbeat: 5000,
+			});
+			if (!this.running) {
+				await messages.close();
+				return;
+			}
+			this.consumerMessages = messages;
+			const processLoop = this.processMessages()
+				.catch((error) => {
+					Logger.error({workerId: this.workerId, err: error}, 'Worker message processing failed unexpectedly');
+				})
+				.finally(() => {
+					if (this.processLoop === processLoop) this.processLoop = null;
+				});
+			this.processLoop = processLoop;
+		})();
+		this.startPromise = startPromise;
+		try {
+			await startPromise;
+		} catch (error) {
+			this.running = false;
+			throw error;
+		} finally {
+			if (this.startPromise === startPromise) this.startPromise = null;
+		}
 	}
 
 	async stop(): Promise<void> {
-		if (!this.running) {
+		if (this.stopPromise !== null) return this.stopPromise;
+		const stopping = this.stopInternal();
+		this.stopPromise = stopping;
+		await stopping;
+		if (this.stopPromise === stopping) this.stopPromise = null;
+	}
+
+	private async stopInternal(): Promise<void> {
+		if (!this.running && this.startPromise === null && this.consumerMessages === null && this.processLoop === null) {
 			return;
 		}
 		this.running = false;
-		if (this.consumerMessages !== null) {
-			await this.consumerMessages.close();
-			this.consumerMessages = null;
+		let shutdownError: unknown = null;
+		const starting = this.startPromise;
+		if (starting !== null) {
+			try {
+				await starting;
+			} catch (error) {
+				shutdownError = error;
+			}
+		}
+		const messages = this.consumerMessages;
+		this.consumerMessages = null;
+		let consumerClosed = messages === null;
+		if (messages !== null) {
+			try {
+				await messages.close();
+				consumerClosed = true;
+			} catch (error) {
+				shutdownError ??= error;
+			}
+		}
+		if (consumerClosed) {
+			await this.processLoop;
+		} else {
+			await Promise.allSettled([...this.inFlightJobs]);
 		}
 		Logger.info({workerId: this.workerId}, 'Worker stopped');
+		if (shutdownError !== null) throw shutdownError;
 	}
 
 	private async processMessages(): Promise<void> {
@@ -132,6 +190,14 @@ export class WorkerRunner {
 			}
 			while (this.inFlightJobs.size >= this.concurrency) {
 				await Promise.race(this.inFlightJobs);
+			}
+			if (!this.running) {
+				try {
+					msg.nak(0);
+				} catch (error) {
+					Logger.warn({workerId: this.workerId, err: error}, 'Failed to NAK prefetched job during shutdown');
+				}
+				break;
 			}
 			const taskType = msg.subject.startsWith('jobs.') ? msg.subject.slice(5) : msg.subject;
 			Logger.info(
@@ -167,6 +233,202 @@ export class WorkerRunner {
 		Logger.info({workerId: this.workerId}, 'Worker message iterator ended');
 	}
 
+	private startOwnershipHeartbeat(
+		jobId: bigint,
+		msg: JsMsg,
+		leaseDurationMs: number,
+		renew: (now: Date) => Promise<boolean>,
+		failureMessage: string,
+	): () => void {
+		const interval = setInterval(
+			() => {
+				void renew(new Date())
+					.then((renewed) => {
+						if (renewed) msg.working();
+						else clearInterval(interval);
+					})
+					.catch((err) => Logger.warn({err, jobId: jobId.toString()}, failureMessage));
+			},
+			Math.max(1000, Math.floor(leaseDurationMs / 3)),
+		);
+		return () => clearInterval(interval);
+	}
+
+	private startLeaseHeartbeat(jobId: bigint, leaseToken: string, msg: JsMsg, leaseDurationMs: number): () => void {
+		return this.startOwnershipHeartbeat(
+			jobId,
+			msg,
+			leaseDurationMs,
+			(now) => this.ledger.renewLease(jobId, leaseToken, now, leaseDurationMs),
+			'Failed to renew worker lease',
+		);
+	}
+
+	private startDeadletterPublicationHeartbeat(
+		jobId: bigint,
+		leaseToken: string,
+		msg: JsMsg,
+		leaseDurationMs: number,
+	): () => void {
+		return this.startOwnershipHeartbeat(
+			jobId,
+			msg,
+			leaseDurationMs,
+			(now) => this.ledger.renewDeadletterPublicationLease(jobId, leaseToken, now, leaseDurationMs),
+			'Failed to renew dead-letter publication lease',
+		);
+	}
+
+	private async retainAfterTerminalizationFailure(
+		jobId: bigint,
+		msg: JsMsg,
+		reason: string,
+		leaseToken: string,
+	): Promise<boolean> {
+		try {
+			const released = await this.ledger.releaseForRetry(jobId, reason, false, leaseToken);
+			if (released) {
+				msg.nak(5000);
+				return false;
+			}
+			const latest = await this.ledger.getJob(jobId);
+			if (latest && ['succeeded', 'failed', 'cancelled', 'deadletter'].includes(latest.status)) {
+				msg.ack();
+				return true;
+			}
+		} catch (err) {
+			Logger.warn({err, jobId: jobId.toString()}, 'Failed to release job after terminalization failure');
+		}
+		msg.nak(5000);
+		return false;
+	}
+
+	private async publishDlqAndFinalize(
+		taskType: string,
+		msg: JsMsg,
+		jobPayload: Record<string, unknown>,
+		runAt: string | undefined,
+		ledgerJobId: bigint | null,
+		errorMessage: string,
+		leaseToken: string | null = null,
+	): Promise<void> {
+		const deliveryCount = msg.info.deliveryCount;
+		let durableErrorMessage = errorMessage;
+		let publicationLeaseToken: string | null = null;
+		if (ledgerJobId !== null) {
+			try {
+				const prepared = await this.ledger.markDeadletterPending(
+					ledgerJobId,
+					errorMessage,
+					leaseToken,
+					new Date(),
+					this.ackWaitMs,
+				);
+				if (prepared) {
+					publicationLeaseToken = prepared.leaseToken;
+					durableErrorMessage = prepared.errorMessage;
+				} else {
+					const latest = await this.ledger.getJob(ledgerJobId);
+					if (latest?.status === 'deadletter_pending') {
+						msg.nak(5000);
+						return;
+					}
+					if (latest && ['succeeded', 'failed', 'cancelled', 'deadletter'].includes(latest.status)) {
+						msg.ack();
+						return;
+					}
+					if (leaseToken !== null) {
+						await this.ledger.releaseForRetry(ledgerJobId, errorMessage, false, leaseToken);
+					}
+					msg.nak(5000);
+					return;
+				}
+			} catch (ledgerError) {
+				Logger.warn({err: ledgerError, jobId: ledgerJobId.toString()}, 'Failed to claim dead-letter publication');
+				msg.nak(5000);
+				return;
+			}
+		}
+
+		const stopHeartbeat =
+			ledgerJobId !== null && publicationLeaseToken !== null
+				? this.startDeadletterPublicationHeartbeat(ledgerJobId, publicationLeaseToken, msg, this.ackWaitMs)
+				: () => undefined;
+		let published = false;
+		try {
+			await this.queue.publishToDlq(taskType, jobPayload, {
+				originalSeq: msg.seq,
+				errorMessage: durableErrorMessage,
+				deliveryCount,
+				lane: this.laneName,
+				runAt,
+			});
+			published = true;
+			if (ledgerJobId !== null && publicationLeaseToken !== null) {
+				const marked = await this.ledger.markDeadletter(ledgerJobId, durableErrorMessage, publicationLeaseToken);
+				if (!marked) {
+					const latest = await this.ledger.getJob(ledgerJobId);
+					if (latest?.status !== 'deadletter') {
+						throw new Error(`Unable to terminalize ledger job from ${latest?.status ?? 'missing'} state`);
+					}
+				}
+			}
+			msg.term('moved to dead-letter queue');
+		} catch (dlqError) {
+			if (published) {
+				Logger.error(
+					{taskType, seq: msg.seq, deliveryCount, err: dlqError},
+					'Dead-letter message was published but ledger terminalization failed; retaining source delivery',
+				);
+				msg.nak(5000);
+				return;
+			}
+			let dlqPublishAttempts: number | null = deliveryCount - this.maxDeliver;
+			if (ledgerJobId !== null && publicationLeaseToken !== null) {
+				try {
+					dlqPublishAttempts = await this.ledger.recordDlqPublishFailure(ledgerJobId, publicationLeaseToken);
+				} catch (ledgerError) {
+					Logger.warn(
+						{err: ledgerError, jobId: ledgerJobId.toString()},
+						'Failed to persist DLQ publication attempt; retaining broker message',
+					);
+					msg.nak(5000);
+					return;
+				}
+				if (dlqPublishAttempts === null) {
+					const latest = await this.ledger.getJob(ledgerJobId);
+					if (latest && ['succeeded', 'failed', 'cancelled', 'deadletter'].includes(latest.status)) {
+						msg.term('dead-letter handling already terminal');
+						return;
+					}
+					msg.nak(5000);
+					return;
+				}
+			}
+			if (dlqPublishAttempts >= WORKER_DLQ_PUBLISH_ATTEMPTS) {
+				Logger.error(
+					{taskType, seq: msg.seq, deliveryCount, dlqPublishAttempts, err: dlqError},
+					'Dead-letter publication failed repeatedly',
+				);
+				if (ledgerJobId === null) {
+					msg.term('dead-letter publish failed repeatedly');
+					return;
+				}
+				Logger.warn(
+					{jobId: ledgerJobId.toString()},
+					'Retaining ledgered source delivery until DLQ publication succeeds or stream retention expires',
+				);
+			}
+			Logger.error(
+				{taskType, seq: msg.seq, deliveryCount, dlqPublishAttempts, err: dlqError},
+				'Failed to publish dead-letter message, will retry on redelivery',
+			);
+			msg.nak(5000);
+		} finally {
+			stopHeartbeat();
+		}
+	}
+
 	protected async processJob(taskType: string, msg: JsMsg): Promise<boolean> {
 		const task = this.tasks[taskType];
 		if (!task) {
@@ -183,14 +445,18 @@ export class WorkerRunner {
 				throw new Error('job envelope must be a JSON object');
 			}
 			jobPayload = isJsonRecord(decoded.payload) ? decoded.payload : {};
-			runAt = typeof decoded.run_at === 'string' ? decoded.run_at : undefined;
-			const embedded = jobPayload['__jobId'];
-			if (typeof embedded === 'string') {
-				try {
-					ledgerJobId = BigInt(embedded);
-				} catch {
-					ledgerJobId = null;
+			if (decoded.run_at !== undefined) {
+				if (typeof decoded.run_at !== 'string' || !Number.isFinite(new Date(decoded.run_at).getTime())) {
+					throw new Error('run_at must be a valid timestamp string');
 				}
+				runAt = decoded.run_at;
+			}
+			const embedded = jobPayload['__jobId'];
+			if (embedded !== undefined) {
+				if (typeof embedded !== 'string' || !/^[1-9]\d*$/.test(embedded)) {
+					throw new Error('__jobId must be a positive decimal string');
+				}
+				ledgerJobId = BigInt(embedded);
 				delete jobPayload['__jobId'];
 			}
 		} catch {
@@ -200,44 +466,58 @@ export class WorkerRunner {
 		}
 		if (runAt) {
 			const runAtMs = new Date(runAt).getTime();
-			if (Number.isFinite(runAtMs)) {
-				const delayMs = runAtMs - Date.now();
-				if (delayMs > 0) {
-					const deliveryCount = msg.info.deliveryCount;
-					const shouldReEnqueue = delayMs > this.ackWaitMs || deliveryCount >= this.maxDeliver - 1;
-					if (shouldReEnqueue) {
-						try {
-							await this.queue.enqueue(taskType, jobPayload, {runAt: new Date(runAtMs)});
-							msg.ack();
-							Logger.debug(
-								{taskType, seq: msg.seq, runAt, deliveryCount},
-								'Re-enqueued scheduled job to free ack slot',
-							);
-						} catch (error) {
-							Logger.error(
-								{taskType, seq: msg.seq, err: error},
-								'Failed to re-enqueue scheduled job, falling back to NAK',
-							);
-							msg.nak(Math.min(delayMs, this.ackWaitMs - 5000));
-						}
-					} else {
-						Logger.debug(
-							{taskType, seq: msg.seq, runAt, delayMs},
-							'Job scheduled for future execution, redelivering with delay',
+			const delayMs = runAtMs - Date.now();
+			if (delayMs > 0) {
+				Logger.debug(
+					{taskType, seq: msg.seq, runAt, delayMs},
+					'Job scheduled for future execution, redelivering with broker delay',
+				);
+				msg.nak(delayMs);
+				return false;
+			}
+		}
+		let claimedJob: JobByIdRow | null = null;
+		let leaseToken: string | null = null;
+		const leaseDurationMs = Math.max(this.ackWaitMs * 2, 60_000);
+		if (ledgerJobId !== null) {
+			try {
+				leaseToken = `${this.workerId}:${msg.seq}:${msg.info.deliveryCount}:${randomUUID()}`;
+				claimedJob = await this.ledger.claimJob(ledgerJobId, this.laneName, leaseToken, new Date(), leaseDurationMs);
+				const claimed = claimedJob !== null;
+				if (!claimed) {
+					leaseToken = null;
+					claimedJob = await this.ledger.getJob(ledgerJobId);
+					if (claimedJob?.status === 'deadletter_pending' && claimedJob.error_message) {
+						await this.publishDlqAndFinalize(taskType, msg, jobPayload, runAt, ledgerJobId, claimedJob.error_message);
+						return false;
+					}
+					if (claimedJob && ['succeeded', 'failed', 'cancelled', 'deadletter'].includes(claimedJob.status)) {
+						Logger.warn(
+							{jobId: ledgerJobId.toString(), taskType, seq: msg.seq, status: claimedJob.status},
+							'Ledger job is terminal; acknowledging duplicate delivery',
 						);
-						msg.nak(delayMs);
+						msg.ack();
+					} else {
+						Logger.warn(
+							{jobId: ledgerJobId.toString(), taskType, seq: msg.seq, status: claimedJob?.status},
+							'Ledger job is currently owned; retrying duplicate delivery',
+						);
+						msg.nak(5000);
 					}
 					return false;
 				}
-			}
-		}
-		if (ledgerJobId !== null) {
-			try {
-				await this.ledger.markRunning(ledgerJobId, this.laneName);
 			} catch (err) {
-				Logger.warn({err, jobId: ledgerJobId.toString()}, 'Ledger markRunning failed');
+				Logger.warn({err, jobId: ledgerJobId.toString()}, 'Ledger claim failed; retrying delivery');
+				msg.nak();
+				return false;
 			}
 		}
+		if (ledgerJobId !== null && leaseToken === null) {
+			Logger.error({jobId: ledgerJobId.toString()}, 'Claimed ledger job is missing its lease token');
+			msg.nak();
+			return false;
+		}
+		const activeLeaseToken = leaseToken;
 		const ledger = this.ledger;
 		const capturedJobId = ledgerJobId;
 		const helpers = {
@@ -245,9 +525,9 @@ export class WorkerRunner {
 			jobId: capturedJobId ?? 0n,
 			addJob: this.workerService.addJob.bind(this.workerService),
 			reportProgress: async (current: number, total: number | null, message?: string | null) => {
-				if (capturedJobId === null) return;
+				if (capturedJobId === null || activeLeaseToken === null) return;
 				try {
-					await ledger.reportProgress(capturedJobId, current, total, message ?? null);
+					await ledger.reportProgress(capturedJobId, current, total, message ?? null, activeLeaseToken);
 				} catch (err) {
 					Logger.warn({err, jobId: capturedJobId.toString()}, 'Ledger reportProgress failed');
 				}
@@ -262,91 +542,121 @@ export class WorkerRunner {
 				}
 			},
 			setContextLink: async (link: string) => {
-				if (capturedJobId === null) return;
+				if (capturedJobId === null || activeLeaseToken === null) return;
 				try {
-					await ledger.setContextLink(capturedJobId, link);
+					await ledger.setContextLink(capturedJobId, link, activeLeaseToken);
 				} catch (err) {
 					Logger.warn({err, jobId: capturedJobId.toString()}, 'Ledger setContextLink failed');
 				}
 			},
 		};
+		const stopLeaseHeartbeat =
+			ledgerJobId !== null && activeLeaseToken !== null
+				? this.startLeaseHeartbeat(ledgerJobId, activeLeaseToken, msg, leaseDurationMs)
+				: () => undefined;
 		try {
-			await task(jobPayload, helpers);
-			if (ledgerJobId !== null) {
-				try {
-					await this.ledger.markSucceeded(ledgerJobId, null);
-				} catch (err) {
-					Logger.warn({err, jobId: ledgerJobId.toString()}, 'Ledger markSucceeded failed');
-				}
-			}
-			msg.ack();
-			return true;
-		} catch (error) {
-			const isCancelled = error instanceof JobCancelledError;
-			if (isCancelled) {
-				if (ledgerJobId !== null) {
+			try {
+				await task(jobPayload, helpers);
+				if (ledgerJobId !== null && activeLeaseToken !== null) {
 					try {
-						await this.ledger.markCancelled(ledgerJobId);
+						const marked = await this.ledger.markSucceeded(ledgerJobId, null, activeLeaseToken);
+						if (!marked) {
+							Logger.warn({jobId: ledgerJobId.toString()}, 'Ledger markSucceeded was not applied');
+							return this.retainAfterTerminalizationFailure(
+								ledgerJobId,
+								msg,
+								'Terminalization failed after successful execution',
+								activeLeaseToken,
+							);
+						}
 					} catch (err) {
-						Logger.warn({err, jobId: ledgerJobId.toString()}, 'Ledger markCancelled failed');
+						Logger.warn({err, jobId: ledgerJobId.toString()}, 'Ledger markSucceeded failed');
+						return this.retainAfterTerminalizationFailure(
+							ledgerJobId,
+							msg,
+							'Terminalization failed after successful execution',
+							activeLeaseToken,
+						);
 					}
 				}
-				Logger.info({taskType, seq: msg.seq, jobId: ledgerJobId?.toString()}, 'Job cancelled by admin');
 				msg.ack();
+				return true;
+			} catch (error) {
+				const isCancelled = error instanceof JobCancelledError;
+				if (isCancelled) {
+					if (ledgerJobId !== null && activeLeaseToken !== null) {
+						try {
+							const marked = await this.ledger.markCancelled(ledgerJobId, activeLeaseToken);
+							if (!marked) {
+								Logger.warn({jobId: ledgerJobId.toString()}, 'Ledger markCancelled was not applied');
+								await this.retainAfterTerminalizationFailure(
+									ledgerJobId,
+									msg,
+									'Terminalization failed after cancellation',
+									activeLeaseToken,
+								);
+								return false;
+							}
+						} catch (err) {
+							Logger.warn({err, jobId: ledgerJobId.toString()}, 'Ledger markCancelled failed');
+							await this.retainAfterTerminalizationFailure(
+								ledgerJobId,
+								msg,
+								'Terminalization failed after cancellation',
+								activeLeaseToken,
+							);
+							return false;
+						}
+					}
+					Logger.info({taskType, seq: msg.seq, jobId: ledgerJobId?.toString()}, 'Job cancelled by admin');
+					msg.ack();
+					return false;
+				}
+				const deliveryCount = msg.info.deliveryCount;
+				const ledgerAttempts = claimedJob?.attempts;
+				const ledgerMaxAttempts = claimedJob?.max_attempts;
+				const hasLedgerAttemptBudget =
+					ledgerJobId !== null && typeof ledgerAttempts === 'number' && typeof ledgerMaxAttempts === 'number';
+				const isLastDelivery = hasLedgerAttemptBudget
+					? ledgerAttempts + 1 >= ledgerMaxAttempts
+					: deliveryCount >= this.maxDeliver;
+				const errorMessage = error instanceof Error ? error.message : String(error);
+				if (isLastDelivery) {
+					Logger.error(
+						{taskType, seq: msg.seq, deliveryCount, err: error},
+						'Job failed on final delivery attempt, moving to dead-letter queue',
+					);
+					await this.publishDlqAndFinalize(
+						taskType,
+						msg,
+						jobPayload,
+						runAt,
+						ledgerJobId,
+						errorMessage,
+						activeLeaseToken,
+					);
+				} else {
+					Logger.error({taskType, seq: msg.seq, err: error}, 'Job failed');
+					if (ledgerJobId !== null && activeLeaseToken !== null) {
+						try {
+							const released = await this.ledger.releaseForRetry(ledgerJobId, errorMessage, true, activeLeaseToken);
+							if (!released) {
+								const latest = await this.ledger.getJob(ledgerJobId);
+								if (latest && ['succeeded', 'failed', 'cancelled', 'deadletter'].includes(latest.status)) {
+									msg.ack();
+									return false;
+								}
+							}
+						} catch (err) {
+							Logger.warn({err, jobId: ledgerJobId.toString()}, 'Ledger releaseForRetry failed');
+						}
+					}
+					msg.nak(5000);
+				}
 				return false;
 			}
-			const deliveryCount = msg.info.deliveryCount;
-			const isLastDelivery = deliveryCount >= this.maxDeliver;
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			if (isLastDelivery) {
-				Logger.error(
-					{taskType, seq: msg.seq, deliveryCount, err: error},
-					'Job failed on final delivery attempt, moving to dead-letter queue',
-				);
-				if (ledgerJobId !== null) {
-					try {
-						await this.ledger.markDeadletter(ledgerJobId, errorMessage);
-					} catch (err) {
-						Logger.warn({err, jobId: ledgerJobId.toString()}, 'Ledger markDeadletter failed');
-					}
-				}
-				try {
-					await this.queue.publishToDlq(taskType, jobPayload, {
-						originalSeq: msg.seq,
-						errorMessage,
-						deliveryCount,
-						lane: this.laneName,
-						runAt,
-					});
-					msg.term('moved to dead-letter queue');
-				} catch (dlqError) {
-					const dlqPublishAttempts = deliveryCount - this.maxDeliver;
-					if (dlqPublishAttempts >= MAX_DLQ_PUBLISH_ATTEMPTS) {
-						Logger.error(
-							{taskType, seq: msg.seq, deliveryCount, err: dlqError},
-							'Failed to publish to dead-letter queue after repeated attempts, dropping message to avoid poison loop',
-						);
-						msg.term('dead-letter publish failed repeatedly');
-					} else {
-						Logger.error(
-							{taskType, seq: msg.seq, deliveryCount, err: dlqError},
-							'Failed to publish to dead-letter queue, will retry on redelivery',
-						);
-						msg.nak(5000);
-					}
-				}
-			} else {
-				Logger.error({taskType, seq: msg.seq, err: error}, 'Job failed');
-				if (ledgerJobId !== null) {
-					try {
-						await this.ledger.incrementAttempts(ledgerJobId);
-					} catch (err) {
-						Logger.warn({err, jobId: ledgerJobId.toString()}, 'Ledger incrementAttempts failed');
-					}
-				}
-				msg.nak(5000);
-			}
-			return false;
+		} finally {
+			stopLeaseHeartbeat();
 		}
 	}
 }

--- a/fluxer_api/src/api/worker/WorkerService.ts
+++ b/fluxer_api/src/api/worker/WorkerService.ts
@@ -27,36 +27,41 @@ export class WorkerService implements IWorkerService<WorkerTaskName> {
 		const jobId = await this.snowflake.generate();
 		const skipLedger = options?.skipLedger === true;
 		const payloadRecord = payload as Record<string, unknown>;
-		const enrichedPayload = skipLedger ? payloadRecord : {...payloadRecord, __jobId: jobId.toString()};
+		const enqueueOptions = {
+			...(options?.runAt !== undefined && {runAt: options.runAt}),
+			...(options?.maxAttempts !== undefined && {maxAttempts: options.maxAttempts}),
+			...(options?.priority !== undefined && {priority: options.priority}),
+			...(options?.jobKey !== undefined && {jobKey: options.jobKey}),
+		};
+		if (skipLedger) {
+			const seq = await this.queue.enqueue(taskType, payloadRecord, enqueueOptions);
+			Logger.debug({taskType, jobId: jobId.toString(), seq}, 'Job queued successfully');
+			return jobId;
+		}
+		const lane = findLaneForTask(taskType);
+		await this.ledger.createJob({
+			jobId,
+			taskType,
+			payload: payloadRecord,
+			requestedByUserId: options?.requestedByUserId ?? null,
+			auditLogReason: options?.auditLogReason ?? null,
+			maxAttempts: options?.maxAttempts ?? 5,
+			runAt: options?.runAt ?? null,
+			jetStreamLane: lane,
+			jetStreamSeq: null,
+		});
+		const enrichedPayload = {...payloadRecord, __jobId: jobId.toString()};
 		try {
-			const seq = await this.queue.enqueue(taskType, enrichedPayload, {
-				...(options?.runAt !== undefined && {runAt: options.runAt}),
-				...(options?.maxAttempts !== undefined && {maxAttempts: options.maxAttempts}),
-				...(options?.priority !== undefined && {priority: options.priority}),
-				...(options?.jobKey !== undefined && {jobKey: options.jobKey}),
-			});
-			if (!skipLedger) {
-				const lane = findLaneForTask(taskType);
-				try {
-					await this.ledger.createJob({
-						jobId,
-						taskType,
-						payload: payload as Record<string, unknown>,
-						requestedByUserId: options?.requestedByUserId ?? null,
-						auditLogReason: options?.auditLogReason ?? null,
-						maxAttempts: options?.maxAttempts ?? 5,
-						runAt: options?.runAt ?? null,
-						jetStreamLane: lane,
-						jetStreamSeq: seq,
-					});
-				} catch (ledgerErr) {
-					Logger.error({err: ledgerErr, jobId: jobId.toString(), taskType}, 'Failed to write ledger row for job');
-				}
-			}
+			const seq = await this.queue.enqueue(taskType, enrichedPayload, enqueueOptions);
 			Logger.debug({taskType, jobId: jobId.toString(), seq}, 'Job queued successfully');
 			return jobId;
 		} catch (error) {
-			Logger.error({error, taskType, payload}, 'Failed to queue job');
+			try {
+				await this.ledger.markEnqueueFailed(jobId, 'Failed to publish job to the worker queue');
+			} catch (ledgerError) {
+				Logger.error({err: ledgerError, jobId: jobId.toString(), taskType}, 'Failed to mark unpublished job failed');
+			}
+			Logger.error({error, taskType}, 'Failed to queue job');
 			throw error;
 		}
 	}
@@ -65,8 +70,7 @@ export class WorkerService implements IWorkerService<WorkerTaskName> {
 		const job = await this.ledger.getJob(jobId);
 		if (!job) return false;
 		if (job.status !== 'queued' && job.status !== 'running') return false;
-		await this.ledger.requestCancel(jobId);
-		return true;
+		return this.ledger.requestCancel(jobId);
 	}
 
 	async retryDeadLetterJob(_jobId: bigint): Promise<boolean> {

--- a/fluxer_api/src/api/worker/WorkerTaskRegistry.ts
+++ b/fluxer_api/src/api/worker/WorkerTaskRegistry.ts
@@ -32,6 +32,7 @@ import processPendingBulkMessageDeletions from './tasks/ProcessPendingBulkMessag
 import processPremiumStateReconciliationQueue from './tasks/ProcessPremiumStateReconciliationQueue';
 import processStripeWebhook from './tasks/ProcessStripeWebhook';
 import prunePostgresKvTtl from './tasks/PrunePostgresKvTtl';
+import reconcileActiveJobs from './tasks/ReconcileActiveJobs';
 import reconcileUserPayments from './tasks/ReconcileUserPayments';
 import refreshSearchIndex from './tasks/RefreshSearchIndex';
 import revalidateUserConnections from './tasks/RevalidateUserConnections';
@@ -77,6 +78,7 @@ export const workerTasks: Record<WorkerTaskName, WorkerTaskHandler> = {
 	processPremiumStateReconciliationQueue,
 	reconcileUserPayments,
 	prunePostgresKvTtl,
+	reconcileActiveJobs,
 	refreshSearchIndex,
 	revalidateUserConnections,
 	sendScheduledMessage,

--- a/fluxer_api/src/api/worker/tasks/ReconcileActiveJobs.ts
+++ b/fluxer_api/src/api/worker/tasks/ReconcileActiveJobs.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type {WorkerTaskHandler} from '@pkgs/worker/src/contracts/WorkerTask';
+import {ms} from 'itty-time';
+import {JobLedgerRepository} from '../../jobs/JobLedgerRepository';
+import {WORKER_QUEUE_RECOVERY_WINDOW_MS} from '../../jobs/JobSchedulingPolicy';
+
+const ACTIVE_JOB_RECONCILE_GRACE_MS = ms('1 day');
+const ACTIVE_JOB_RECONCILE_LIMIT = 500;
+
+const reconcileActiveJobs: WorkerTaskHandler = async (_payload, helpers) => {
+	const now = new Date();
+	const result = await new JobLedgerRepository().reconcileActiveJobs({
+		now,
+		staleBefore: new Date(now.getTime() - WORKER_QUEUE_RECOVERY_WINDOW_MS - ACTIVE_JOB_RECONCILE_GRACE_MS),
+		limit: ACTIVE_JOB_RECONCILE_LIMIT,
+	});
+	if (result.failedStaleQueued > 0 || result.removedMissing > 0 || result.removedTerminal > 0) {
+		helpers.logger.info({...result}, 'Reconciled stale job-ledger active entries');
+	} else {
+		helpers.logger.debug({...result}, 'Job-ledger active entries are consistent');
+	}
+};
+
+export default reconcileActiveJobs;

--- a/fluxer_api/src/api/worker/tests/CronScheduler.test.ts
+++ b/fluxer_api/src/api/worker/tests/CronScheduler.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {CronScheduler} from '../CronScheduler';
+import type {WorkerService} from '../WorkerService';
+
+function createLogger() {
+	return {
+		debug: vi.fn(),
+		error: vi.fn(),
+		info: vi.fn(),
+	} as never;
+}
+
+describe('CronScheduler', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('does not persist routine cron ticks in the job ledger', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-10T06:30:00.000Z'));
+		const addJob = vi.fn().mockResolvedValue(1n);
+		const scheduler = new CronScheduler({addJob} as unknown as WorkerService, createLogger());
+		scheduler.upsert('maintenance', 'flushUserActivityBuffer', {}, '* * * * * *');
+
+		scheduler.start();
+		await vi.advanceTimersByTimeAsync(1000);
+		await scheduler.stop();
+
+		expect(addJob).toHaveBeenCalledOnce();
+		expect(addJob).toHaveBeenCalledWith('flushUserActivityBuffer', {}, expect.objectContaining({skipLedger: true}));
+	});
+
+	it('waits for an active enqueue tick during shutdown', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-10T06:30:00.000Z'));
+		let finishEnqueue: (() => void) | undefined;
+		const addJob = vi.fn(
+			() =>
+				new Promise<bigint>((resolve) => {
+					finishEnqueue = () => resolve(1n);
+				}),
+		);
+		const scheduler = new CronScheduler({addJob} as unknown as WorkerService, createLogger());
+		scheduler.upsert('maintenance', 'flushUserActivityBuffer', {}, '* * * * * *');
+		scheduler.start();
+		await vi.advanceTimersByTimeAsync(1000);
+		let stopped = false;
+		const stopping = scheduler.stop().then(() => {
+			stopped = true;
+		});
+		await Promise.resolve();
+		expect(stopped).toBe(false);
+		finishEnqueue!();
+		await stopping;
+		expect(stopped).toBe(true);
+	});
+});

--- a/fluxer_api/src/api/worker/tests/JetStreamWorkerQueue.test.ts
+++ b/fluxer_api/src/api/worker/tests/JetStreamWorkerQueue.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {nanos} from 'nats';
+import {describe, expect, it, vi} from 'vitest';
+import {JetStreamWorkerQueue, WORKER_QUEUE_MAX_AGE_MS} from '../JetStreamWorkerQueue';
+
+describe('JetStreamWorkerQueue dead-letter handling', () => {
+	it('retains permitted 30-day schedules plus the queue recovery window', async () => {
+		const add = vi.fn().mockResolvedValue(undefined);
+		const queue = new JetStreamWorkerQueue({
+			getJetStreamManager: async () => ({
+				streams: {info: vi.fn().mockRejectedValue(new Error('missing')), add},
+			}),
+		} as unknown as ConstructorParameters<typeof JetStreamWorkerQueue>[0]);
+
+		await queue.ensureStream();
+
+		expect(WORKER_QUEUE_MAX_AGE_MS).toBe(37 * 24 * 60 * 60 * 1000);
+		expect(add).toHaveBeenCalledWith(expect.objectContaining({max_age: nanos(WORKER_QUEUE_MAX_AGE_MS)}));
+	});
+
+	it('updates an existing source stream to the schedule-safe retained lifetime', async () => {
+		const update = vi.fn().mockResolvedValue(undefined);
+		const info = vi.fn().mockResolvedValue({
+			config: {name: 'JOBS', subjects: ['jobs.>'], max_age: nanos(7 * 24 * 60 * 60 * 1000)},
+		});
+		const queue = new JetStreamWorkerQueue({
+			getJetStreamManager: async () => ({streams: {info, update}}),
+		} as unknown as ConstructorParameters<typeof JetStreamWorkerQueue>[0]);
+
+		await queue.ensureStream();
+
+		expect(update).toHaveBeenCalledWith('JOBS', expect.objectContaining({max_age: nanos(WORKER_QUEUE_MAX_AGE_MS)}));
+	});
+
+	it('lets the application retain recovery deliveries while stream max age bounds message lifetime', async () => {
+		const add = vi.fn().mockResolvedValue(undefined);
+		const queue = new JetStreamWorkerQueue({
+			getJetStreamManager: async () => ({consumers: {add}}),
+		} as unknown as ConstructorParameters<typeof JetStreamWorkerQueue>[0]);
+
+		await queue.ensureConsumers([
+			{
+				name: 'realtime',
+				consumerName: 'test-consumer',
+				taskTypes: ['handleMentions'],
+				concurrency: 1,
+				maxAckPending: 1,
+				ackWaitMs: 60_000,
+				maxDeliver: 5,
+			},
+		]);
+
+		expect(add.mock.calls[0]?.[1]).toEqual(expect.objectContaining({max_deliver: -1}));
+	});
+
+	it('keeps DLQ message IDs deduplicated for the complete retained lifetime', async () => {
+		const add = vi.fn().mockResolvedValue(undefined);
+		const queue = new JetStreamWorkerQueue({
+			getJetStreamManager: async () => ({
+				streams: {info: vi.fn().mockRejectedValue(new Error('missing')), add},
+			}),
+		} as unknown as ConstructorParameters<typeof JetStreamWorkerQueue>[0]);
+
+		await queue.ensureDlqStream();
+
+		expect(add).toHaveBeenCalledWith(
+			expect.objectContaining({
+				duplicate_window: nanos(30 * 24 * 60 * 60 * 1000),
+				max_age: nanos(30 * 24 * 60 * 60 * 1000),
+			}),
+		);
+	});
+
+	it('updates an existing DLQ stream to use the retained-lifetime duplicate window', async () => {
+		const update = vi.fn().mockResolvedValue(undefined);
+		const info = vi.fn().mockResolvedValue({
+			config: {
+				name: 'JOBS_DLQ',
+				subjects: ['dlq.>'],
+				retention: 'limits',
+				storage: 'file',
+				max_age: nanos(30 * 24 * 60 * 60 * 1000),
+			},
+		});
+		const queue = new JetStreamWorkerQueue({
+			getJetStreamManager: async () => ({streams: {info, update}}),
+		} as unknown as ConstructorParameters<typeof JetStreamWorkerQueue>[0]);
+
+		await queue.ensureDlqStream();
+
+		expect(update).toHaveBeenCalledWith(
+			'JOBS_DLQ',
+			expect.objectContaining({duplicate_window: nanos(30 * 24 * 60 * 60 * 1000)}),
+		);
+	});
+
+	it('uses a stable message ID so retry publication is idempotent', async () => {
+		const publish = vi.fn().mockResolvedValue({seq: 1});
+		const queue = new JetStreamWorkerQueue({getJetStreamClient: () => ({publish})} as unknown as ConstructorParameters<
+			typeof JetStreamWorkerQueue
+		>[0]);
+		const meta = {
+			originalSeq: 123,
+			errorMessage: 'failed',
+			deliveryCount: 5,
+			lane: 'batch',
+		};
+
+		await queue.publishToDlq('testTask', {id: 'a'}, meta);
+		await queue.publishToDlq('testTask', {id: 'a'}, {...meta, deliveryCount: 6});
+
+		expect(publish).toHaveBeenCalledTimes(2);
+		expect(publish.mock.calls[0]?.[2]).toEqual({msgID: 'dlq:batch:testTask:123'});
+		expect(publish.mock.calls[1]?.[2]).toEqual({msgID: 'dlq:batch:testTask:123'});
+	});
+});

--- a/fluxer_api/src/api/worker/tests/JobLedgerReconciliationWiring.test.ts
+++ b/fluxer_api/src/api/worker/tests/JobLedgerReconciliationWiring.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {describe, expect, it, vi} from 'vitest';
+import type {CronScheduler} from '../CronScheduler';
+import {registerCronJobs} from '../WorkerMain';
+import {workerTasks} from '../WorkerTaskRegistry';
+
+describe('job-ledger reconciliation wiring', () => {
+	it('registers a periodic unledgered reconciliation task', () => {
+		const upsert = vi.fn();
+
+		registerCronJobs({upsert} as unknown as CronScheduler);
+
+		expect(workerTasks).toHaveProperty('reconcileActiveJobs');
+		expect(upsert).toHaveBeenCalledWith('reconcileActiveJobs', 'reconcileActiveJobs', {}, '0 0 * * * *');
+	});
+});

--- a/fluxer_api/src/api/worker/tests/WorkerMainLifecycle.test.ts
+++ b/fluxer_api/src/api/worker/tests/WorkerMainLifecycle.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {describe, expect, it, vi} from 'vitest';
+import {createJoinableShutdown, stopWorkerRunners} from '../WorkerMain';
+
+describe('worker main shutdown coordination', () => {
+	it('makes overlapping shutdown callers join the same cleanup', async () => {
+		let finish: (() => void) | undefined;
+		const action = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					finish = resolve;
+				}),
+		);
+		const shutdown = createJoinableShutdown(action);
+		let secondSettled = false;
+		const first = shutdown();
+		const second = shutdown().then(() => {
+			secondSettled = true;
+		});
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(secondSettled).toBe(false);
+		finish?.();
+		await Promise.all([first, second]);
+		expect(action).toHaveBeenCalledOnce();
+	});
+
+	it('waits for every runner even when one stop fails', async () => {
+		let finishSecond: (() => void) | undefined;
+		const firstError = new Error('first stop failed');
+		const first = {stop: vi.fn().mockRejectedValue(firstError)};
+		const second = {
+			stop: vi.fn(
+				() =>
+					new Promise<void>((resolve) => {
+						finishSecond = resolve;
+					}),
+			),
+		};
+		let settled = false;
+		const stopping = stopWorkerRunners([first, second]).finally(() => {
+			settled = true;
+		});
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(settled).toBe(false);
+		finishSecond?.();
+		await expect(stopping).rejects.toBeInstanceOf(AggregateError);
+		expect(first.stop).toHaveBeenCalledOnce();
+		expect(second.stop).toHaveBeenCalledOnce();
+	});
+});

--- a/fluxer_api/src/api/worker/tests/WorkerRunnerPayload.test.ts
+++ b/fluxer_api/src/api/worker/tests/WorkerRunnerPayload.test.ts
@@ -1,0 +1,656 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {JobCancelledError, type WorkerTaskHandler} from '@pkgs/worker/src/contracts/WorkerTask';
+import type {JsMsg} from 'nats';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import type {IJobLedgerRepository} from '../../jobs/IJobLedgerRepository';
+
+vi.mock('../../middleware/ServiceRegistry', () => ({
+	getWorkerService: () => ({addJob: vi.fn()}),
+}));
+
+import {WorkerRunner} from '../WorkerRunner';
+
+class TestWorkerRunner extends WorkerRunner {
+	processTestJob(taskType: string, msg: JsMsg): Promise<boolean> {
+		return this.processJob(taskType, msg);
+	}
+}
+
+function message(
+	payload: Record<string, unknown>,
+	deliveryCount: number,
+	seq = 100,
+): JsMsg & {
+	ack: ReturnType<typeof vi.fn>;
+	nak: ReturnType<typeof vi.fn>;
+	term: ReturnType<typeof vi.fn>;
+	working: ReturnType<typeof vi.fn>;
+} {
+	return {
+		data: new TextEncoder().encode(JSON.stringify({payload})),
+		subject: 'jobs.testTask',
+		info: {deliveryCount},
+		seq,
+		ack: vi.fn(),
+		nak: vi.fn(),
+		term: vi.fn(),
+		working: vi.fn(),
+	} as unknown as JsMsg & {
+		ack: ReturnType<typeof vi.fn>;
+		nak: ReturnType<typeof vi.fn>;
+		term: ReturnType<typeof vi.fn>;
+		working: ReturnType<typeof vi.fn>;
+	};
+}
+
+function runner(
+	task: WorkerTaskHandler,
+	queue: Record<string, unknown>,
+	ledger: Record<string, unknown>,
+	maxDeliver = 5,
+): TestWorkerRunner {
+	const normalizedLedger = {...ledger};
+	if (typeof normalizedLedger['claimJob'] !== 'function') {
+		const markRunning = normalizedLedger['markRunning'] as
+			| ((jobId: bigint, lane: string) => Promise<boolean>)
+			| undefined;
+		normalizedLedger['claimJob'] = async (jobId: bigint, lane: string, leaseToken: string) => {
+			const claimed = (await markRunning?.(jobId, lane)) ?? false;
+			return claimed ? {status: 'running', lease_token: leaseToken, error_message: null} : null;
+		};
+	}
+	normalizedLedger['renewLease'] ??= vi.fn().mockResolvedValue(true);
+	normalizedLedger['renewDeadletterPublicationLease'] ??= vi.fn().mockResolvedValue(true);
+	return new TestWorkerRunner({
+		tasks: {testTask: task},
+		queue: queue as never,
+		consumerName: 'test-consumer',
+		laneName: 'batch',
+		ledger: normalizedLedger as unknown as IJobLedgerRepository,
+		ackWaitMs: 60_000,
+		maxDeliver,
+	});
+}
+
+function queueForConsumer(consume: () => Promise<unknown> | unknown): Record<string, unknown> {
+	return {
+		enqueue: vi.fn(),
+		getStreamName: () => 'jobs',
+		getConnectionManager: () => ({
+			getJetStreamClient: () => ({
+				consumers: {
+					get: vi.fn().mockResolvedValue({consume}),
+				},
+			}),
+		}),
+	};
+}
+
+describe('WorkerRunner ledger state machine', () => {
+	afterEach(() => vi.useRealTimers());
+
+	it.each([
+		{__jobId: 'not-a-number'},
+		{__jobId: 42},
+		{__jobId: '0'},
+		{__jobId: '-1'},
+	])('terminates malformed ledger identities instead of executing them without a ledger: %j', async (payload) => {
+		const task = vi.fn() as unknown as WorkerTaskHandler;
+		const claimJob = vi.fn();
+		const msg = message(payload, 1);
+		const worker = runner(task, {}, {claimJob});
+
+		await expect(worker.processTestJob('testTask', msg)).resolves.toBe(false);
+
+		expect(msg.term).toHaveBeenCalledWith('invalid payload');
+		expect(task).not.toHaveBeenCalled();
+		expect(claimJob).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		null,
+		123,
+		'not-a-timestamp',
+	])('terminates malformed run_at metadata instead of executing early: %j', async (runAt) => {
+		const task = vi.fn() as unknown as WorkerTaskHandler;
+		const msg = message({}, 1);
+		msg.data = new TextEncoder().encode(JSON.stringify({payload: {}, run_at: runAt}));
+		const worker = runner(task, {}, {});
+
+		await expect(worker.processTestJob('testTask', msg)).resolves.toBe(false);
+
+		expect(msg.term).toHaveBeenCalledWith('invalid payload');
+		expect(task).not.toHaveBeenCalled();
+	});
+
+	it('preserves the ledger identity through the real future-message processing path', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-10T08:00:00.000Z'));
+		const enqueue = vi.fn().mockResolvedValue('next-sequence');
+		const task = vi.fn() as unknown as WorkerTaskHandler;
+		const markRunning = vi.fn().mockResolvedValue(true);
+		const msg = {
+			...message({channelId: '123', __jobId: '42'}, 4),
+			data: new TextEncoder().encode(
+				JSON.stringify({
+					payload: {channelId: '123', __jobId: '42'},
+					run_at: '2026-08-10T08:02:00.000Z',
+				}),
+			),
+		};
+		const worker = runner(task, {enqueue}, {markRunning});
+
+		await expect(worker.processTestJob('testTask', msg)).resolves.toBe(false);
+
+		expect(enqueue).not.toHaveBeenCalled();
+		expect(msg.ack).not.toHaveBeenCalled();
+		expect(msg.nak).toHaveBeenCalledOnce();
+		expect(msg.nak).toHaveBeenCalledWith(120_000);
+		expect(markRunning).not.toHaveBeenCalled();
+		expect(task).not.toHaveBeenCalled();
+	});
+
+	it('renews the durable lease and broker ack timer while task execution is active', async () => {
+		vi.useFakeTimers();
+		let finishTask: (() => void) | undefined;
+		const task = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					finishTask = resolve;
+				}),
+		);
+		const renewLease = vi.fn().mockResolvedValue(true);
+		const claimJob = vi.fn(async (_jobId: bigint, _lane: string, leaseToken: string) => ({
+			status: 'running',
+			lease_token: leaseToken,
+			error_message: null,
+		}));
+		const msg = message({__jobId: '42'}, 1);
+		const worker = runner(
+			task as unknown as WorkerTaskHandler,
+			{},
+			{claimJob, renewLease, markSucceeded: vi.fn().mockResolvedValue(true)},
+		);
+
+		const processing = worker.processTestJob('testTask', msg);
+		await vi.advanceTimersByTimeAsync(40_000);
+
+		expect(renewLease).toHaveBeenCalledWith(42n, expect.any(String), expect.any(Date), 120_000);
+		expect(msg.working).toHaveBeenCalledOnce();
+		finishTask?.();
+		await expect(processing).resolves.toBe(true);
+	});
+
+	it('keeps the broker message when successful work cannot be terminalized', async () => {
+		const task = vi.fn().mockResolvedValue(undefined);
+		const releaseForRetry = vi.fn().mockResolvedValue(true);
+		const worker = runner(
+			task as unknown as WorkerTaskHandler,
+			{},
+			{
+				markRunning: vi.fn().mockResolvedValue(true),
+				markSucceeded: vi.fn().mockRejectedValue(new Error('database unavailable')),
+				releaseForRetry,
+			},
+		);
+		const msg = message({__jobId: '42'}, 1);
+
+		await expect(worker.processTestJob('testTask', msg)).resolves.toBe(false);
+
+		expect(task).toHaveBeenCalledOnce();
+		expect(releaseForRetry).toHaveBeenCalledWith(
+			42n,
+			'Terminalization failed after successful execution',
+			false,
+			expect.any(String),
+		);
+		expect(msg.nak).toHaveBeenCalledOnce();
+		expect(msg.ack).not.toHaveBeenCalled();
+	});
+
+	it('keeps the broker message when successful terminalization loses its compare-and-set race', async () => {
+		const task = vi.fn().mockResolvedValue(undefined);
+		const releaseForRetry = vi.fn().mockResolvedValue(true);
+		const worker = runner(
+			task as unknown as WorkerTaskHandler,
+			{},
+			{
+				markRunning: vi.fn().mockResolvedValue(true),
+				markSucceeded: vi.fn().mockResolvedValue(false),
+				getJob: vi.fn().mockResolvedValue({status: 'running'}),
+				releaseForRetry,
+			},
+		);
+		const msg = message({__jobId: '42'}, 1);
+
+		await expect(worker.processTestJob('testTask', msg)).resolves.toBe(false);
+
+		expect(releaseForRetry).toHaveBeenCalledWith(
+			42n,
+			'Terminalization failed after successful execution',
+			false,
+			expect.any(String),
+		);
+		expect(msg.nak).toHaveBeenCalledOnce();
+		expect(msg.ack).not.toHaveBeenCalled();
+	});
+
+	it('keeps the broker message when cancellation cannot be terminalized', async () => {
+		const task = vi.fn().mockRejectedValue(new JobCancelledError());
+		const releaseForRetry = vi.fn().mockResolvedValue(true);
+		const worker = runner(
+			task as unknown as WorkerTaskHandler,
+			{},
+			{
+				markRunning: vi.fn().mockResolvedValue(true),
+				markCancelled: vi.fn().mockRejectedValue(new Error('database unavailable')),
+				releaseForRetry,
+			},
+		);
+		const msg = message({__jobId: '42'}, 1);
+
+		await expect(worker.processTestJob('testTask', msg)).resolves.toBe(false);
+
+		expect(releaseForRetry).toHaveBeenCalledWith(
+			42n,
+			'Terminalization failed after cancellation',
+			false,
+			expect.any(String),
+		);
+		expect(msg.nak).toHaveBeenCalledOnce();
+		expect(msg.ack).not.toHaveBeenCalled();
+	});
+
+	it('NAKs a concurrent duplicate while another worker owns the running job', async () => {
+		const task = vi.fn() as unknown as WorkerTaskHandler;
+		const worker = runner(
+			task,
+			{},
+			{
+				markRunning: vi.fn().mockResolvedValue(false),
+				getJob: vi.fn().mockResolvedValue({status: 'running', error_message: null}),
+			},
+		);
+		const duplicate = message({__jobId: '42'}, 2);
+
+		await expect(worker.processTestJob('testTask', duplicate)).resolves.toBe(false);
+
+		expect(duplicate.nak).toHaveBeenCalledWith(5000);
+		expect(duplicate.ack).not.toHaveBeenCalled();
+		expect(task).not.toHaveBeenCalled();
+	});
+
+	it('closes a consumer acquired after stop begins before start can return', async () => {
+		let releaseConsume: ((messages: unknown) => void) | undefined;
+		const consume = vi.fn(
+			() =>
+				new Promise<unknown>((resolve) => {
+					releaseConsume = resolve;
+				}),
+		);
+		const close = vi.fn().mockResolvedValue(undefined);
+		const messages = {
+			close,
+			async *[Symbol.asyncIterator]() {},
+		};
+		const worker = runner(vi.fn() as unknown as WorkerTaskHandler, queueForConsumer(consume), {});
+
+		const starting = worker.start();
+		await vi.waitFor(() => expect(consume).toHaveBeenCalledOnce());
+		const stopping = worker.stop();
+		releaseConsume?.(messages);
+		await Promise.all([starting, stopping]);
+
+		expect(close).toHaveBeenCalledOnce();
+	});
+
+	it('drains active work even when closing the consumer fails', async () => {
+		let finishTask: (() => void) | undefined;
+		const task = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					finishTask = resolve;
+				}),
+		);
+		const first = message({__jobId: '80'}, 1, 301);
+		const closeError = new Error('close failed');
+		const messages = {
+			close: vi.fn().mockRejectedValue(closeError),
+			async *[Symbol.asyncIterator]() {
+				yield first;
+			},
+		};
+		const worker = runner(
+			task as unknown as WorkerTaskHandler,
+			queueForConsumer(() => messages),
+			{
+				claimJob: vi.fn().mockResolvedValue({status: 'running', lease_token: 'lease-80', error_message: null}),
+				markSucceeded: vi.fn().mockResolvedValue(true),
+			},
+		);
+		await worker.start();
+		await vi.waitFor(() => expect(task).toHaveBeenCalledOnce());
+
+		let stopSettled = false;
+		let observedStopError: unknown;
+		const stopping = worker.stop().then(
+			() => {
+				stopSettled = true;
+			},
+			(error) => {
+				stopSettled = true;
+				observedStopError = error;
+			},
+		);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(stopSettled).toBe(false);
+		finishTask?.();
+		await stopping;
+		expect(observedStopError).toBe(closeError);
+	});
+
+	it('joins concurrent stop callers when consumer close fails instead of awaiting a stuck iterator', async () => {
+		let finishTask: (() => void) | undefined;
+		const task = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					finishTask = resolve;
+				}),
+		);
+		const closeError = new Error('close failed');
+		const messages = {
+			close: vi.fn().mockRejectedValue(closeError),
+			async *[Symbol.asyncIterator]() {
+				yield message({__jobId: '85'}, 1, 302);
+				await new Promise<never>(() => undefined);
+			},
+		};
+		const worker = runner(
+			task as unknown as WorkerTaskHandler,
+			queueForConsumer(() => messages),
+			{
+				claimJob: vi.fn().mockResolvedValue({status: 'running', lease_token: 'lease-85', error_message: null}),
+				markSucceeded: vi.fn().mockResolvedValue(true),
+			},
+		);
+		await worker.start();
+		await vi.waitFor(() => expect(task).toHaveBeenCalledOnce());
+
+		const firstStop = worker.stop();
+		let secondStopSettled = false;
+		let secondStopError: unknown;
+		void worker.stop().then(
+			() => {
+				secondStopSettled = true;
+			},
+			(error) => {
+				secondStopSettled = true;
+				secondStopError = error;
+			},
+		);
+		finishTask?.();
+
+		await expect(firstStop).rejects.toBe(closeError);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(secondStopSettled).toBe(true);
+		expect(secondStopError).toBe(closeError);
+		expect(messages.close).toHaveBeenCalledOnce();
+	});
+
+	it('drains active work and does not start prefetched work after stop begins', async () => {
+		let finishTask: (() => void) | undefined;
+		const task = vi
+			.fn()
+			.mockImplementationOnce(
+				() =>
+					new Promise<void>((resolve) => {
+						finishTask = resolve;
+					}),
+			)
+			.mockResolvedValue(undefined);
+		const first = message({__jobId: '81'}, 1, 201);
+		const second = message({__jobId: '82'}, 1, 202);
+		let markSecondPrefetched: (() => void) | undefined;
+		const secondPrefetched = new Promise<void>((resolve) => {
+			markSecondPrefetched = resolve;
+		});
+		const consumerMessages = {
+			close: vi.fn().mockResolvedValue(undefined),
+			async *[Symbol.asyncIterator]() {
+				yield first;
+				markSecondPrefetched?.();
+				yield second;
+			},
+		};
+		const consume = vi.fn().mockResolvedValue(consumerMessages);
+		const queue = {
+			getStreamName: () => 'jobs',
+			getConnectionManager: () => ({
+				getJetStreamClient: () => ({consumers: {get: vi.fn().mockResolvedValue({consume})}}),
+			}),
+		};
+		const worker = runner(task as unknown as WorkerTaskHandler, queue, {
+			claimJob: vi.fn(async (_jobId: bigint, _lane: string, leaseToken: string) => ({
+				status: 'running',
+				lease_token: leaseToken,
+				error_message: null,
+			})),
+			markSucceeded: vi.fn().mockResolvedValue(true),
+		});
+
+		await worker.start();
+		await vi.waitFor(() => expect(task).toHaveBeenCalledOnce());
+		await secondPrefetched;
+		let stopped = false;
+		const stopping = worker.stop().then(() => {
+			stopped = true;
+		});
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(stopped).toBe(false);
+
+		finishTask?.();
+		await stopping;
+		expect(task).toHaveBeenCalledOnce();
+		expect(second.nak).toHaveBeenCalled();
+	});
+
+	it('releases a failed attempt so the broker redelivery can claim and execute the retry', async () => {
+		let status = 'queued';
+		const markRunning = vi.fn(async () => {
+			if (status !== 'queued') return false;
+			status = 'running';
+			return true;
+		});
+		const releaseForRetry = vi.fn(async () => {
+			if (status !== 'running') return false;
+			status = 'queued';
+			return true;
+		});
+		const markSucceeded = vi.fn(async () => {
+			status = 'succeeded';
+			return true;
+		});
+		const task = vi.fn().mockRejectedValueOnce(new Error('temporary')).mockResolvedValueOnce(undefined);
+		const worker = runner(
+			task as unknown as WorkerTaskHandler,
+			{},
+			{
+				markRunning,
+				releaseForRetry,
+				markSucceeded,
+				getJob: vi.fn(async () => ({status})),
+				incrementAttempts: vi.fn(),
+			},
+		);
+		const first = message({__jobId: '42'}, 1);
+		const second = message({__jobId: '42'}, 2);
+
+		await expect(worker.processTestJob('testTask', first)).resolves.toBe(false);
+		await expect(worker.processTestJob('testTask', second)).resolves.toBe(true);
+
+		expect(task).toHaveBeenCalledTimes(2);
+		expect(releaseForRetry).toHaveBeenCalledOnce();
+		expect(first.nak).toHaveBeenCalledOnce();
+		expect(second.ack).toHaveBeenCalledOnce();
+	});
+
+	it('does not count lease-contention redeliveries as business task attempts', async () => {
+		const task = vi.fn().mockRejectedValue(new Error('attempt failed'));
+		const releaseForRetry = vi.fn().mockResolvedValue(true);
+		const publishToDlq = vi.fn();
+		const claimJob = vi.fn(async (_jobId: bigint, _lane: string, leaseToken: string) => ({
+			status: 'running',
+			lease_token: leaseToken,
+			error_message: null,
+			attempts: 0,
+			max_attempts: 5,
+		}));
+		const worker = runner(
+			task as unknown as WorkerTaskHandler,
+			{publishToDlq},
+			{claimJob, renewLease: vi.fn().mockResolvedValue(true), releaseForRetry},
+		);
+		const msg = message({__jobId: '42'}, 10);
+
+		await expect(worker.processTestJob('testTask', msg)).resolves.toBe(false);
+
+		expect(releaseForRetry).toHaveBeenCalledWith(42n, 'attempt failed', true, expect.any(String));
+		expect(publishToDlq).not.toHaveBeenCalled();
+		expect(msg.nak).toHaveBeenCalledWith(5000);
+	});
+
+	it('renews the exclusive DLQ publication lease while publication is active', async () => {
+		vi.useFakeTimers();
+		let finishPublish: (() => void) | undefined;
+		const publishToDlq = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					finishPublish = resolve;
+				}),
+		);
+		const renewDeadletterPublicationLease = vi.fn().mockResolvedValue(true);
+		const worker = runner(
+			vi.fn().mockRejectedValue(new Error('permanent')) as unknown as WorkerTaskHandler,
+			{publishToDlq},
+			{
+				markRunning: vi.fn().mockResolvedValue(true),
+				markDeadletterPending: vi.fn().mockResolvedValue({leaseToken: 'publication-owner', errorMessage: 'permanent'}),
+				renewDeadletterPublicationLease,
+				markDeadletter: vi.fn().mockResolvedValue(true),
+			},
+		);
+		const msg = message({__jobId: '42'}, 5, 100);
+		const processing = worker.processTestJob('testTask', msg);
+		await vi.waitFor(() => expect(publishToDlq).toHaveBeenCalledOnce());
+
+		await vi.advanceTimersByTimeAsync(20_000);
+		expect(renewDeadletterPublicationLease).toHaveBeenCalledWith(42n, 'publication-owner', expect.any(Date), 60_000);
+		expect(msg.working).toHaveBeenCalled();
+		finishPublish?.();
+		await processing;
+		expect(msg.term).toHaveBeenCalledOnce();
+	});
+
+	it('does not publish DLQ work when another publisher owns the pending generation', async () => {
+		const publishToDlq = vi.fn();
+		const worker = runner(
+			vi.fn() as unknown as WorkerTaskHandler,
+			{publishToDlq},
+			{
+				markRunning: vi.fn().mockResolvedValue(false),
+				markDeadletterPending: vi.fn().mockResolvedValue(null),
+				getJob: vi.fn().mockResolvedValue({status: 'deadletter_pending', error_message: 'permanent'}),
+			},
+		);
+		const redelivery = message({__jobId: '42'}, 6, 100);
+
+		await expect(worker.processTestJob('testTask', redelivery)).resolves.toBe(false);
+
+		expect(publishToDlq).not.toHaveBeenCalled();
+		expect(redelivery.nak).toHaveBeenCalledWith(5000);
+	});
+
+	it('retries a durable pending DLQ publication on redelivery without executing the task again', async () => {
+		let status = 'queued';
+		let errorMessage: string | null = null;
+		const markRunning = vi.fn(async () => {
+			if (status !== 'queued') return false;
+			status = 'running';
+			return true;
+		});
+		let publicationGeneration = 0;
+		const markDeadletterPending = vi.fn(async (_jobId: bigint, error: string) => {
+			if (status !== 'running' && status !== 'deadletter_pending') return null;
+			status = 'deadletter_pending';
+			errorMessage ??= error;
+			publicationGeneration += 1;
+			return {leaseToken: `publication-${publicationGeneration}`, errorMessage};
+		});
+		const markDeadletter = vi.fn(async () => {
+			if (status !== 'deadletter_pending') return false;
+			status = 'deadletter';
+			return true;
+		});
+		const getJob = vi.fn(async () => ({status, error_message: errorMessage}));
+		const publishToDlq = vi.fn().mockRejectedValueOnce(new Error('nats unavailable')).mockResolvedValueOnce(undefined);
+		const task = vi.fn().mockRejectedValue(new Error('permanent'));
+		const worker = runner(
+			task as unknown as WorkerTaskHandler,
+			{publishToDlq},
+			{
+				markRunning,
+				markDeadletterPending,
+				recordDlqPublishFailure: vi.fn().mockResolvedValue(1),
+				markDeadletter,
+				getJob,
+			},
+		);
+		const first = message({__jobId: '42'}, 5, 100);
+		const redelivery = message({__jobId: '42'}, 6, 100);
+
+		await expect(worker.processTestJob('testTask', first)).resolves.toBe(false);
+		await expect(worker.processTestJob('testTask', redelivery)).resolves.toBe(false);
+
+		expect(task).toHaveBeenCalledOnce();
+		expect(markDeadletterPending).toHaveBeenNthCalledWith(
+			1,
+			42n,
+			'permanent',
+			expect.any(String),
+			expect.any(Date),
+			60_000,
+		);
+		expect(markDeadletterPending).toHaveBeenNthCalledWith(2, 42n, 'permanent', null, expect.any(Date), 60_000);
+		expect(publishToDlq).toHaveBeenCalledTimes(2);
+		expect(markDeadletter).toHaveBeenCalledOnce();
+		expect(first.nak).toHaveBeenCalledOnce();
+		expect(redelivery.term).toHaveBeenCalledOnce();
+		expect(status).toBe('deadletter');
+	});
+
+	it('retains ledgered DLQ work after repeated publication failures until stream expiry reconciliation', async () => {
+		const publishToDlq = vi.fn().mockRejectedValue(new Error('nats unavailable'));
+		const markFailed = vi.fn().mockRejectedValue(new Error('database unavailable'));
+		const task = vi.fn() as unknown as WorkerTaskHandler;
+		const worker = runner(
+			task,
+			{publishToDlq},
+			{
+				markRunning: vi.fn().mockResolvedValue(false),
+				markDeadletterPending: vi.fn().mockResolvedValue({leaseToken: 'publication-retry', errorMessage: 'permanent'}),
+				getJob: vi.fn().mockResolvedValue({status: 'deadletter_pending', error_message: 'permanent'}),
+				recordDlqPublishFailure: vi.fn().mockResolvedValue(3),
+				markFailed,
+			},
+		);
+		const recovery = message({__jobId: '42'}, 8, 100);
+
+		await expect(worker.processTestJob('testTask', recovery)).resolves.toBe(false);
+
+		expect(markFailed).not.toHaveBeenCalled();
+		expect(recovery.nak).toHaveBeenCalledOnce();
+		expect(recovery.term).not.toHaveBeenCalled();
+		expect(task).not.toHaveBeenCalled();
+	});
+});

--- a/fluxer_api/src/api/worker/tests/WorkerService.test.ts
+++ b/fluxer_api/src/api/worker/tests/WorkerService.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {describe, expect, it, vi} from 'vitest';
+import type {ISnowflakeService} from '../../infrastructure/ISnowflakeService';
+import type {IJobLedgerRepository} from '../../jobs/IJobLedgerRepository';
+import type {JetStreamWorkerQueue} from '../JetStreamWorkerQueue';
+import {WorkerService} from '../WorkerService';
+
+function deferred<T = void>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return {promise, reject, resolve};
+}
+
+function createService(input: {
+	queue: Pick<JetStreamWorkerQueue, 'enqueue'>;
+	ledger: Pick<IJobLedgerRepository, 'createJob'> & Partial<IJobLedgerRepository>;
+}) {
+	const snowflake = {generate: vi.fn().mockResolvedValue(42n)} as unknown as ISnowflakeService;
+	return new WorkerService(input.queue as JetStreamWorkerQueue, snowflake, input.ledger as IJobLedgerRepository);
+}
+
+describe('WorkerService', () => {
+	it('persists a complete ledger record before publishing the queue message', async () => {
+		const ledgerCreated = deferred();
+		const createJob = vi.fn().mockReturnValue(ledgerCreated.promise);
+		const enqueue = vi.fn().mockResolvedValue('stream-sequence');
+		const service = createService({queue: {enqueue}, ledger: {createJob}});
+
+		const addPromise = service.addJob('flushUserActivityBuffer', {});
+		await vi.waitFor(() => expect(createJob).toHaveBeenCalledOnce());
+
+		expect(enqueue).not.toHaveBeenCalled();
+		expect(createJob).toHaveBeenCalledWith(
+			expect.objectContaining({
+				jobId: 42n,
+				jetStreamSeq: null,
+				taskType: 'flushUserActivityBuffer',
+			}),
+		);
+
+		ledgerCreated.resolve();
+		await addPromise;
+		expect(enqueue).toHaveBeenCalledOnce();
+	});
+
+	it('marks a precreated ledger job failed when queue publication fails', async () => {
+		const queueError = new Error('queue unavailable');
+		const createJob = vi.fn().mockResolvedValue(undefined);
+		const markEnqueueFailed = vi.fn().mockResolvedValue(true);
+		const enqueue = vi.fn().mockRejectedValue(queueError);
+		const service = createService({queue: {enqueue}, ledger: {createJob, markEnqueueFailed}});
+
+		await expect(service.addJob('flushUserActivityBuffer', {})).rejects.toBe(queueError);
+
+		expect(markEnqueueFailed).toHaveBeenCalledWith(42n, 'Failed to publish job to the worker queue');
+	});
+
+	it('does not publish when authoritative ledger creation fails', async () => {
+		const ledgerError = new Error('database unavailable');
+		const createJob = vi.fn().mockRejectedValue(ledgerError);
+		const enqueue = vi.fn();
+		const service = createService({queue: {enqueue}, ledger: {createJob}});
+
+		await expect(service.addJob('flushUserActivityBuffer', {})).rejects.toBe(ledgerError);
+
+		expect(enqueue).not.toHaveBeenCalled();
+	});
+
+	it('returns false when cancellation loses its terminalization compare-and-set race', async () => {
+		const requestCancel = vi.fn().mockResolvedValue(false);
+		const getJob = vi.fn().mockResolvedValue({status: 'running'});
+		const service = createService({
+			queue: {enqueue: vi.fn()},
+			ledger: {createJob: vi.fn(), getJob, requestCancel},
+		});
+
+		await expect(service.cancelJob(42n)).resolves.toBe(false);
+		expect(requestCancel).toHaveBeenCalledWith(42n);
+	});
+
+	it('publishes skip-ledger jobs without creating or enriching ledger state', async () => {
+		const createJob = vi.fn();
+		const enqueue = vi.fn().mockResolvedValue('stream-sequence');
+		const service = createService({queue: {enqueue}, ledger: {createJob}});
+
+		await service.addJob('flushUserActivityBuffer', {batch: 1}, {skipLedger: true});
+
+		expect(createJob).not.toHaveBeenCalled();
+		expect(enqueue).toHaveBeenCalledWith('flushUserActivityBuffer', {batch: 1}, {});
+	});
+});

--- a/packages/schema/src/domains/admin/JobsSchemas.ts
+++ b/packages/schema/src/domains/admin/JobsSchemas.ts
@@ -3,7 +3,15 @@
 import {SnowflakeStringType, SnowflakeType} from '@fluxer/schema/src/primitives/SchemaPrimitives';
 import {z} from 'zod';
 
-const JobStatusEnum = z.enum(['queued', 'running', 'succeeded', 'failed', 'cancelled', 'deadletter']);
+const JobStatusEnum = z.enum([
+	'queued',
+	'running',
+	'deadletter_pending',
+	'succeeded',
+	'failed',
+	'cancelled',
+	'deadletter',
+]);
 
 export const JobLedgerEntrySchema = z.object({
 	job_id: SnowflakeStringType,
@@ -31,11 +39,16 @@ export const JobLedgerEntrySchema = z.object({
 
 export type JobLedgerEntry = z.infer<typeof JobLedgerEntrySchema>;
 
-const ListJobsCursorSchema = z.object({
-	bucket_day: z.string(),
-	created_at: z.string(),
-	job_id: SnowflakeStringType,
-});
+const ListJobsCursorSchema = z
+	.object({
+		bucket_day: z.iso.date(),
+		created_at: z.iso.datetime({offset: true}),
+		job_id: SnowflakeStringType,
+	})
+	.refine((cursor) => new Date(cursor.created_at).toISOString().slice(0, 10) === cursor.bucket_day, {
+		message: 'created_at must fall within bucket_day in UTC',
+		path: ['created_at'],
+	});
 
 export const ListJobsRequest = z.object({
 	limit: z.number().int().min(1).max(200).default(50).describe('Page size'),
@@ -73,6 +86,15 @@ export const CancelJobResponseSchema = z.object({
 	cancelled: z.boolean().describe('True if a cancel request was recorded; false if the job was already terminal.'),
 });
 
+export const ActiveJobsRequest = z.object({
+	limit: z.number().int().min(1).max(200).default(50),
+	page_state: z.string().max(16_384).nullish(),
+	task_type: z.string().optional(),
+});
+
+export type ActiveJobsRequest = z.infer<typeof ActiveJobsRequest>;
+
 export const ActiveJobsResponseSchema = z.object({
 	jobs: z.array(JobLedgerEntrySchema),
+	next_page_state: z.string().nullable(),
 });

--- a/tools/dev/cassandra_target_schema.json
+++ b/tools/dev/cassandra_target_schema.json
@@ -6256,6 +6256,20 @@
 			"options": ""
 		},
 		{
+			"name": "jobs_active_v2",
+			"columns": [
+				{"name": "shard", "type": "int"},
+				{"name": "job_id", "type": "bigint"},
+				{"name": "task_type", "type": "text"},
+				{"name": "status", "type": "text"},
+				{"name": "requested_by_user_id", "type": "bigint"},
+				{"name": "created_at", "type": "timestamp"},
+				{"name": "started_at", "type": "timestamp"}
+			],
+			"primary_key": "((shard), job_id)",
+			"options": "CLUSTERING ORDER BY (job_id ASC)"
+		},
+		{
 			"name": "jobs_by_day_bucket",
 			"columns": [
 				{
@@ -6352,6 +6366,22 @@
 				{
 					"name": "jet_stream_lane",
 					"type": "text"
+				},
+				{
+					"name": "lease_token",
+					"type": "text"
+				},
+				{
+					"name": "lease_expires_at",
+					"type": "timestamp"
+				},
+				{
+					"name": "state_changed_at",
+					"type": "timestamp"
+				},
+				{
+					"name": "dlq_attempts",
+					"type": "int"
 				},
 				{
 					"name": "attempts",


### PR DESCRIPTION
## Summary

- push Cassandra-style filters into PostgreSQL instead of loading whole logical tables into application memory
- make job publication and ledger persistence recoverable, preserve complete lifecycle fields, and reconcile stale active entries
- apply retention TTLs to terminal job history and exclude high-frequency maintenance work from the durable ledger
- support parameterized binary comparisons, including the Buffer-valued auth-session lookup path
- add focused unit and real PostgreSQL integration coverage for query semantics, worker recovery, lifecycle transitions, retention, and binary values

This addresses the full-table PostgreSQL reads and continuously growing job history discussed in #1523.

## Verification

- API typecheck passed
- full API suite: 3,284/3,284 tests across 371 files
- real PostgreSQL integration: 11/11
- focused executor and job-ledger tests: 49/49
- Biome passed for all changed TypeScript and JSON files
- `git diff --check` passed

The exact patch was also exercised on a self-hosted PostgreSQL deployment. A first candidate exposed a missing Buffer-comparison case in normal auth-session traffic and was rolled back. The follow-up binary fix added the production-shaped regression test; the repaired candidate then passed live auth traffic and a ledger create/claim/terminalize canary with TTL-retained history and no active-index residue.

This PR changes ongoing query, persistence, reconciliation, and retention behavior. It does not include any destructive migration or historical-data cleanup.

## LLM assistance

LLMs were used to help investigate the production behavior, implement portions of the patch, and expand tests. I reviewed the resulting code and can explain and defend the changes; the final rebased tree passed the verification above.

Closes #1523
