### PR TITLE
Use locale parameter for date formatting

### DIFF
--- a/packages/date_utils/src/DateFormatting.ts
+++ b/packages/date_utils/src/DateFormatting.ts
@@ -70,7 +70,7 @@ export function getFormattedCompactDateTime(
 	hour12?: boolean,
 ): string {
 	const date = parseDate(timestamp);
-	const datePart = getDateFormatter('en-US', {month: 'numeric', day: 'numeric', year: '2-digit'}).format(date);
+	const datePart = getDateFormatter(locale, {month: 'numeric', day: 'numeric', year: '2-digit'}).format(date);
 	const timePart = getDateFormatter(locale, {
 		hour: 'numeric',
 		minute: '2-digit',


### PR DESCRIPTION
Fix FormattedCompactDateTIme defaulting to en-US even if user had different locale selected.

Closes #1632 

<!-- Repeat this line for each resolved issue, up to 20. Remove the placeholder only if no issue is resolved and the approval gate does not apply. -->

## Summary

Pass the user's locale and not default to en-US.

## Correctness and risk

Fixes confusing wrong dates showing up on NewMessagesBar.
Risk: None.

## Verification

Tested before and after changes:
<img width="578" height="295" alt="image" src="https://github.com/user-attachments/assets/cb35c7b1-269f-4585-9b8f-b3a6f98c1755" />

