### PR TITLE
fix(app): Flip around manifest.json and icon declaration

### DIFF
--- a/fluxer_app/index.html
+++ b/fluxer_app/index.html
@@ -7,8 +7,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content, maximum-scale=1, user-scalable=no">
 <meta name="description" content="Fluxer is a free and open source instant messaging and VoIP chat app built for friends, groups, and communities.">
 <link rel="preconnect" href="{{STATIC_CDN_ENDPOINT}}">
-<link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/png" sizes="32x32" href="{{STATIC_CDN_ENDPOINT}}/web/favicon-32x32.png">
+<link rel="manifest" href="/manifest.json">
 <link rel="apple-touch-icon" sizes="180x180" href="{{STATIC_CDN_ENDPOINT}}/web/apple-touch-icon.png">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="default">


### PR DESCRIPTION

<!-- Repeat this line for each resolved issue, up to 20. Remove the placeholder only if no issue is resolved and the approval gate does not apply. -->

## Summary

<!-- State what changes and why. -->

There is currently an issue with the favicon not loading for Google search results, this PR attempts to fix this by flipping around icon and manifest declaration

## Correctness and risk

<!-- State why the change is correct, the invariants it preserves, and what fails if it is wrong. -->

I suspect when GoogleBot is crawling it finds "Open Fluxer" (which leads to the web client), and from what I've found Google Search results can sometimes get picky about manifest.json files containing assets with "standalone" tags, and since manifest.json is loaded before the icon is defined it might be tripping up GoogleBot.

Bing and DuckDuckGo renders it fine.

## Verification

<!-- List the commands and manual checks performed. State anything not verified. -->

Not possible to verify, have to wait and see until Google search results cache gets revalidated.
