### PR TITLE
fix(app): treat official invite and gift links as external when self-hosted

### DIFF
--- a/fluxer_app/src/features/gift/utils/GiftCodeUtils.ts
+++ b/fluxer_app/src/features/gift/utils/GiftCodeUtils.ts
@@ -14,6 +14,9 @@ const OFFICIAL_GIFT_URL_BASES = Object.freeze([
 const GIFT_CONFIG: CodeLinkUtils.CodeLinkConfig = {
 	path: 'gift',
 	get urlBases() {
+		if (RuntimeConfig.isSelfHosted()) {
+			return [RuntimeConfig.giftUrlBase];
+		}
 		return [RuntimeConfig.giftUrlBase, ...OFFICIAL_GIFT_URL_BASES];
 	},
 };

--- a/fluxer_app/src/features/invite/utils/InviteUtils.ts
+++ b/fluxer_app/src/features/invite/utils/InviteUtils.ts
@@ -22,6 +22,9 @@ const OFFICIAL_INVITE_URL_BASES = Object.freeze([
 const INVITE_CONFIG: CodeLinkUtils.CodeLinkConfig = {
 	path: 'invite',
 	get urlBases() {
+		if (RuntimeConfig.isSelfHosted()) {
+			return [RuntimeConfig.inviteUrlBase];
+		}
 		return [RuntimeConfig.inviteUrlBase, ...OFFICIAL_INVITE_URL_BASES];
 	},
 };


### PR DESCRIPTION
Closes #1117