### PR TITLE
fix(app): wrap long guild names in the sidebar tooltip

### DIFF
--- a/fluxer_app/src/features/app/components/layout/GuildsLayout.module.css
+++ b/fluxer_app/src/features/app/components/layout/GuildsLayout.module.css
@@ -589,9 +589,8 @@
 
 .guildTooltipName {
 	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	white-space: normal;
+	overflow-wrap: anywhere;
 	font-size: 1rem;
 	line-height: 1.4;
 	font-weight: 600;


### PR DESCRIPTION
Closes #1060